### PR TITLE
Warn on WAL checkpoint failure in session

### DIFF
--- a/docs/crash-resilience.md
+++ b/docs/crash-resilience.md
@@ -164,6 +164,7 @@ WAL commit 後の `flush_meta()` で永続化される。
 補足:
 - チェックポイントは best-effort で、失敗してもコミット成功結果は維持する
 - チェックポイント時は WAL 本体 `fsync` に加えて、親ディレクトリの `fsync` も best-effort 実施
+- チェックポイント失敗時は `WARNING` を stderr に出力し、運用で検知可能にする
 - 失敗時は従来どおり `Database::open()` 時の recovery + truncate が安全網になる
 
 ## 関連コード

--- a/src/sql/session.rs
+++ b/src/sql/session.rs
@@ -152,11 +152,15 @@ impl Session {
     fn post_commit_checkpoint(&mut self) {
         // Best-effort: commit already reached durable state in data file.
         // If WAL truncate fails, keep serving and rely on startup recovery path.
-        let _ = self.wal.checkpoint_truncate();
+        if let Err(e) = self.wal.checkpoint_truncate() {
+            eprintln!("WARNING: post-commit WAL checkpoint failed: {}", e);
+        }
     }
 
     fn post_rollback_checkpoint(&mut self) {
         // Best-effort: rollback leaves no committed changes to preserve in WAL.
-        let _ = self.wal.checkpoint_truncate();
+        if let Err(e) = self.wal.checkpoint_truncate() {
+            eprintln!("WARNING: post-rollback WAL checkpoint failed: {}", e);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add explicit warning logs when post-commit WAL checkpoint fails
- add explicit warning logs when post-rollback WAL checkpoint fails
- keep behavior best-effort (successful commit result is preserved)
- update crash-resilience docs to document observability improvement

## Why
Previously checkpoint failures were silently ignored, which made operational detection difficult. This change keeps availability semantics while surfacing durability-risk signals to operators.

## Test
- cargo build
- cargo test
- cargo clippy -- -D warnings
- cargo fmt -- --check