### PR TITLE
Test checkpoint failure path without breaking commit

### DIFF
--- a/docs/crash-resilience.md
+++ b/docs/crash-resilience.md
@@ -165,6 +165,7 @@ WAL commit 後の `flush_meta()` で永続化される。
 - チェックポイントは best-effort で、失敗してもコミット成功結果は維持する
 - チェックポイント時は WAL 本体 `fsync` に加えて、親ディレクトリの `fsync` も best-effort 実施
 - チェックポイント失敗時は `WARNING` を stderr に出力し、`wal_path` / `wal_size_bytes` を含めて運用で検知可能にする
+- チェックポイント失敗注入の unit test で「コミット成功を壊さない」経路を回帰固定している
 - 失敗時は従来どおり `Database::open()` 時の recovery + truncate が安全網になる
 
 ## 関連コード


### PR DESCRIPTION
## Summary
- add internal checkpoint truncate wrapper in Session to enable one-shot failure injection in unit tests
- add session unit test that injects checkpoint failure and verifies commit still succeeds
- verify WAL remains for recovery when checkpoint fails, and reopen recovery still preserves schema
- update crash resilience docs to record this regression guard

## Why
Checkpoint is intentionally best-effort, but without a deterministic failure-path test we could regress and accidentally turn checkpoint failure into commit failure.

## Test
- cargo build
- cargo test test_commit_survives_checkpoint_failure_and_leaves_wal_for_recovery -- --nocapture
- cargo test
- cargo clippy -- -D warnings
- cargo fmt -- --check