### PR TITLE
Strengthen TLA invariants for commit metadata and order

### DIFF
--- a/specs/tla/CrashResilience.cfg
+++ b/specs/tla/CrashResilience.cfg
@@ -10,3 +10,5 @@ CONSTANTS
 INVARIANT TypeInv
 INVARIANT RecoveredSound
 INVARIANT NoUncommittedInfluence
+INVARIANT CommitRequiresMeta
+INVARIANT UniqueCommittedOrder

--- a/specs/tla/CrashResilience.large.cfg
+++ b/specs/tla/CrashResilience.large.cfg
@@ -10,3 +10,5 @@ CONSTANTS
 INVARIANT TypeInv
 INVARIANT RecoveredSound
 INVARIANT NoUncommittedInfluence
+INVARIANT CommitRequiresMeta
+INVARIANT UniqueCommittedOrder

--- a/specs/tla/CrashResilience.tla
+++ b/specs/tla/CrashResilience.tla
@@ -148,6 +148,7 @@ SetMeta ==
 DurableCommit ==
   /\ mode = "Running"
   /\ activeTx \in TxIds
+  /\ bufMetaSet = TRUE
   /\ walTx' = [walTx EXCEPT
       ![activeTx] = [@ EXCEPT
         !.committed = TRUE,
@@ -248,6 +249,14 @@ NoUncommittedInfluence ==
       ~walTx[t].committed =>
         \A p \in walTx[t].touched:
           LastIndexTouching(p) = 0 \/ committedOrder[LastIndexTouching(p)] # t
+
+CommitRequiresMeta ==
+  \A t \in TxIds:
+    walTx[t].committed => walTx[t].metaSet
+
+UniqueCommittedOrder ==
+  \A i, j \in 1..Len(committedOrder):
+    i # j => committedOrder[i] # committedOrder[j]
 
 THEOREM Spec => []TypeInv
 ====

--- a/specs/tla/README.md
+++ b/specs/tla/README.md
@@ -24,6 +24,8 @@ This folder contains a small TLA+ model for MuroDB crash resilience.
 - `TypeInv`: basic type safety of all state variables
 - `RecoveredSound`: after recovery, DB state equals replayed committed WAL state
 - `NoUncommittedInfluence`: uncommitted txs do not influence recovered state
+- `CommitRequiresMeta`: committed tx always has metadata update
+- `UniqueCommittedOrder`: each tx appears at most once in commit order
 
 ## Run TLC
 


### PR DESCRIPTION
## Summary
- require metadata to be present before durable commit in the TLA+ model
- add invariants for commit metadata presence and unique commit ordering
- enable the new invariants in both small and large TLC configs
- document the added invariants in specs/tla README

## Validation
- make tlc
