### PR TITLE
Add TLA+ crash resilience model and TLC make targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+/.tools/
+
+/specs/tla/states/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+TLA_TOOLS_DIR ?= .tools
+TLA2TOOLS_JAR ?= $(TLA_TOOLS_DIR)/tla2tools.jar
+TLA2TOOLS_URL ?= https://github.com/tlaplus/tlaplus/releases/latest/download/tla2tools.jar
+
+.PHONY: tlc-tools tlc tlc-large
+
+tlc-tools: $(TLA2TOOLS_JAR)
+
+$(TLA2TOOLS_JAR):
+	@mkdir -p "$(TLA_TOOLS_DIR)"
+	@if command -v curl >/dev/null 2>&1; then \
+		echo "Downloading TLA+ tools with curl..."; \
+		curl -fL "$(TLA2TOOLS_URL)" -o "$(TLA2TOOLS_JAR)"; \
+	elif command -v wget >/dev/null 2>&1; then \
+		echo "Downloading TLA+ tools with wget..."; \
+		wget -O "$(TLA2TOOLS_JAR)" "$(TLA2TOOLS_URL)"; \
+	else \
+		echo "Neither curl nor wget is available."; \
+		exit 1; \
+	fi
+	@echo "Saved $(TLA2TOOLS_JAR)"
+
+tlc: tlc-tools
+	@TLA2TOOLS_JAR="$(abspath $(TLA2TOOLS_JAR))" ./specs/tla/run_tlc.sh
+
+tlc-large: tlc-tools
+	@TLA2TOOLS_JAR="$(abspath $(TLA2TOOLS_JAR))" ./specs/tla/run_tlc.sh ./specs/tla/CrashResilience.large.cfg

--- a/README.md
+++ b/README.md
@@ -151,9 +151,17 @@ LIMIT 10;
 
 ### WAL & Recovery
 
-- Records: BEGIN, PAGE_PUT, COMMIT, ABORT
+- Records: BEGIN, PAGE_PUT, META_UPDATE, COMMIT, ABORT
 - Recovery: replay committed transactions, discard uncommitted
 - All WAL records encrypted
+
+### Formal Verification
+
+- TLA+ model for crash/recovery invariants: `specs/tla/CrashResilience.tla`
+- TLC config: `specs/tla/CrashResilience.cfg`
+- Runner script: `specs/tla/run_tlc.sh`
+- Make targets: `make tlc-tools`, `make tlc`, `make tlc-large`
+- Notes and scope: `specs/tla/README.md`
 
 ### Concurrency
 

--- a/specs/tla/CrashResilience.cfg
+++ b/specs/tla/CrashResilience.cfg
@@ -1,0 +1,12 @@
+SPECIFICATION Spec
+
+CONSTANTS
+  TxIds = {"T1"}
+  Pages = {0, 1}
+  Values = {"A", "B"}
+  Roots = {"R0", "R1"}
+  NoTx = "NoTx"
+
+INVARIANT TypeInv
+INVARIANT RecoveredSound
+INVARIANT NoUncommittedInfluence

--- a/specs/tla/CrashResilience.large.cfg
+++ b/specs/tla/CrashResilience.large.cfg
@@ -1,0 +1,12 @@
+SPECIFICATION Spec
+
+CONSTANTS
+  TxIds = {"T1", "T2"}
+  Pages = {0, 1, 2}
+  Values = {"A", "B", "C"}
+  Roots = {"R0", "R1", "R2"}
+  NoTx = "NoTx"
+
+INVARIANT TypeInv
+INVARIANT RecoveredSound
+INVARIANT NoUncommittedInfluence

