### PR TITLE
Add WAL path and size to checkpoint warnings

### DIFF
--- a/docs/crash-resilience.md
+++ b/docs/crash-resilience.md
@@ -164,7 +164,7 @@ WAL commit 後の `flush_meta()` で永続化される。
 補足:
 - チェックポイントは best-effort で、失敗してもコミット成功結果は維持する
 - チェックポイント時は WAL 本体 `fsync` に加えて、親ディレクトリの `fsync` も best-effort 実施
-- チェックポイント失敗時は `WARNING` を stderr に出力し、運用で検知可能にする
+- チェックポイント失敗時は `WARNING` を stderr に出力し、`wal_path` / `wal_size_bytes` を含めて運用で検知可能にする
 - 失敗時は従来どおり `Database::open()` 時の recovery + truncate が安全網になる
 
 ## 関連コード

--- a/src/sql/session.rs
+++ b/src/sql/session.rs
@@ -153,14 +153,32 @@ impl Session {
         // Best-effort: commit already reached durable state in data file.
         // If WAL truncate fails, keep serving and rely on startup recovery path.
         if let Err(e) = self.wal.checkpoint_truncate() {
-            eprintln!("WARNING: post-commit WAL checkpoint failed: {}", e);
+            let wal_path = self.wal.wal_path().display();
+            let wal_size = self.wal.file_size_bytes().ok();
+            eprintln!(
+                "WARNING: post-commit WAL checkpoint failed: {} (wal_path={}, wal_size_bytes={})",
+                e,
+                wal_path,
+                wal_size
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "unknown".to_string())
+            );
         }
     }
 
     fn post_rollback_checkpoint(&mut self) {
         // Best-effort: rollback leaves no committed changes to preserve in WAL.
         if let Err(e) = self.wal.checkpoint_truncate() {
-            eprintln!("WARNING: post-rollback WAL checkpoint failed: {}", e);
+            let wal_path = self.wal.wal_path().display();
+            let wal_size = self.wal.file_size_bytes().ok();
+            eprintln!(
+                "WARNING: post-rollback WAL checkpoint failed: {} (wal_path={}, wal_size_bytes={})",
+                e,
+                wal_path,
+                wal_size
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "unknown".to_string())
+            );
         }
     }
 }

--- a/src/wal/writer.rs
+++ b/src/wal/writer.rs
@@ -103,6 +103,10 @@ impl WalWriter {
         Ok(self.file.metadata()?.len())
     }
 
+    pub fn wal_path(&self) -> &Path {
+        &self.path
+    }
+
     pub fn current_lsn(&self) -> Lsn {
         self.current_lsn
     }


### PR DESCRIPTION
## Summary
- expose WAL path via WalWriter API for diagnostics
- enrich post-commit checkpoint warning with wal_path and wal_size_bytes
- enrich post-rollback checkpoint warning with wal_path and wal_size_bytes
- update crash resilience doc to reflect warning context

## Why
Checkpoint failures are now visible, but plain error text is often insufficient in multi-db environments. Including path and size makes triage and remediation faster.

## Test
- cargo build
- cargo test
- cargo clippy -- -D warnings
- cargo fmt -- --check