### PR TITLE
Add fatal_error field to inspect-wal JSON output

### DIFF
--- a/docs/crash-resilience.md
+++ b/docs/crash-resilience.md
@@ -87,6 +87,7 @@ API:
 - CLI: `murodb <db> --inspect-wal <wal> --recovery-mode permissive` で WAL 診断のみ実行可能
 - CLI: `--format json` で WAL 診断結果を機械可読形式で出力可能
   - JSON は `schema_version=1` を含み、`skipped[].code` で機械向け分類を提供
+  - 致命失敗時も JSON を返し、`fatal_error` にエラー内容を格納する
 - `--inspect-wal` の終了コード規約:
   - `0`: 問題なし
   - `10`: malformed tx 検出（診断成功）


### PR DESCRIPTION
## Summary
- add inspect JSON helpers for success and fatal output paths
- include fatal_error field in inspect JSON schema
  - success: fatal_error is null
  - fatal failure: fatal_error contains error string and exit code 20
- keep text output behavior unchanged
- update crash resilience docs for fatal JSON contract

## Why
Automation currently has to parse stderr plus exit code on fatal inspect failures. Adding fatal_error makes machine handling consistent in JSON mode.

## Test
- cargo build
- cargo test --bin murodb -- --nocapture
- cargo test
- cargo clippy -- -D warnings
- cargo fmt -- --check