### PR TITLE
Quarantine malformed WAL on permissive recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ LIMIT 10;
   - strict (default): `Database::open(...)`
   - permissive: `Database::open_with_recovery_mode(..., RecoveryMode::Permissive)`
   - report: `Database::open_with_recovery_mode_and_report(...)` returns skipped malformed tx details
+  - permissive + skipped tx: original WAL is quarantined to `*.wal.quarantine.*`
 - All WAL records encrypted
 
 ### Formal Verification

--- a/docs/crash-resilience.md
+++ b/docs/crash-resilience.md
@@ -76,6 +76,7 @@ Database::open(path, master_key)
   - 不正なトランザクションを無視し、有効な committed トランザクションのみ復旧する
   - 破損環境からの救出用途（調査・緊急復旧）向け
   - `RecoveryResult.skipped` で無視した txid と理由を取得できる
+  - `skipped` がある場合、元 WAL は `*.wal.quarantine.*` に退避される
 
 API:
 

--- a/src/bin/murodb.rs
+++ b/src/bin/murodb.rs
@@ -240,6 +240,9 @@ fn main() {
                         "WARNING: permissive recovery skipped {} malformed transaction(s)",
                         report.skipped.len()
                     );
+                    if let Some(path) = &report.wal_quarantine_path {
+                        eprintln!("  - quarantined WAL: {}", path);
+                    }
                     for skipped in &report.skipped {
                         eprintln!("  - txid {}: {}", skipped.txid, skipped.reason);
                     }

--- a/src/wal/recovery.rs
+++ b/src/wal/recovery.rs
@@ -60,6 +60,7 @@ pub fn recover_with_mode(
             aborted_txids: Vec::new(),
             pages_replayed: 0,
             skipped: Vec::new(),
+            wal_quarantine_path: None,
         });
     }
 
@@ -72,6 +73,7 @@ pub fn recover_with_mode(
             aborted_txids: Vec::new(),
             pages_replayed: 0,
             skipped: Vec::new(),
+            wal_quarantine_path: None,
         });
     }
 
@@ -350,6 +352,7 @@ pub fn recover_with_mode(
             .into_iter()
             .map(|(txid, reason)| RecoverySkippedTx { txid, reason })
             .collect(),
+        wal_quarantine_path: None,
     })
 }
 
@@ -368,6 +371,7 @@ pub struct RecoveryResult {
     pub aborted_txids: Vec<TxId>,
     pub pages_replayed: usize,
     pub skipped: Vec<RecoverySkippedTx>,
+    pub wal_quarantine_path: Option<String>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary
- when permissive recovery skips malformed transactions, move original WAL to a quarantine file
- include quarantine path in recovery report
- surface quarantine path in CLI warnings for permissive recovery
- add integration test covering WAL quarantine behavior
- update README and crash-resilience docs

## Validation
- cargo fmt -- --check
- cargo test recovery::tests::test_recovery_ -- --nocapture
- cargo test --test wal_recovery -- --nocapture
