### PR TITLE
Stabilize inspect-wal JSON schema with skip codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Options:
 - `--recovery-mode <strict|permissive>` — WAL recovery policy for open
 - `--inspect-wal <PATH>` — Analyze WAL consistency and exit
 - `--format <text|json>` — Output format (mainly for `--inspect-wal`)
+  - JSON includes stable fields: `schema_version`, `mode`, `wal_path`, `generated_at`, `skipped[].code`
 
 ## Components
 

--- a/docs/crash-resilience.md
+++ b/docs/crash-resilience.md
@@ -85,6 +85,7 @@ API:
 - `Database::open_with_recovery_mode_and_report(...)` で recovery report を取得可能
 - CLI: `murodb <db> --inspect-wal <wal> --recovery-mode permissive` で WAL 診断のみ実行可能
 - CLI: `--format json` で WAL 診断結果を機械可読形式で出力可能
+  - JSON は `schema_version=1` を含み、`skipped[].code` で機械向け分類を提供
 
 ## TLA+ と実装の対応
 


### PR DESCRIPTION
## Summary
- add machine-readable skip codes to recovery diagnostics
- extend inspect-wal JSON output with stable envelope fields
- include skip code in text output
- update README and crash-resilience docs

## Validation
- cargo fmt -- --check
- cargo test recovery::tests::test_recovery_ -- --nocapture
- cargo test --test wal_recovery -- --nocapture
