### PR TITLE
docs: fix crash resilience and format migration accuracy

### DIFF
--- a/docs/crash-resilience.md
+++ b/docs/crash-resilience.md
@@ -5,7 +5,7 @@
 **MuroDB は WAL ベースのクラッシュ耐性を持つ。** すべての書き込みは WAL を経由し、クラッシュ後のリカバリが可能。
 
 主要機能:
-- WAL MetaUpdate にヘッダ CRC32 チェックサムを含む（破損検出）
+- データファイルヘッダ（format v2）に CRC32 チェックサムを含む（破損検出）
 - freelist_page_id を WAL MetaUpdate に含め、クラッシュ後も freelist を復元
 - データファイルヘッダの fsync 強化（WAL sync 後、データファイル flush_meta で fsync）
 

--- a/docs/format-migration.md
+++ b/docs/format-migration.md
@@ -39,10 +39,10 @@ Users must upgrade their MuroDB binary to open databases created by newer versio
 In format version 2, the freelist may span multiple pages linked as a chain:
 
 ```
-[next_freelist_page_id: u64] [count_in_this_page: u64] [page_id entries: u64...]
+[magic "FLMP": 4B] [next_freelist_page_id: u64] [count_in_this_page: u64] [page_id entries: u64...]
 ```
 
 - `next_freelist_page_id = 0` indicates end of chain
 - Each page holds up to `ENTRIES_PER_FREELIST_PAGE` entries
 - The header's `freelist_page_id` points to the first page in the chain
-- Single-page freelists from older v2 databases are detected and read correctly (backward compatible)
+- For backward compatibility, pages without `FLMP` magic are treated as legacy single-page freelist format (`[count:u64][entries...]`)


### PR DESCRIPTION
## Summary
- fix incorrect statement that CRC32 is in WAL MetaUpdate (it is in the database header v2)
- document current multi-page freelist wire format with `FLMP` magic
- clarify backward-compat behavior for non-magic freelist pages

## Why
- keep docs aligned with merged resilience hardening implementation
- avoid operational confusion during crash/debug analysis