### PR TITLE
Replace INT64 with MySQL-compatible integer types

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Encrypted embedded SQL database with B-Tree + Full-Text Search (Bigram), written
 ## Features
 
 - **Transparent encryption** - AES-256-GCM-SIV (nonce-misuse resistant) for all pages and WAL
-- **B-tree storage** - PRIMARY KEY (INT64), UNIQUE indexes (single column)
+- **B-tree storage** - PRIMARY KEY (TINYINT/SMALLINT/INT/BIGINT), UNIQUE indexes (single column)
 - **Full-text search** - Bigram (n=2) with NFKC normalization
   - MySQL-style `MATCH(col) AGAINST(...)` syntax
   - NATURAL LANGUAGE MODE with BM25 scoring
@@ -25,7 +25,7 @@ cargo install --path .
 
 ```bash
 # Create a new database
-murodb mydb.db --create -e "CREATE TABLE t (id INT64 PRIMARY KEY, name VARCHAR)"
+murodb mydb.db --create -e "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)"
 
 # Insert data
 murodb mydb.db -e "INSERT INTO t (id, name) VALUES (1, 'hello')"
@@ -67,16 +67,22 @@ Options:
 
 ### Types
 
-- `INT64`
-- `VARCHAR`
-- `VARBINARY`
-- `NULL`
+| Type | Storage | Range |
+|------|---------|-------|
+| TINYINT | 1 byte | -128 to 127 |
+| SMALLINT | 2 bytes | -32,768 to 32,767 |
+| INT | 4 bytes | -2,147,483,648 to 2,147,483,647 |
+| BIGINT | 8 bytes | -2^63 to 2^63-1 |
+| VARCHAR(n) | variable | max n bytes (optional) |
+| TEXT | variable | unbounded text |
+| VARBINARY(n) | variable | max n bytes (optional) |
+| NULL | 0 bytes | null value |
 
 ### DDL
 
 ```sql
 CREATE TABLE t (
-  id INT64 PRIMARY KEY,
+  id BIGINT PRIMARY KEY,
   body VARCHAR,
   blob VARBINARY,
   uniq VARCHAR UNIQUE
@@ -134,7 +140,7 @@ LIMIT 10;
 
 ### B-tree
 
-- Key encoding: INT64 (big-endian + sign flip for order preservation), VARCHAR/VARBINARY (raw bytes)
+- Key encoding: Integer types (big-endian + sign flip for order preservation), VARCHAR/VARBINARY (raw bytes)
 - Clustered by PRIMARY KEY
 - Secondary indexes share the same B-tree implementation
 

--- a/src/bin/murodb.rs
+++ b/src/bin/murodb.rs
@@ -107,7 +107,7 @@ fn format_rows(result: &ExecResult) -> String {
 
 fn format_value(val: &Value) -> String {
     match val {
-        Value::Int64(n) => n.to_string(),
+        Value::Integer(n) => n.to_string(),
         Value::Varchar(s) => s.clone(),
         Value::Varbinary(b) => format!("0x{}", hex_encode(b)),
         Value::Null => "NULL".to_string(),

--- a/src/btree/key_encoding.rs
+++ b/src/btree/key_encoding.rs
@@ -1,8 +1,43 @@
 /// Key encoding for order-preserving byte comparison.
 ///
-/// INT64: big-endian with sign bit flipped (so negative < positive in byte order)
-/// VARCHAR: raw UTF-8 bytes
+/// Integer types: big-endian with sign bit flipped (so negative < positive in byte order)
+/// VARCHAR/TEXT: raw UTF-8 bytes
 /// VARBINARY: raw bytes
+/// Encode i8 into 1 byte that preserves sort order under byte comparison.
+pub fn encode_i8(val: i8) -> [u8; 1] {
+    let unsigned = (val as u8) ^ (1u8 << 7);
+    [unsigned]
+}
+
+/// Decode i8 from order-preserving encoding.
+pub fn decode_i8(bytes: &[u8; 1]) -> i8 {
+    (bytes[0] ^ (1u8 << 7)) as i8
+}
+
+/// Encode i16 into 2 bytes that preserve sort order under byte comparison.
+pub fn encode_i16(val: i16) -> [u8; 2] {
+    let unsigned = (val as u16) ^ (1u16 << 15);
+    unsigned.to_be_bytes()
+}
+
+/// Decode i16 from order-preserving encoding.
+pub fn decode_i16(bytes: &[u8; 2]) -> i16 {
+    let unsigned = u16::from_be_bytes(*bytes);
+    (unsigned ^ (1u16 << 15)) as i16
+}
+
+/// Encode i32 into 4 bytes that preserve sort order under byte comparison.
+pub fn encode_i32(val: i32) -> [u8; 4] {
+    let unsigned = (val as u32) ^ (1u32 << 31);
+    unsigned.to_be_bytes()
+}
+
+/// Decode i32 from order-preserving encoding.
+pub fn decode_i32(bytes: &[u8; 4]) -> i32 {
+    let unsigned = u32::from_be_bytes(*bytes);
+    (unsigned ^ (1u32 << 31)) as i32
+}
+
 /// Encode i64 into 8 bytes that preserve sort order under byte comparison.
 pub fn encode_i64(val: i64) -> [u8; 8] {
     // Flip the sign bit so that negative numbers sort before positive
@@ -45,6 +80,54 @@ mod tests {
     fn test_i64_roundtrip() {
         for val in [i64::MIN, -1, 0, 1, i64::MAX, 42, -42] {
             assert_eq!(decode_i64(&encode_i64(val)), val);
+        }
+    }
+
+    #[test]
+    fn test_i8_encoding_order() {
+        let values = [i8::MIN, -1, 0, 1, i8::MAX];
+        let encoded: Vec<[u8; 1]> = values.iter().map(|&v| encode_i8(v)).collect();
+        for i in 0..encoded.len() - 1 {
+            assert!(encoded[i] < encoded[i + 1]);
+        }
+    }
+
+    #[test]
+    fn test_i8_roundtrip() {
+        for val in [i8::MIN, -1, 0, 1, i8::MAX, 42, -42] {
+            assert_eq!(decode_i8(&encode_i8(val)), val);
+        }
+    }
+
+    #[test]
+    fn test_i16_encoding_order() {
+        let values = [i16::MIN, -1000, -1, 0, 1, 1000, i16::MAX];
+        let encoded: Vec<[u8; 2]> = values.iter().map(|&v| encode_i16(v)).collect();
+        for i in 0..encoded.len() - 1 {
+            assert!(encoded[i] < encoded[i + 1]);
+        }
+    }
+
+    #[test]
+    fn test_i16_roundtrip() {
+        for val in [i16::MIN, -1, 0, 1, i16::MAX, 42, -42] {
+            assert_eq!(decode_i16(&encode_i16(val)), val);
+        }
+    }
+
+    #[test]
+    fn test_i32_encoding_order() {
+        let values = [i32::MIN, -1000, -1, 0, 1, 1000, i32::MAX];
+        let encoded: Vec<[u8; 4]> = values.iter().map(|&v| encode_i32(v)).collect();
+        for i in 0..encoded.len() - 1 {
+            assert!(encoded[i] < encoded[i + 1]);
+        }
+    }
+
+    #[test]
+    fn test_i32_roundtrip() {
+        for val in [i32::MIN, -1, 0, 1, i32::MAX, 42, -42] {
+            assert_eq!(decode_i32(&encode_i32(val)), val);
         }
     }
 

--- a/src/schema/catalog.rs
+++ b/src/schema/catalog.rs
@@ -191,7 +191,7 @@ impl SystemCatalog {
             (columns, pk_name)
         } else {
             use crate::types::DataType;
-            let rowid_col = ColumnDef::new("_rowid", DataType::Int64)
+            let rowid_col = ColumnDef::new("_rowid", DataType::BigInt)
                 .primary_key()
                 .hidden();
             let mut cols = vec![rowid_col];
@@ -320,9 +320,9 @@ mod tests {
         let table = TableDef {
             name: "users".to_string(),
             columns: vec![
-                ColumnDef::new("id", DataType::Int64).primary_key(),
-                ColumnDef::new("name", DataType::Varchar),
-                ColumnDef::new("data", DataType::Varbinary),
+                ColumnDef::new("id", DataType::BigInt).primary_key(),
+                ColumnDef::new("name", DataType::Varchar(None)),
+                ColumnDef::new("data", DataType::Varbinary(None)),
             ],
             pk_column: Some("id".to_string()),
             data_btree_root: 42,
@@ -346,8 +346,8 @@ mod tests {
         let mut catalog = SystemCatalog::create(&mut pager).unwrap();
 
         let columns = vec![
-            ColumnDef::new("id", DataType::Int64).primary_key(),
-            ColumnDef::new("body", DataType::Varchar),
+            ColumnDef::new("id", DataType::BigInt).primary_key(),
+            ColumnDef::new("body", DataType::Varchar(None)),
         ];
 
         let table_def = catalog.create_table(&mut pager, "posts", columns).unwrap();
@@ -367,7 +367,7 @@ mod tests {
         let mut pager = Pager::create(&db_path, &test_key()).unwrap();
         let mut catalog = SystemCatalog::create(&mut pager).unwrap();
 
-        let columns = vec![ColumnDef::new("id", DataType::Int64).primary_key()];
+        let columns = vec![ColumnDef::new("id", DataType::BigInt).primary_key()];
         catalog
             .create_table(&mut pager, "t", columns.clone())
             .unwrap();
@@ -412,8 +412,8 @@ mod tests {
             let mut catalog = SystemCatalog::create(&mut pager).unwrap();
 
             let columns = vec![
-                ColumnDef::new("id", DataType::Int64).primary_key(),
-                ColumnDef::new("name", DataType::Varchar),
+                ColumnDef::new("id", DataType::BigInt).primary_key(),
+                ColumnDef::new("name", DataType::Varchar(None)),
             ];
             catalog.create_table(&mut pager, "users", columns).unwrap();
             catalog_root = catalog.root_page_id();

--- a/src/schema/column.rs
+++ b/src/schema/column.rs
@@ -44,17 +44,24 @@ impl ColumnDef {
     }
 
     /// Serialize column definition to bytes.
+    /// Format: [name_len(u16)][name][type_byte][flags][optional_size(u32)]
+    /// optional_size is written for Varchar and Varbinary types:
+    ///   0 = None, non-zero = Some(n)
     pub fn serialize(&self) -> Vec<u8> {
         let mut buf = Vec::new();
         // name length + name
         let name_bytes = self.name.as_bytes();
         buf.extend_from_slice(&(name_bytes.len() as u16).to_le_bytes());
         buf.extend_from_slice(name_bytes);
-        // data type
+        // data type byte
         buf.push(match self.data_type {
-            DataType::Int64 => 1,
-            DataType::Varchar => 2,
-            DataType::Varbinary => 3,
+            DataType::BigInt => 1,
+            DataType::Varchar(_) => 2,
+            DataType::Varbinary(_) => 3,
+            DataType::TinyInt => 4,
+            DataType::SmallInt => 5,
+            DataType::Int => 6,
+            DataType::Text => 7,
         });
         // flags
         let mut flags: u8 = 0;
@@ -71,6 +78,13 @@ impl ColumnDef {
             flags |= 0x08;
         }
         buf.push(flags);
+        // optional size for Varchar/Varbinary
+        match self.data_type {
+            DataType::Varchar(size) | DataType::Varbinary(size) => {
+                buf.extend_from_slice(&size.unwrap_or(0).to_le_bytes());
+            }
+            _ => {}
+        }
         buf
     }
 
@@ -84,13 +98,49 @@ impl ColumnDef {
             return None;
         }
         let name = String::from_utf8(data[2..2 + name_len].to_vec()).ok()?;
-        let data_type = match data[2 + name_len] {
-            1 => DataType::Int64,
-            2 => DataType::Varchar,
-            3 => DataType::Varbinary,
+        let type_byte = data[2 + name_len];
+        let flags = data[2 + name_len + 1];
+        let mut consumed = 2 + name_len + 2;
+
+        let data_type = match type_byte {
+            1 => DataType::BigInt,
+            2 => {
+                // Varchar with optional size
+                let size = if data.len() >= consumed + 4 {
+                    let n = u32::from_le_bytes(data[consumed..consumed + 4].try_into().unwrap());
+                    consumed += 4;
+                    if n == 0 {
+                        None
+                    } else {
+                        Some(n)
+                    }
+                } else {
+                    None
+                };
+                DataType::Varchar(size)
+            }
+            3 => {
+                // Varbinary with optional size
+                let size = if data.len() >= consumed + 4 {
+                    let n = u32::from_le_bytes(data[consumed..consumed + 4].try_into().unwrap());
+                    consumed += 4;
+                    if n == 0 {
+                        None
+                    } else {
+                        Some(n)
+                    }
+                } else {
+                    None
+                };
+                DataType::Varbinary(size)
+            }
+            4 => DataType::TinyInt,
+            5 => DataType::SmallInt,
+            6 => DataType::Int,
+            7 => DataType::Text,
             _ => return None,
         };
-        let flags = data[2 + name_len + 1];
+
         let col = ColumnDef {
             name,
             data_type,
@@ -99,7 +149,7 @@ impl ColumnDef {
             is_nullable: flags & 0x04 != 0,
             is_hidden: flags & 0x08 != 0,
         };
-        Some((col, 2 + name_len + 2))
+        Some((col, consumed))
     }
 }
 
@@ -109,12 +159,41 @@ mod tests {
 
     #[test]
     fn test_column_roundtrip() {
-        let col = ColumnDef::new("id", DataType::Int64).primary_key();
+        let col = ColumnDef::new("id", DataType::BigInt).primary_key();
         let bytes = col.serialize();
         let (col2, _) = ColumnDef::deserialize(&bytes).unwrap();
         assert_eq!(col2.name, "id");
-        assert_eq!(col2.data_type, DataType::Int64);
+        assert_eq!(col2.data_type, DataType::BigInt);
         assert!(col2.is_primary_key);
         assert!(!col2.is_nullable);
+    }
+
+    #[test]
+    fn test_column_roundtrip_varchar_with_size() {
+        let col = ColumnDef::new("name", DataType::Varchar(Some(255)));
+        let bytes = col.serialize();
+        let (col2, _) = ColumnDef::deserialize(&bytes).unwrap();
+        assert_eq!(col2.name, "name");
+        assert_eq!(col2.data_type, DataType::Varchar(Some(255)));
+    }
+
+    #[test]
+    fn test_column_roundtrip_all_types() {
+        for dt in [
+            DataType::TinyInt,
+            DataType::SmallInt,
+            DataType::Int,
+            DataType::BigInt,
+            DataType::Varchar(None),
+            DataType::Varchar(Some(100)),
+            DataType::Varbinary(None),
+            DataType::Varbinary(Some(512)),
+            DataType::Text,
+        ] {
+            let col = ColumnDef::new("test", dt);
+            let bytes = col.serialize();
+            let (col2, _) = ColumnDef::deserialize(&bytes).unwrap();
+            assert_eq!(col2.data_type, dt, "Roundtrip failed for {:?}", dt);
+        }
     }
 }

--- a/src/sql/lexer.rs
+++ b/src/sql/lexer.rs
@@ -56,9 +56,13 @@ pub enum Token {
     Show,
     Tables,
     PrimaryKey,    // "PRIMARY KEY" as a combined token
-    Int64Type,     // "INT64"
+    TinyIntType,   // "TINYINT"
+    SmallIntType,  // "SMALLINT"
+    IntType,       // "INT" / "INTEGER"
+    BigIntType,    // "BIGINT"
     VarcharType,   // "VARCHAR"
     VarbinaryType, // "VARBINARY"
+    TextType,      // "TEXT"
 
     // Literals
     Integer(i64),
@@ -257,9 +261,13 @@ fn lex_keyword_or_ident(input: &str) -> IResult<&str, Token> {
             }
             Token::Ident(word.to_string())
         }
-        "INT64" => Token::Int64Type,
+        "TINYINT" => Token::TinyIntType,
+        "SMALLINT" => Token::SmallIntType,
+        "INT" | "INTEGER" => Token::IntType,
+        "BIGINT" => Token::BigIntType,
         "VARCHAR" => Token::VarcharType,
         "VARBINARY" => Token::VarbinaryType,
+        "TEXT" => Token::TextType,
         "FTS_SNIPPET" => Token::FtsSnippet,
         _ => Token::Ident(word.to_string()),
     };
@@ -273,13 +281,13 @@ mod tests {
 
     #[test]
     fn test_tokenize_create_table() {
-        let tokens = tokenize("CREATE TABLE t (id INT64 PRIMARY KEY, name VARCHAR)").unwrap();
+        let tokens = tokenize("CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)").unwrap();
         assert_eq!(tokens[0], Token::Create);
         assert_eq!(tokens[1], Token::Table);
         assert_eq!(tokens[2], Token::Ident("t".to_string()));
         assert_eq!(tokens[3], Token::LParen);
         assert_eq!(tokens[4], Token::Ident("id".to_string()));
-        assert_eq!(tokens[5], Token::Int64Type);
+        assert_eq!(tokens[5], Token::BigIntType);
         assert_eq!(tokens[6], Token::PrimaryKey);
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
-    Int64(i64),
+    Integer(i64),
     Varchar(String),
     Varbinary(Vec<u8>),
     Null,
@@ -15,7 +15,7 @@ impl Value {
 
     pub fn as_i64(&self) -> Option<i64> {
         match self {
-            Value::Int64(v) => Some(*v),
+            Value::Integer(v) => Some(*v),
             _ => None,
         }
     }
@@ -38,7 +38,7 @@ impl Value {
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Value::Int64(v) => write!(f, "{}", v),
+            Value::Integer(v) => write!(f, "{}", v),
             Value::Varchar(v) => write!(f, "{}", v),
             Value::Varbinary(v) => write!(f, "<binary {} bytes>", v.len()),
             Value::Null => write!(f, "NULL"),
@@ -48,17 +48,27 @@ impl fmt::Display for Value {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DataType {
-    Int64,
-    Varchar,
-    Varbinary,
+    TinyInt,
+    SmallInt,
+    Int,
+    BigInt,
+    Varchar(Option<u32>),
+    Varbinary(Option<u32>),
+    Text,
 }
 
 impl fmt::Display for DataType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            DataType::Int64 => write!(f, "INT64"),
-            DataType::Varchar => write!(f, "VARCHAR"),
-            DataType::Varbinary => write!(f, "VARBINARY"),
+            DataType::TinyInt => write!(f, "TINYINT"),
+            DataType::SmallInt => write!(f, "SMALLINT"),
+            DataType::Int => write!(f, "INT"),
+            DataType::BigInt => write!(f, "BIGINT"),
+            DataType::Varchar(None) => write!(f, "VARCHAR"),
+            DataType::Varchar(Some(n)) => write!(f, "VARCHAR({})", n),
+            DataType::Varbinary(None) => write!(f, "VARBINARY"),
+            DataType::Varbinary(Some(n)) => write!(f, "VARBINARY({})", n),
+            DataType::Text => write!(f, "TEXT"),
         }
     }
 }

--- a/tests/basic_crud.rs
+++ b/tests/basic_crud.rs
@@ -23,7 +23,7 @@ fn test_full_crud_cycle() {
 
     // CREATE TABLE
     execute(
-        "CREATE TABLE users (id INT64 PRIMARY KEY, name VARCHAR, email VARCHAR)",
+        "CREATE TABLE users (id BIGINT PRIMARY KEY, name VARCHAR, email VARCHAR)",
         &mut pager,
         &mut catalog,
     )
@@ -89,7 +89,7 @@ fn test_insert_with_explicit_columns() {
     let (mut pager, mut catalog, _dir) = setup();
 
     execute(
-        "CREATE TABLE t (id INT64 PRIMARY KEY, a VARCHAR, b VARCHAR)",
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, a VARCHAR, b VARCHAR)",
         &mut pager,
         &mut catalog,
     )
@@ -113,7 +113,7 @@ fn test_order_by_desc_limit() {
     let (mut pager, mut catalog, _dir) = setup();
 
     execute(
-        "CREATE TABLE t (id INT64 PRIMARY KEY, val INT64)",
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val BIGINT)",
         &mut pager,
         &mut catalog,
     )
@@ -135,9 +135,9 @@ fn test_order_by_desc_limit() {
     .unwrap();
     if let ExecResult::Rows(rows) = result {
         assert_eq!(rows.len(), 3);
-        assert_eq!(rows[0].get("val"), Some(&Value::Int64(100)));
-        assert_eq!(rows[1].get("val"), Some(&Value::Int64(90)));
-        assert_eq!(rows[2].get("val"), Some(&Value::Int64(80)));
+        assert_eq!(rows[0].get("val"), Some(&Value::Integer(100)));
+        assert_eq!(rows[1].get("val"), Some(&Value::Integer(90)));
+        assert_eq!(rows[2].get("val"), Some(&Value::Integer(80)));
     }
 }
 
@@ -146,7 +146,7 @@ fn test_null_handling() {
     let (mut pager, mut catalog, _dir) = setup();
 
     execute(
-        "CREATE TABLE t (id INT64 PRIMARY KEY, name VARCHAR)",
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)",
         &mut pager,
         &mut catalog,
     )
@@ -172,7 +172,7 @@ fn test_varbinary_type() {
     let (mut pager, mut catalog, _dir) = setup();
 
     execute(
-        "CREATE TABLE t (id INT64 PRIMARY KEY, data VARBINARY)",
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, data VARBINARY)",
         &mut pager,
         &mut catalog,
     )
@@ -191,7 +191,7 @@ fn test_multiple_value_insert() {
     let (mut pager, mut catalog, _dir) = setup();
 
     execute(
-        "CREATE TABLE t (id INT64 PRIMARY KEY, name VARCHAR)",
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)",
         &mut pager,
         &mut catalog,
     )
@@ -214,7 +214,7 @@ fn test_duplicate_pk_error() {
     let (mut pager, mut catalog, _dir) = setup();
 
     execute(
-        "CREATE TABLE t (id INT64 PRIMARY KEY, name VARCHAR)",
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)",
         &mut pager,
         &mut catalog,
     )

--- a/tests/encryption_tests.rs
+++ b/tests/encryption_tests.rs
@@ -64,7 +64,7 @@ fn test_wrong_key_cannot_open_database() {
         let mut pager = Pager::create(&db_path, &correct_key).unwrap();
         let mut catalog = SystemCatalog::create(&mut pager).unwrap();
         execute(
-            "CREATE TABLE t (id INT64 PRIMARY KEY)",
+            "CREATE TABLE t (id BIGINT PRIMARY KEY)",
             &mut pager,
             &mut catalog,
         )
@@ -98,7 +98,7 @@ fn test_data_persists_across_reopen() {
         let mut catalog = SystemCatalog::create(&mut pager).unwrap();
 
         execute(
-            "CREATE TABLE t (id INT64 PRIMARY KEY, name VARCHAR)",
+            "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)",
             &mut pager,
             &mut catalog,
         )

--- a/tests/join_tests.rs
+++ b/tests/join_tests.rs
@@ -1,0 +1,439 @@
+use murodb::crypto::aead::MasterKey;
+use murodb::schema::catalog::SystemCatalog;
+use murodb::sql::executor::{execute, ExecResult};
+use murodb::storage::pager::Pager;
+use murodb::types::Value;
+use tempfile::TempDir;
+
+fn test_key() -> MasterKey {
+    MasterKey::new([0x42u8; 32])
+}
+
+fn setup() -> (Pager, SystemCatalog, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let mut pager = Pager::create(&db_path, &test_key()).unwrap();
+    let catalog = SystemCatalog::create(&mut pager).unwrap();
+    (pager, catalog, dir)
+}
+
+fn setup_users_orders(pager: &mut Pager, catalog: &mut SystemCatalog) {
+    execute(
+        "CREATE TABLE users (id BIGINT PRIMARY KEY, name VARCHAR)",
+        pager,
+        catalog,
+    )
+    .unwrap();
+    execute(
+        "CREATE TABLE orders (id BIGINT PRIMARY KEY, user_id BIGINT, product VARCHAR)",
+        pager,
+        catalog,
+    )
+    .unwrap();
+
+    execute("INSERT INTO users VALUES (1, 'Alice')", pager, catalog).unwrap();
+    execute("INSERT INTO users VALUES (2, 'Bob')", pager, catalog).unwrap();
+    execute("INSERT INTO users VALUES (3, 'Charlie')", pager, catalog).unwrap();
+
+    execute(
+        "INSERT INTO orders VALUES (10, 1, 'Widget')",
+        pager,
+        catalog,
+    )
+    .unwrap();
+    execute(
+        "INSERT INTO orders VALUES (11, 1, 'Gadget')",
+        pager,
+        catalog,
+    )
+    .unwrap();
+    execute(
+        "INSERT INTO orders VALUES (12, 2, 'Doohickey')",
+        pager,
+        catalog,
+    )
+    .unwrap();
+}
+
+#[test]
+fn test_inner_join_basic() {
+    let (mut pager, mut catalog, _dir) = setup();
+    setup_users_orders(&mut pager, &mut catalog);
+
+    let result = execute(
+        "SELECT users.name, orders.product FROM users INNER JOIN orders ON users.id = orders.user_id ORDER BY orders.id",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    if let ExecResult::Rows(rows) = result {
+        assert_eq!(rows.len(), 3);
+        assert_eq!(
+            rows[0].get("users.name"),
+            Some(&Value::Varchar("Alice".into()))
+        );
+        assert_eq!(
+            rows[0].get("orders.product"),
+            Some(&Value::Varchar("Widget".into()))
+        );
+        assert_eq!(
+            rows[1].get("orders.product"),
+            Some(&Value::Varchar("Gadget".into()))
+        );
+        assert_eq!(
+            rows[2].get("users.name"),
+            Some(&Value::Varchar("Bob".into()))
+        );
+    } else {
+        panic!("Expected rows");
+    }
+}
+
+#[test]
+fn test_inner_join_implicit() {
+    let (mut pager, mut catalog, _dir) = setup();
+    setup_users_orders(&mut pager, &mut catalog);
+
+    // JOIN without INNER keyword
+    let result = execute(
+        "SELECT users.name, orders.product FROM users JOIN orders ON users.id = orders.user_id ORDER BY orders.id",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    if let ExecResult::Rows(rows) = result {
+        assert_eq!(rows.len(), 3);
+    } else {
+        panic!("Expected rows");
+    }
+}
+
+#[test]
+fn test_left_join_with_null() {
+    let (mut pager, mut catalog, _dir) = setup();
+    setup_users_orders(&mut pager, &mut catalog);
+
+    // Charlie has no orders -> should appear with NULL product
+    let result = execute(
+        "SELECT users.name, orders.product FROM users LEFT JOIN orders ON users.id = orders.user_id ORDER BY users.id",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    if let ExecResult::Rows(rows) = result {
+        assert_eq!(rows.len(), 4); // Alice(2) + Bob(1) + Charlie(1 with NULL)
+                                   // Charlie's row should have NULL product
+        let charlie_row = rows
+            .iter()
+            .find(|r| r.get("users.name") == Some(&Value::Varchar("Charlie".into())))
+            .expect("Charlie should be in results");
+        assert_eq!(charlie_row.get("orders.product"), Some(&Value::Null));
+    } else {
+        panic!("Expected rows");
+    }
+}
+
+#[test]
+fn test_cross_join() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE colors (id BIGINT PRIMARY KEY, name VARCHAR)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute(
+        "CREATE TABLE sizes (id BIGINT PRIMARY KEY, name VARCHAR)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    execute(
+        "INSERT INTO colors VALUES (1, 'Red')",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute(
+        "INSERT INTO colors VALUES (2, 'Blue')",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute(
+        "INSERT INTO sizes VALUES (1, 'S')",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute(
+        "INSERT INTO sizes VALUES (2, 'M')",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute(
+        "INSERT INTO sizes VALUES (3, 'L')",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    let result = execute(
+        "SELECT colors.name, sizes.name FROM colors CROSS JOIN sizes",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    if let ExecResult::Rows(rows) = result {
+        assert_eq!(rows.len(), 6); // 2 colors * 3 sizes
+    } else {
+        panic!("Expected rows");
+    }
+}
+
+#[test]
+fn test_join_with_alias() {
+    let (mut pager, mut catalog, _dir) = setup();
+    setup_users_orders(&mut pager, &mut catalog);
+
+    let result = execute(
+        "SELECT u.name, o.product FROM users AS u INNER JOIN orders AS o ON u.id = o.user_id ORDER BY o.id",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    if let ExecResult::Rows(rows) = result {
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].get("u.name"), Some(&Value::Varchar("Alice".into())));
+        assert_eq!(
+            rows[0].get("o.product"),
+            Some(&Value::Varchar("Widget".into()))
+        );
+    } else {
+        panic!("Expected rows");
+    }
+}
+
+#[test]
+fn test_join_with_alias_no_as() {
+    let (mut pager, mut catalog, _dir) = setup();
+    setup_users_orders(&mut pager, &mut catalog);
+
+    // Alias without AS keyword
+    let result = execute(
+        "SELECT u.name, o.product FROM users u INNER JOIN orders o ON u.id = o.user_id ORDER BY o.id",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    if let ExecResult::Rows(rows) = result {
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].get("u.name"), Some(&Value::Varchar("Alice".into())));
+    } else {
+        panic!("Expected rows");
+    }
+}
+
+#[test]
+fn test_join_with_where() {
+    let (mut pager, mut catalog, _dir) = setup();
+    setup_users_orders(&mut pager, &mut catalog);
+
+    let result = execute(
+        "SELECT users.name, orders.product FROM users JOIN orders ON users.id = orders.user_id WHERE orders.product = 'Widget'",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    if let ExecResult::Rows(rows) = result {
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].get("users.name"),
+            Some(&Value::Varchar("Alice".into()))
+        );
+        assert_eq!(
+            rows[0].get("orders.product"),
+            Some(&Value::Varchar("Widget".into()))
+        );
+    } else {
+        panic!("Expected rows");
+    }
+}
+
+#[test]
+fn test_join_with_order_by_and_limit() {
+    let (mut pager, mut catalog, _dir) = setup();
+    setup_users_orders(&mut pager, &mut catalog);
+
+    let result = execute(
+        "SELECT users.name, orders.product FROM users JOIN orders ON users.id = orders.user_id ORDER BY orders.id DESC LIMIT 2",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    if let ExecResult::Rows(rows) = result {
+        assert_eq!(rows.len(), 2);
+        // order_id DESC: 12, 11, 10 → first two: Doohickey, Gadget
+        assert_eq!(
+            rows[0].get("orders.product"),
+            Some(&Value::Varchar("Doohickey".into()))
+        );
+        assert_eq!(
+            rows[1].get("orders.product"),
+            Some(&Value::Varchar("Gadget".into()))
+        );
+    } else {
+        panic!("Expected rows");
+    }
+}
+
+#[test]
+fn test_join_select_star() {
+    let (mut pager, mut catalog, _dir) = setup();
+    setup_users_orders(&mut pager, &mut catalog);
+
+    let result = execute(
+        "SELECT * FROM users JOIN orders ON users.id = orders.user_id ORDER BY orders.id LIMIT 1",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    if let ExecResult::Rows(rows) = result {
+        assert_eq!(rows.len(), 1);
+        // Should have columns from both tables
+        assert_eq!(rows[0].get("name"), Some(&Value::Varchar("Alice".into())));
+        assert_eq!(
+            rows[0].get("product"),
+            Some(&Value::Varchar("Widget".into()))
+        );
+    } else {
+        panic!("Expected rows");
+    }
+}
+
+#[test]
+fn test_multiple_joins() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE users (id BIGINT PRIMARY KEY, name VARCHAR)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute(
+        "CREATE TABLE orders (id BIGINT PRIMARY KEY, user_id BIGINT, product_id BIGINT)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute(
+        "CREATE TABLE products (id BIGINT PRIMARY KEY, name VARCHAR)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    execute(
+        "INSERT INTO users VALUES (1, 'Alice')",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute(
+        "INSERT INTO products VALUES (100, 'Widget')",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute(
+        "INSERT INTO products VALUES (101, 'Gadget')",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute(
+        "INSERT INTO orders VALUES (10, 1, 100)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute(
+        "INSERT INTO orders VALUES (11, 1, 101)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    let result = execute(
+        "SELECT u.name, p.name FROM users u JOIN orders o ON u.id = o.user_id JOIN products p ON o.product_id = p.id ORDER BY p.name",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    if let ExecResult::Rows(rows) = result {
+        assert_eq!(rows.len(), 2);
+        assert_eq!(
+            rows[0].get("p.name"),
+            Some(&Value::Varchar("Gadget".into()))
+        );
+        assert_eq!(
+            rows[1].get("p.name"),
+            Some(&Value::Varchar("Widget".into()))
+        );
+    } else {
+        panic!("Expected rows");
+    }
+}
+
+#[test]
+fn test_left_join_empty_right() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE a (id BIGINT PRIMARY KEY, val VARCHAR)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute(
+        "CREATE TABLE b (id BIGINT PRIMARY KEY, a_id BIGINT, val VARCHAR)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    execute("INSERT INTO a VALUES (1, 'x')", &mut pager, &mut catalog).unwrap();
+    execute("INSERT INTO a VALUES (2, 'y')", &mut pager, &mut catalog).unwrap();
+    // b is empty
+
+    let result = execute(
+        "SELECT a.val, b.val FROM a LEFT JOIN b ON a.id = b.a_id ORDER BY a.id",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    if let ExecResult::Rows(rows) = result {
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].get("a.val"), Some(&Value::Varchar("x".into())));
+        assert_eq!(rows[0].get("b.val"), Some(&Value::Null));
+        assert_eq!(rows[1].get("a.val"), Some(&Value::Varchar("y".into())));
+        assert_eq!(rows[1].get("b.val"), Some(&Value::Null));
+    } else {
+        panic!("Expected rows");
+    }
+}

--- a/tests/rowid_tests.rs
+++ b/tests/rowid_tests.rs
@@ -1,0 +1,145 @@
+use murodb::crypto::aead::MasterKey;
+use murodb::schema::catalog::SystemCatalog;
+use murodb::sql::executor::{execute, ExecResult};
+use murodb::storage::pager::Pager;
+use murodb::types::Value;
+use tempfile::TempDir;
+
+fn test_key() -> MasterKey {
+    MasterKey::new([0x42u8; 32])
+}
+
+fn setup() -> (Pager, SystemCatalog, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let mut pager = Pager::create(&db_path, &test_key()).unwrap();
+    let catalog = SystemCatalog::create(&mut pager).unwrap();
+    (pager, catalog, dir)
+}
+
+#[test]
+fn test_rowid_hidden_in_select_star() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE t (name VARCHAR, age BIGINT)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    execute(
+        "INSERT INTO t VALUES ('Alice', 30)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    let result = execute("SELECT * FROM t", &mut pager, &mut catalog).unwrap();
+    if let ExecResult::Rows(rows) = result {
+        assert_eq!(rows.len(), 1);
+        // _rowid should NOT appear in SELECT *
+        assert!(rows[0].get("_rowid").is_none());
+        assert_eq!(rows[0].get("name"), Some(&Value::Varchar("Alice".into())));
+        assert_eq!(rows[0].get("age"), Some(&Value::Integer(30)));
+    } else {
+        panic!("Expected rows");
+    }
+}
+
+#[test]
+fn test_rowid_explicit_select() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute("CREATE TABLE t (name VARCHAR)", &mut pager, &mut catalog).unwrap();
+
+    execute("INSERT INTO t VALUES ('Alice')", &mut pager, &mut catalog).unwrap();
+
+    let result = execute("SELECT _rowid, name FROM t", &mut pager, &mut catalog).unwrap();
+    if let ExecResult::Rows(rows) = result {
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].get("_rowid"), Some(&Value::Integer(1)));
+        assert_eq!(rows[0].get("name"), Some(&Value::Varchar("Alice".into())));
+    } else {
+        panic!("Expected rows");
+    }
+}
+
+#[test]
+fn test_rowid_sequential() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute("CREATE TABLE t (name VARCHAR)", &mut pager, &mut catalog).unwrap();
+
+    execute("INSERT INTO t VALUES ('a')", &mut pager, &mut catalog).unwrap();
+    execute("INSERT INTO t VALUES ('b')", &mut pager, &mut catalog).unwrap();
+    execute("INSERT INTO t VALUES ('c')", &mut pager, &mut catalog).unwrap();
+
+    let result = execute("SELECT _rowid, name FROM t", &mut pager, &mut catalog).unwrap();
+    if let ExecResult::Rows(rows) = result {
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].get("_rowid"), Some(&Value::Integer(1)));
+        assert_eq!(rows[1].get("_rowid"), Some(&Value::Integer(2)));
+        assert_eq!(rows[2].get("_rowid"), Some(&Value::Integer(3)));
+    } else {
+        panic!("Expected rows");
+    }
+}
+
+#[test]
+fn test_pk_table_unchanged() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    execute(
+        "INSERT INTO t VALUES (10, 'Alice')",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute("INSERT INTO t VALUES (20, 'Bob')", &mut pager, &mut catalog).unwrap();
+
+    let result = execute("SELECT * FROM t", &mut pager, &mut catalog).unwrap();
+    if let ExecResult::Rows(rows) = result {
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].get("id"), Some(&Value::Integer(10)));
+        assert_eq!(rows[0].get("name"), Some(&Value::Varchar("Alice".into())));
+    } else {
+        panic!("Expected rows");
+    }
+}
+
+#[test]
+fn test_rowid_insert_with_columns() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE t (name VARCHAR, age BIGINT)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    execute(
+        "INSERT INTO t (name, age) VALUES ('Alice', 25)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    let result = execute("SELECT _rowid, name, age FROM t", &mut pager, &mut catalog).unwrap();
+    if let ExecResult::Rows(rows) = result {
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].get("_rowid"), Some(&Value::Integer(1)));
+        assert_eq!(rows[0].get("name"), Some(&Value::Varchar("Alice".into())));
+        assert_eq!(rows[0].get("age"), Some(&Value::Integer(25)));
+    } else {
+        panic!("Expected rows");
+    }
+}

--- a/tests/transaction_tests.rs
+++ b/tests/transaction_tests.rs
@@ -31,7 +31,7 @@ fn test_begin_commit() {
     let (mut session, _dir) = setup_session();
 
     session
-        .execute("CREATE TABLE t (id INT64 PRIMARY KEY, name VARCHAR)")
+        .execute("CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)")
         .unwrap();
 
     session.execute("BEGIN").unwrap();
@@ -50,7 +50,7 @@ fn test_begin_rollback() {
     let (mut session, _dir) = setup_session();
 
     session
-        .execute("CREATE TABLE t (id INT64 PRIMARY KEY, name VARCHAR)")
+        .execute("CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)")
         .unwrap();
 
     // Insert one row without transaction (auto-commit)
@@ -72,7 +72,7 @@ fn test_autocommit() {
     let (mut session, _dir) = setup_session();
 
     session
-        .execute("CREATE TABLE t (id INT64 PRIMARY KEY, name VARCHAR)")
+        .execute("CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)")
         .unwrap();
 
     // Without BEGIN, INSERT should be immediately committed
@@ -114,7 +114,7 @@ fn test_ddl_in_transaction() {
 
     session.execute("BEGIN").unwrap();
     session
-        .execute("CREATE TABLE t (id INT64 PRIMARY KEY, name VARCHAR)")
+        .execute("CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)")
         .unwrap();
     session
         .execute("INSERT INTO t VALUES (1, 'Alice')")
@@ -130,7 +130,7 @@ fn test_select_in_transaction() {
     let (mut session, _dir) = setup_session();
 
     session
-        .execute("CREATE TABLE t (id INT64 PRIMARY KEY, name VARCHAR)")
+        .execute("CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)")
         .unwrap();
     session
         .execute("INSERT INTO t VALUES (1, 'Alice')")
@@ -151,7 +151,7 @@ fn test_update_in_transaction() {
     let (mut session, _dir) = setup_session();
 
     session
-        .execute("CREATE TABLE t (id INT64 PRIMARY KEY, name VARCHAR)")
+        .execute("CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)")
         .unwrap();
     session
         .execute("INSERT INTO t VALUES (1, 'Alice')")
@@ -180,7 +180,7 @@ fn test_delete_in_transaction() {
     let (mut session, _dir) = setup_session();
 
     session
-        .execute("CREATE TABLE t (id INT64 PRIMARY KEY, name VARCHAR)")
+        .execute("CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)")
         .unwrap();
     session
         .execute("INSERT INTO t VALUES (1, 'Alice')")
@@ -199,7 +199,7 @@ fn test_rollback_preserves_prior_data() {
     let (mut session, _dir) = setup_session();
 
     session
-        .execute("CREATE TABLE t (id INT64 PRIMARY KEY, name VARCHAR)")
+        .execute("CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)")
         .unwrap();
     session
         .execute("INSERT INTO t VALUES (1, 'Alice')")
@@ -226,7 +226,7 @@ fn test_database_into_session() {
     let mut session = db.into_session();
 
     session
-        .execute("CREATE TABLE t (id INT64 PRIMARY KEY)")
+        .execute("CREATE TABLE t (id BIGINT PRIMARY KEY)")
         .unwrap();
     session.execute("BEGIN").unwrap();
     session.execute("INSERT INTO t VALUES (1)").unwrap();


### PR DESCRIPTION
## Summary
- Replace `INT64` with MySQL-compatible integer types: `TINYINT` (1B), `SMALLINT` (2B), `INT` (4B), `BIGINT` (8B) with actual byte-width storage
- Rename `Value::Int64` to `Value::Integer` (shared `i64` internal representation)
- Add `VARCHAR(n)`/`VARBINARY(n)` size constraints with INSERT-time validation
- Add `TEXT` type (unbounded text)
- Add range validation on INSERT for integer types and length validation for VARCHAR/VARBINARY
- Add order-preserving key encoding (`encode_i8`/`encode_i16`/`encode_i32`) for B-tree keys
- Remove `INT64` completely (no alias)

## Test plan
- [x] All 173 tests pass (116 unit + 57 integration)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [ ] Verify new integer types with manual testing (CREATE TABLE with TINYINT/SMALLINT/INT, INSERT, SELECT)
- [ ] Verify range validation errors (e.g., INSERT 128 into TINYINT column)
- [ ] Verify VARCHAR(n) length constraint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)