### PR TITLE
Add JSON output format for inspect-wal

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ murodb mydb.db --recovery-mode permissive
 
 # Inspect WAL consistency only (no replay/apply)
 murodb mydb.db --inspect-wal mydb.wal --recovery-mode permissive
+
+# Inspect as JSON (for tooling/automation)
+murodb mydb.db --inspect-wal mydb.wal --recovery-mode permissive --format json
 ```
 
 Options:
@@ -52,6 +55,7 @@ Options:
 - `--password <PW>` — Password (prompts if omitted)
 - `--recovery-mode <strict|permissive>` — WAL recovery policy for open
 - `--inspect-wal <PATH>` — Analyze WAL consistency and exit
+- `--format <text|json>` — Output format (mainly for `--inspect-wal`)
 
 ## Components
 

--- a/docs/crash-resilience.md
+++ b/docs/crash-resilience.md
@@ -84,6 +84,7 @@ API:
 - `Database::open_with_recovery_mode(path, key, RecoveryMode::Permissive)` で permissive を選択可能
 - `Database::open_with_recovery_mode_and_report(...)` で recovery report を取得可能
 - CLI: `murodb <db> --inspect-wal <wal> --recovery-mode permissive` で WAL 診断のみ実行可能
+- CLI: `--format json` で WAL 診断結果を機械可読形式で出力可能
 
 ## TLA+ と実装の対応
 


### PR DESCRIPTION
## Summary
- add format option to CLI (text or json)
- support machine-readable JSON output for inspect-wal
- keep existing text output as default
- update README and crash-resilience docs with JSON usage

## Validation
- cargo fmt -- --check
- cargo test recovery::tests::test_recovery_ -- --nocapture
- cargo test --test wal_recovery -- --nocapture
