### PR TITLE
Expose recovery audit report and skipped tx diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ LIMIT 10;
 - Recovery mode:
   - strict (default): `Database::open(...)`
   - permissive: `Database::open_with_recovery_mode(..., RecoveryMode::Permissive)`
+  - report: `Database::open_with_recovery_mode_and_report(...)` returns skipped malformed tx details
 - All WAL records encrypted
 
 ### Formal Verification

--- a/docs/crash-resilience.md
+++ b/docs/crash-resilience.md
@@ -75,11 +75,13 @@ Database::open(path, master_key)
 - `permissive`:
   - 不正なトランザクションを無視し、有効な committed トランザクションのみ復旧する
   - 破損環境からの救出用途（調査・緊急復旧）向け
+  - `RecoveryResult.skipped` で無視した txid と理由を取得できる
 
 API:
 
 - `Database::open(path, key)` は strict
 - `Database::open_with_recovery_mode(path, key, RecoveryMode::Permissive)` で permissive を選択可能
+- `Database::open_with_recovery_mode_and_report(...)` で recovery report を取得可能
 
 ## TLA+ と実装の対応
 


### PR DESCRIPTION
## Summary
- add recovery report APIs that return WAL recovery details
- include skipped malformed tx diagnostics in RecoveryResult for permissive mode
- surface skipped tx warnings in CLI when opened with permissive recovery mode
- update crash resilience docs and README

## Validation
- cargo fmt -- --check
- cargo test recovery::tests::test_recovery_ -- --nocapture
- cargo test --test wal_recovery -- --nocapture