--- a/specs/tla/CrashResilience.tla
+++ b/specs/tla/CrashResilience.tla
@@ -1,0 +1,253 @@
+---- MODULE CrashResilience ----
+EXTENDS Naturals, FiniteSets, Sequences, TLC
+
+(***************************************************************************)
+(* Abstraction                                                             *)
+(* - Model commit pipeline at tx granularity (Begin/Write/Meta/Commit).   *)
+(* - WAL is modeled as durable per-transaction summaries + commit order.   *)
+(* - Crash discards only volatile in-flight transaction state.             *)
+(* - Recover replays committed WAL transactions to reconstruct state.       *)
+(***************************************************************************)
+
+CONSTANTS
+  TxIds,
+  Pages,
+  Values,
+  Roots,
+  NoTx
+
+ASSUME TxIds /= {}
+ASSUME Pages /= {}
+ASSUME Values /= {}
+ASSUME Roots /= {}
+ASSUME NoTx \notin TxIds
+
+MaxPageCount == Cardinality(Pages)
+
+MaxNat(S) ==
+  CHOOSE m \in S : \A x \in S : x <= m
+
+TxRec ==
+  [ committed : BOOLEAN,
+    pages     : [Pages -> Values],
+    touched   : SUBSET Pages,
+    metaSet   : BOOLEAN,
+    metaRoot  : Roots,
+    metaCount : 0..MaxPageCount ]
+
+VARIABLES
+  mode,
+  activeTx,
+  bufPages,
+  bufTouched,
+  bufMetaSet,
+  bufMetaRoot,
+  bufMetaCount,
+  walTx,
+  committedOrder,
+  db,
+  catalogRoot,
+  pageCount,
+  initDb,
+  initCatalogRoot,
+  initPageCount
+
+vars == <<
+  mode,
+  activeTx,
+  bufPages,
+  bufTouched,
+  bufMetaSet,
+  bufMetaRoot,
+  bufMetaCount,
+  walTx,
+  committedOrder,
+  db,
+  catalogRoot,
+  pageCount,
+  initDb,
+  initCatalogRoot,
+  initPageCount
+>>
+
+TypeInv ==
+  /\ mode \in {"Running", "Crashed", "Recovered"}
+  /\ activeTx \in TxIds \cup {NoTx}
+  /\ bufPages \in [Pages -> Values]
+  /\ bufTouched \subseteq Pages
+  /\ bufMetaSet \in BOOLEAN
+  /\ bufMetaRoot \in Roots
+  /\ bufMetaCount \in 0..MaxPageCount
+  /\ walTx \in [TxIds -> TxRec]
+  /\ committedOrder \in Seq(TxIds)
+  /\ db \in [Pages -> Values]
+  /\ catalogRoot \in Roots
+  /\ pageCount \in 0..MaxPageCount
+  /\ initDb \in [Pages -> Values]
+  /\ initCatalogRoot \in Roots
+  /\ initPageCount \in 0..MaxPageCount
+
+Init ==
+  /\ mode = "Running"
+  /\ activeTx = NoTx
+  /\ bufPages \in [Pages -> Values]
+  /\ bufTouched = {}
+  /\ bufMetaSet = FALSE
+  /\ bufMetaRoot \in Roots
+  /\ bufMetaCount \in 0..MaxPageCount
+  /\ walTx = [t \in TxIds |->
+      [ committed |-> FALSE,
+        pages     |-> [p \in Pages |-> CHOOSE v \in Values : TRUE],
+        touched   |-> {},
+        metaSet   |-> FALSE,
+        metaRoot  |-> CHOOSE r \in Roots : TRUE,
+        metaCount |-> 0 ]]
+  /\ committedOrder = <<>>
+  /\ db \in [Pages -> Values]
+  /\ catalogRoot \in Roots
+  /\ pageCount \in 0..MaxPageCount
+  /\ initDb = db
+  /\ initCatalogRoot = catalogRoot
+  /\ initPageCount = pageCount
+
+BeginTx ==
+  /\ mode = "Running"
+  /\ activeTx = NoTx
+  /\ \E t \in TxIds:
+      /\ ~walTx[t].committed
+      /\ activeTx' = t
+      /\ bufPages' = [p \in Pages |-> db[p]]
+      /\ bufTouched' = {}
+      /\ bufMetaSet' = FALSE
+      /\ bufMetaRoot' = catalogRoot
+      /\ bufMetaCount' = pageCount
+  /\ UNCHANGED <<mode, walTx, committedOrder, db, catalogRoot, pageCount,
+                 initDb, initCatalogRoot, initPageCount>>
+
+WritePage ==
+  /\ mode = "Running"
+  /\ activeTx \in TxIds
+  /\ \E p \in Pages, v \in Values:
+      /\ bufPages' = [bufPages EXCEPT ![p] = v]
+      /\ bufTouched' = bufTouched \cup {p}
+  /\ UNCHANGED <<mode, activeTx, bufMetaSet, bufMetaRoot, bufMetaCount,
+                 walTx, committedOrder, db, catalogRoot, pageCount,
+                 initDb, initCatalogRoot, initPageCount>>
+
+SetMeta ==
+  /\ mode = "Running"
+  /\ activeTx \in TxIds
+  /\ \E r \in Roots, c \in 0..MaxPageCount:
+      /\ bufMetaSet' = TRUE
+      /\ bufMetaRoot' = r
+      /\ bufMetaCount' = c
+  /\ UNCHANGED <<mode, activeTx, bufPages, bufTouched,
+                 walTx, committedOrder, db, catalogRoot, pageCount,
+                 initDb, initCatalogRoot, initPageCount>>
+
+DurableCommit ==
+  /\ mode = "Running"
+  /\ activeTx \in TxIds
+  /\ walTx' = [walTx EXCEPT
+      ![activeTx] = [@ EXCEPT
+        !.committed = TRUE,
+        !.pages = bufPages,
+        !.touched = bufTouched,
+        !.metaSet = bufMetaSet,
+        !.metaRoot = bufMetaRoot,
+        !.metaCount = bufMetaCount ]]
+  /\ committedOrder' = Append(committedOrder, activeTx)
+  /\ activeTx' = NoTx
+  /\ bufTouched' = {}
+  /\ bufMetaSet' = FALSE
+  /\ UNCHANGED <<mode, bufPages, bufMetaRoot, bufMetaCount,
+                 db, catalogRoot, pageCount,
+                 initDb, initCatalogRoot, initPageCount>>
+
+(* Optional data-file flush before crash: any subset of a committed tx may be applied. *)
+FlushSomeCommitted ==
+  /\ mode = "Running"
+  /\ \E t \in TxIds:
+      /\ walTx[t].committed
+      /\ \E s \in SUBSET walTx[t].touched:
+          /\ db' = [p \in Pages |-> IF p \in s THEN walTx[t].pages[p] ELSE db[p]]
+          /\ \E fm \in BOOLEAN:
+              /\ catalogRoot' = IF fm /\ walTx[t].metaSet THEN walTx[t].metaRoot ELSE catalogRoot
+              /\ pageCount' = IF fm /\ walTx[t].metaSet
+                              THEN IF walTx[t].metaCount > pageCount THEN walTx[t].metaCount ELSE pageCount
+                              ELSE pageCount
+  /\ UNCHANGED <<mode, activeTx, bufPages, bufTouched, bufMetaSet, bufMetaRoot, bufMetaCount,
+                 walTx, committedOrder, initDb, initCatalogRoot, initPageCount>>
+
+Crash ==
+  /\ mode = "Running"
+  /\ mode' = "Crashed"
+  /\ activeTx' = NoTx
+  /\ bufTouched' = {}
+  /\ bufMetaSet' = FALSE
+  /\ UNCHANGED <<bufPages, bufMetaRoot, bufMetaCount,
+                 walTx, committedOrder, db, catalogRoot, pageCount,
+                 initDb, initCatalogRoot, initPageCount>>
+
+LastIndexTouching(p) ==
+  LET Is == {i \in 1..Len(committedOrder) : p \in walTx[committedOrder[i]].touched}
+  IN IF Is = {} THEN 0 ELSE MaxNat(Is)
+
+HasCommittedMeta ==
+  \E i \in 1..Len(committedOrder): walTx[committedOrder[i]].metaSet
+
+LastMetaIndex ==
+  LET Is == {i \in 1..Len(committedOrder) : walTx[committedOrder[i]].metaSet}
+  IN IF Is = {} THEN 0 ELSE MaxNat(Is)
+
+ExpectedDb ==
+  [p \in Pages |->
+    IF LastIndexTouching(p) = 0
+    THEN initDb[p]
+    ELSE walTx[committedOrder[LastIndexTouching(p)]].pages[p]]
+
+ExpectedCatalogRoot ==
+  IF LastMetaIndex = 0
+  THEN initCatalogRoot
+  ELSE walTx[committedOrder[LastMetaIndex]].metaRoot
+
+ExpectedMinPageCount ==
+  LET touchedMax ==
+        IF \E p \in Pages : LastIndexTouching(p) > 0
+        THEN MaxNat({q + 1 : q \in {p \in Pages : LastIndexTouching(p) > 0}})
+        ELSE 0
+      metaMax ==
+        IF LastMetaIndex = 0
+        THEN initPageCount
+        ELSE walTx[committedOrder[LastMetaIndex]].metaCount
+  IN MaxNat({initPageCount, metaMax, touchedMax})
+
+Recover ==
+  /\ mode = "Crashed"
+  /\ mode' = "Recovered"
+  /\ db' = ExpectedDb
+  /\ catalogRoot' = ExpectedCatalogRoot
+  /\ pageCount' \in ExpectedMinPageCount..MaxPageCount
+  /\ UNCHANGED <<activeTx, bufPages, bufTouched, bufMetaSet, bufMetaRoot, bufMetaCount,
+                 walTx, committedOrder, initDb, initCatalogRoot, initPageCount>>
+
+Next ==
+  BeginTx \/ WritePage \/ SetMeta \/ DurableCommit \/ FlushSomeCommitted \/ Crash \/ Recover
+
+Spec == Init /\ [][Next]_vars /\ WF_vars(Crash) /\ WF_vars(Recover)
+
+RecoveredSound ==
+  mode = "Recovered" =>
+    /\ db = ExpectedDb
+    /\ catalogRoot = ExpectedCatalogRoot
+    /\ pageCount >= ExpectedMinPageCount
+
+NoUncommittedInfluence ==
+  mode = "Recovered" =>
+    \A t \in TxIds:
+      ~walTx[t].committed =>
+        \A p \in walTx[t].touched:
+          LastIndexTouching(p) = 0 \/ committedOrder[LastIndexTouching(p)] # t
+
+THEOREM Spec => []TypeInv
+====

