### PR TITLE
Avoid WAL append on explicit rollback

### DIFF
--- a/docs/crash-resilience.md
+++ b/docs/crash-resilience.md
@@ -46,7 +46,8 @@ COMMIT
     7. pager.flush_meta()              ← データファイルを fsync
 
 ROLLBACK
-  → tx.rollback(&mut wal)             ← WAL に Abort レコード書き込み
+  → tx.rollback_no_wal()              ← dirty buffer を破棄（WAL 追記なし）
+  → Session の post_rollback_checkpoint() で WAL を空に維持
   → カタログをディスクから再読み込み
 ```
 


### PR DESCRIPTION
## Summary
- switch explicit ROLLBACK path from tx.rollback(wal) to tx.rollback_no_wal
- keep post-rollback checkpoint behavior so WAL remains empty
- update crash-resilience docs to reflect rollback semantics

## Why
For explicit rollback, writing Abort into WAL provides no recovery benefit because uncommitted txs are discarded anyway. Removing WAL append reduces I/O failure surface and keeps rollback fast and deterministic.

## Test
- cargo fmt -- --check
- cargo test --test wal_recovery test_wal_is_checkpointed_after_explicit_rollback -- --nocapture
- cargo test test_transaction_rollback -- --nocapture