### PR TITLE
Quarantine malformed WAL and add inspect-wal diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ murodb mydb.db
 
 # Open with permissive recovery mode (salvage valid committed txs)
 murodb mydb.db --recovery-mode permissive
+
+# Inspect WAL consistency only (no replay/apply)
+murodb mydb.db --inspect-wal mydb.wal --recovery-mode permissive
 ```
 
 Options:
@@ -48,6 +51,7 @@ Options:
 - `--create` — Create a new database
 - `--password <PW>` — Password (prompts if omitted)
 - `--recovery-mode <strict|permissive>` — WAL recovery policy for open
+- `--inspect-wal <PATH>` — Analyze WAL consistency and exit
 
 ## Components
 

--- a/docs/crash-resilience.md
+++ b/docs/crash-resilience.md
@@ -83,6 +83,7 @@ API:
 - `Database::open(path, key)` は strict
 - `Database::open_with_recovery_mode(path, key, RecoveryMode::Permissive)` で permissive を選択可能
 - `Database::open_with_recovery_mode_and_report(...)` で recovery report を取得可能
+- CLI: `murodb <db> --inspect-wal <wal> --recovery-mode permissive` で WAL 診断のみ実行可能
 
 ## TLA+ と実装の対応
 


### PR DESCRIPTION
## Summary
- quarantine original WAL when permissive recovery skips malformed transactions
- include quarantine path in recovery report and CLI warnings
- add inspect-wal diagnostics command for WAL-only analysis
- update docs and README

## Validation
- cargo fmt -- --check
- cargo test recovery::tests::test_recovery_ -- --nocapture
- cargo test --test wal_recovery -- --nocapture