--- a/specs/tla/README.md
+++ b/specs/tla/README.md
@@ -1,0 +1,60 @@
+# CrashResilience TLA+ Model
+
+This folder contains a small TLA+ model for MuroDB crash resilience.
+
+## Files
+
+- `CrashResilience.tla`: system model
+- `CrashResilience.cfg`: TLC configuration (small finite state space, default)
+- `CrashResilience.large.cfg`: larger state space for deeper checking
+- `run_tlc.sh`: helper to run TLC
+
+## What is modeled
+
+- Transaction lifecycle: `BeginTx`, `WritePage`, `SetMeta`, `DurableCommit`
+- Optional partial data-file flush before crash (`FlushSomeCommitted`)
+- Crash and restart recovery (`Crash`, `Recover`)
+- WAL replay semantics at tx granularity:
+  - committed writes are recovered
+  - uncommitted writes are ignored
+  - metadata (`catalogRoot`, `pageCount`) is recovered from committed records
+
+## Checked invariants
+
+- `TypeInv`: basic type safety of all state variables
+- `RecoveredSound`: after recovery, DB state equals replayed committed WAL state
+- `NoUncommittedInfluence`: uncommitted txs do not influence recovered state
+
+## Run TLC
+
+Requirements:
+
+1. Java (installed in this dev environment)
+2. `tla2tools.jar` (TLC)
+
+Example:
+
+```bash
+export TLA2TOOLS_JAR=/path/to/tla2tools.jar
+./specs/tla/run_tlc.sh
+```
+
+Or, from repo root:
+
+```bash
+make tlc-tools   # download tla2tools.jar via curl/wget
+make tlc         # run TLC with specs/tla/CrashResilience.cfg (fast/small)
+make tlc-large   # run TLC with specs/tla/CrashResilience.large.cfg
+```
+
+If your machine has `tlc2` command available, you can also run:
+
+```bash
+tlc2 -config specs/tla/CrashResilience.cfg specs/tla/CrashResilience.tla
+```
+
+## Scope and limitations
+
+- This is an abstract model, not byte-level WAL frame parsing.
+- It does not model OS/filesystem durability anomalies directly.
+- It is intended to validate protocol-level invariants and crash/recovery semantics.

--- a/specs/tla/run_tlc.sh
+++ b/specs/tla/run_tlc.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MODULE="$ROOT_DIR/CrashResilience.tla"
+CFG="${1:-$ROOT_DIR/CrashResilience.cfg}"
+
+if [[ -z "${TLA2TOOLS_JAR:-}" ]]; then
+  echo "TLA2TOOLS_JAR is not set."
+  echo "Example: export TLA2TOOLS_JAR=/path/to/tla2tools.jar"
+  exit 1
+fi
+
+if [[ ! -f "$TLA2TOOLS_JAR" ]]; then
+  echo "tla2tools.jar not found: $TLA2TOOLS_JAR"
+  exit 1
+fi
+
+exec java -cp "$TLA2TOOLS_JAR" tlc2.TLC -deadlock -cleanup -config "$CFG" "$MODULE"


### PR DESCRIPTION
## Summary
- add a TLA+ model for WAL crash resilience invariants
- add TLC config files for small and larger state spaces
- add Makefile targets to fetch tools and run TLC
- document formal verification workflow in README/spec docs

## Validation
- make tlc (passes)
