### PR TITLE
Add inspect-wal exit code contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Options:
 - `--inspect-wal <PATH>` — Analyze WAL consistency and exit
 - `--format <text|json>` — Output format (mainly for `--inspect-wal`)
   - JSON includes stable fields: `schema_version`, `mode`, `wal_path`, `generated_at`, `skipped[].code`
+- `--inspect-wal` exit codes:
+  - `0` no malformed tx detected
+  - `10` malformed tx detected (inspect succeeded)
+  - `20` fatal error (decrypt/IO/strict failure, etc.)
 
 ## Components
 

--- a/docs/crash-resilience.md
+++ b/docs/crash-resilience.md
@@ -86,6 +86,10 @@ API:
 - CLI: `murodb <db> --inspect-wal <wal> --recovery-mode permissive` で WAL 診断のみ実行可能
 - CLI: `--format json` で WAL 診断結果を機械可読形式で出力可能
   - JSON は `schema_version=1` を含み、`skipped[].code` で機械向け分類を提供
+- `--inspect-wal` の終了コード規約:
+  - `0`: 問題なし
+  - `10`: malformed tx 検出（診断成功）
+  - `20`: 致命エラー（復号失敗/IOエラー/strict検証失敗など）
 
 ## TLA+ と実装の対応
 


### PR DESCRIPTION
## Summary
- define inspect-wal exit code contract
- 0: no malformed tx detected
- 10: malformed tx detected (inspection succeeded)
- 20: fatal inspection error
- document the contract in README and crash-resilience docs

## Validation
- cargo fmt -- --check
- cargo test recovery::tests::test_recovery_ -- --nocapture
- cargo test --test wal_recovery -- --nocapture
