### PR TITLE
Expand inspect JSON contract with status and exit_code

### DIFF
--- a/docs/crash-resilience.md
+++ b/docs/crash-resilience.md
@@ -87,7 +87,8 @@ API:
 - CLI: `murodb <db> --inspect-wal <wal> --recovery-mode permissive` で WAL 診断のみ実行可能
 - CLI: `--format json` で WAL 診断結果を機械可読形式で出力可能
   - JSON は `schema_version=1` を含み、`skipped[].code` で機械向け分類を提供
-  - 致命失敗時も JSON を返し、`fatal_error` にエラー内容を格納する
+  - `status` (`ok`/`warning`/`fatal`) と `exit_code` を含み、終了コード規約を JSON 内でも参照可能
+  - 致命失敗時も JSON を返し、`fatal_error` と `fatal_error_code` を格納する
 - `--inspect-wal` の終了コード規約:
   - `0`: 問題なし
   - `10`: malformed tx 検出（診断成功）


### PR DESCRIPTION
## Summary
- strengthen inspect JSON schema for automation
  - add status: ok / warning / fatal
  - add exit_code mirroring CLI exit semantics (0 / 10 / 20)
  - add fatal_error_code for fatal classification
- classify fatal paths with explicit machine-readable codes
  - MISSING_DB_PATH
  - READ_SALT_FAILED
  - DERIVE_KEY_FAILED
  - INSPECT_FAILED
- refactor inspect success exit selection into shared helper
- extend bin-level JSON contract tests
  - success with skipped -> warning + exit_code 10
  - success without skipped -> ok + exit_code 0
  - fatal -> fatal + exit_code 20 + fatal_error_code
- update crash-resilience documentation

## Why
You asked for larger, more impactful increments. This PR upgrades the inspect JSON from basic payload to a stable machine contract suitable for operational pipelines.

## Test
- cargo fmt -- --check
- cargo clippy -- -D warnings
- cargo test --bin murodb -- --nocapture
- cargo test