### PR TITLE
Harden WAL checkpoint truncate with dir fsync

### DIFF
--- a/docs/crash-resilience.md
+++ b/docs/crash-resilience.md
@@ -162,6 +162,7 @@ WAL commit 後の `flush_meta()` で永続化される。
 
 補足:
 - チェックポイントは best-effort で、失敗してもコミット成功結果は維持する
+- チェックポイント時は WAL 本体 `fsync` に加えて、親ディレクトリの `fsync` も best-effort 実施
 - 失敗時は従来どおり `Database::open()` 時の recovery + truncate が安全網になる
 
 ## 関連コード


### PR DESCRIPTION
## Summary
- persist WAL checkpoint truncate more robustly by adding parent directory fsync (best-effort)
- keep existing checkpoint behavior (truncate + file fsync + lsn reset)
- update crash resilience docs to describe directory fsync during checkpoint

## Why
File truncate durability can depend on filesystem metadata persistence semantics. Adding best-effort parent directory fsync provides an additional safety layer for crash scenarios.

## Test
- cargo fmt -- --check
- cargo test test_checkpoint_truncate_resets_wal_and_lsn -- --nocapture
- cargo test --test wal_recovery test_wal_is_checkpointed_after_explicit_rollback -- --nocapture