### PR TITLE
Add CLI recovery-mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,16 @@ murodb mydb.db -e "SHOW TABLES"
 
 # Interactive REPL
 murodb mydb.db
+
+# Open with permissive recovery mode (salvage valid committed txs)
+murodb mydb.db --recovery-mode permissive
 ```
 
 Options:
 - `-e <SQL>` — Execute SQL and exit
 - `--create` — Create a new database
 - `--password <PW>` — Password (prompts if omitted)
+- `--recovery-mode <strict|permissive>` — WAL recovery policy for open
 
 ## Components
 


### PR DESCRIPTION
## Summary
- add recovery-mode option to CLI (strict or permissive)
- wire CLI open path to open_with_password_and_recovery_mode
- document CLI option in README usage

## Validation
- cargo fmt -- --check
- cargo test recovery::tests::test_recovery_ -- --nocapture
- cargo test --test wal_recovery -- --nocapture
