### PR TITLE
Add mdBook documentation site with GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,42 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install mdBook
+        run: |
+          curl -sSL https://github.com/rust-lang/mdBook/releases/latest/download/mdbook-v0.4.44-x86_64-unknown-linux-gnu.tar.gz | tar -xz
+          echo "$PWD" >> $GITHUB_PATH
+      - name: Build docs
+        run: mdbook build docs-site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs-site/book
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.tools/
 
 /specs/tla/states/
+
+docs-site/book/

--- a/docs-site/book.toml
+++ b/docs-site/book.toml
@@ -1,0 +1,10 @@
+[book]
+title = "MuroDB Documentation"
+authors = ["tokuhirom"]
+language = "ja"
+
+[build]
+build-dir = "book"
+
+[output.html]
+git-repository-url = "https://github.com/tokuhirom/murodb"

--- a/docs-site/src/SUMMARY.md
+++ b/docs-site/src/SUMMARY.md
@@ -1,0 +1,29 @@
+# Summary
+
+[Introduction](introduction.md)
+
+# Getting Started
+
+- [Installation](getting-started/installation.md)
+- [Quick Start](getting-started/quick-start.md)
+
+# User Guide
+
+- [CLI Options](user-guide/cli.md)
+- [SQL Reference](user-guide/sql-reference.md)
+- [Full-Text Search](user-guide/full-text-search.md)
+- [Recovery](user-guide/recovery.md)
+
+# Internals
+
+- [Architecture](internals/architecture.md)
+- [Storage](internals/storage.md)
+- [B-tree](internals/btree.md)
+- [WAL & Crash Resilience](internals/wal.md)
+- [FTS Internals](internals/fts-internals.md)
+- [Format Migration](internals/format-migration.md)
+- [Formal Verification](internals/formal-verification.md)
+
+---
+
+[Roadmap](roadmap.md)

--- a/docs-site/src/getting-started/installation.md
+++ b/docs-site/src/getting-started/installation.md
@@ -1,0 +1,23 @@
+# Installation
+
+## Requirements
+
+- Rust toolchain (stable)
+
+## Install from source
+
+```bash
+git clone https://github.com/tokuhirom/murodb.git
+cd murodb
+cargo install --path .
+```
+
+This installs the `murodb` binary to `~/.cargo/bin/`.
+
+## Build only
+
+```bash
+cargo build --release
+```
+
+The binary will be at `target/release/murodb`.

--- a/docs-site/src/getting-started/quick-start.md
+++ b/docs-site/src/getting-started/quick-start.md
@@ -1,0 +1,35 @@
+# Quick Start
+
+## Create a new database
+
+```bash
+murodb mydb.db --create -e "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)"
+```
+
+You will be prompted for an encryption password.
+
+## Insert data
+
+```bash
+murodb mydb.db -e "INSERT INTO t (id, name) VALUES (1, 'hello')"
+```
+
+## Query data
+
+```bash
+murodb mydb.db -e "SELECT * FROM t"
+```
+
+## Show tables
+
+```bash
+murodb mydb.db -e "SHOW TABLES"
+```
+
+## Interactive REPL
+
+```bash
+murodb mydb.db
+```
+
+Start without `-e` to enter the interactive REPL mode.

--- a/docs-site/src/internals/architecture.md
+++ b/docs-site/src/internals/architecture.md
@@ -1,0 +1,43 @@
+# Architecture
+
+MuroDB is an encrypted embedded SQL database. The system is organized in layers:
+
+```
+sql/ (lexer → parser → planner → executor)
+  ↓
+schema/ (catalog: table/index definitions)
+  ↓
+tx/ (transaction: dirty page buffer, commit/rollback)
+  ↓
+btree/ (B-tree: insert/split, delete, search, scan)
+  ↓
+wal/ (WAL: encrypted records, crash recovery)
+  ↓
+storage/ (pager: encrypted page I/O, LRU cache, freelist)
+  ↓
+crypto/ (AES-256-GCM-SIV, Argon2 KDF, HMAC-SHA256)
+```
+
+Additional modules:
+
+- `fts/` - Full-text search (bigram tokenizer, postings B-tree, BM25, BOOLEAN/NATURAL mode)
+- `concurrency/` - parking_lot::RwLock (thread) + fs4 file lock (process)
+
+## Module Map
+
+| Module | Files | Role |
+|---|---|---|
+| `storage/` | page.rs, pager.rs, freelist.rs | 4096B encrypted page I/O |
+| `crypto/` | aead.rs, kdf.rs, hmac_util.rs | Encryption primitives |
+| `btree/` | node.rs, ops.rs, cursor.rs, key_encoding.rs | B-tree operations |
+| `wal/` | record.rs, writer.rs, reader.rs, recovery.rs | WAL + crash recovery |
+| `tx/` | transaction.rs, lock_manager.rs | Transactions |
+| `schema/` | catalog.rs, column.rs, index.rs | System catalog |
+| `sql/` | lexer.rs, parser.rs, ast.rs, planner.rs, executor.rs, eval.rs | SQL processing |
+| `fts/` | tokenizer.rs, postings.rs, index.rs, query.rs, scoring.rs, snippet.rs | Full-text search |
+| `concurrency/` | mod.rs | Concurrency control |
+
+## Concurrency Model
+
+- **Thread-level**: `parking_lot::RwLock` - multiple readers, single writer
+- **Process-level**: `fs4` file lock - prevents concurrent access from multiple processes

--- a/docs-site/src/internals/btree.md
+++ b/docs-site/src/internals/btree.md
@@ -1,0 +1,33 @@
+# B-tree
+
+## Overview
+
+MuroDB uses B-tree as the primary index structure. Both primary (clustered) and secondary indexes share the same B-tree implementation.
+
+## Key Encoding
+
+Keys are encoded for order-preserving binary comparison:
+
+- **Integer types** (TINYINT, SMALLINT, INT, BIGINT): Big-endian encoding with sign bit flip to preserve sort order
+- **VARCHAR / VARBINARY**: Raw bytes
+
+This encoding allows the B-tree to use simple byte comparison for key ordering.
+
+## Operations
+
+- **Insert**: Standard B-tree insert with node splitting when full
+- **Delete**: Remove key-value pair from leaf nodes
+- **Search**: Point lookup by key
+- **Scan**: Range scan with cursor-based iteration
+
+## Clustered Index
+
+Tables are clustered by PRIMARY KEY. The row data is stored directly in the primary B-tree's leaf nodes.
+
+## Secondary Indexes
+
+Secondary indexes map column values to primary key values:
+
+- `CREATE INDEX` creates a non-unique secondary index
+- `CREATE UNIQUE INDEX` creates a unique secondary index with duplicate checking
+- Secondary index entries: `(column_value) → (primary_key)`

--- a/docs-site/src/internals/formal-verification.md
+++ b/docs-site/src/internals/formal-verification.md
@@ -1,0 +1,71 @@
+# Formal Verification
+
+MuroDB uses TLA+ to formally verify crash/recovery protocol invariants.
+
+## Files
+
+| File | Description |
+|---|---|
+| `specs/tla/CrashResilience.tla` | System model |
+| `specs/tla/CrashResilience.cfg` | TLC configuration (small finite state space) |
+| `specs/tla/CrashResilience.large.cfg` | Larger state space for deeper checking |
+| `specs/tla/run_tlc.sh` | Helper script to run TLC |
+
+## What is modeled
+
+- **Transaction lifecycle**: `BeginTx`, `WritePage`, `SetMeta`, `DurableCommit`
+- **Partial flush before crash**: `FlushSomeCommitted`
+- **Crash and recovery**: `Crash`, `Recover`
+- **WAL replay semantics** at transaction granularity:
+  - Committed writes are recovered
+  - Uncommitted writes are ignored
+  - Metadata (`catalogRoot`, `pageCount`) is recovered from committed records
+
+## Checked invariants
+
+| Invariant | Description |
+|---|---|
+| `TypeInv` | Basic type safety of all state variables |
+| `RecoveredSound` | After recovery, DB state equals replayed committed WAL state |
+| `NoUncommittedInfluence` | Uncommitted transactions do not influence recovered state |
+| `CommitRequiresMeta` | Committed transactions always have metadata update |
+| `UniqueCommittedOrder` | Each transaction appears at most once in commit order |
+| `FreelistPreserved` | After recovery, freelist ID equals the last committed freelist ID |
+
+## Running TLC
+
+### Prerequisites
+
+- Java runtime
+- `tla2tools.jar` (TLC model checker)
+
+### Using Make
+
+```bash
+make tlc-tools   # Download tla2tools.jar
+make tlc         # Run with small config (fast)
+make tlc-large   # Run with large config (deeper)
+```
+
+### Manual
+
+```bash
+export TLA2TOOLS_JAR=/path/to/tla2tools.jar
+./specs/tla/run_tlc.sh
+```
+
+Or with the `tlc2` command:
+
+```bash
+tlc2 -config specs/tla/CrashResilience.cfg specs/tla/CrashResilience.tla
+```
+
+## Scope and Limitations
+
+- This is an abstract model, not byte-level WAL frame parsing
+- It does not model OS/filesystem durability anomalies directly
+- It validates protocol-level invariants and crash/recovery semantics
+
+## Correspondence with Implementation
+
+See the [WAL & Crash Resilience](wal.md#tla-correspondence) page for a detailed mapping between TLA+ invariants and their implementation in code.

--- a/docs-site/src/internals/format-migration.md
+++ b/docs-site/src/internals/format-migration.md
@@ -1,0 +1,67 @@
+# Format Migration
+
+## Format Versions
+
+### Version 1 (Legacy)
+
+Header layout:
+```
+Magic (8B) + Version (4B) + Salt (16B) + CatalogRoot (8B)
++ PageCount (8B) + Epoch (8B)
+```
+
+- No freelist page ID field
+- No header CRC32
+
+### Version 2 (Current)
+
+Header layout:
+```
+Magic (8B) + Version (4B) + Salt (16B) + CatalogRoot (8B)
++ PageCount (8B) + Epoch (8B) + FreelistPageId (8B) + CRC32 (4B)
+```
+
+- Added freelist page ID for persistent freelist storage
+- Added CRC32 over bytes 0..60 for header corruption detection
+
+## Auto-Migration: v1 to v2
+
+When MuroDB opens a database file with format version 1:
+
+1. The header is read using v1 layout rules (no CRC validation)
+2. `freelist_page_id` defaults to 0 (no persisted freelist)
+3. The header is immediately rewritten as v2 with CRC32
+4. The file is fsynced to ensure the upgrade is durable
+
+This is a safe, non-destructive upgrade: v1 databases have no freelist page, so defaulting to 0 preserves correctness.
+
+## Forward Incompatibility Policy
+
+MuroDB **rejects** database files with a format version higher than the current `FORMAT_VERSION`. This prevents data corruption from attempting to read formats that require features not yet implemented.
+
+Opening a database with an unsupported future version returns:
+```
+WAL error: unsupported database format version N
+```
+
+Users must upgrade their MuroDB binary to open databases created by newer versions.
+
+## Freelist Multi-Page Chain (v2)
+
+In format version 2, the freelist may span multiple pages linked as a chain:
+
+```
+[magic "FLMP": 4B] [next_freelist_page_id: u64] [count_in_this_page: u64] [page_id entries: u64...]
+```
+
+- `next_freelist_page_id = 0` indicates end of chain
+- Each page holds up to `ENTRIES_PER_FREELIST_PAGE` entries
+- The header's `freelist_page_id` points to the first page in the chain
+- For backward compatibility, pages without `FLMP` magic are treated as legacy single-page freelist format (`[count:u64][entries...]`)
+
+## WAL Format Version History
+
+| Version | Changes |
+|---|---|
+| v1 | Initial: Begin, PagePut, MetaUpdate(catalog_root, page_count), Commit, Abort |
+| v2 | MetaUpdate adds `freelist_page_id` field. Data file header adds CRC32. Legacy v1 MetaUpdate (25 bytes) decoded with `freelist_page_id=0` (backward compatible) |

--- a/docs-site/src/internals/fts-internals.md
+++ b/docs-site/src/internals/fts-internals.md
@@ -1,0 +1,45 @@
+# FTS Internals
+
+## Tokenization
+
+- **Normalization**: NFKC unicode normalization
+- **Tokenizer**: Bigram (n=2) - each text is split into overlapping 2-character sequences
+- Example: "東京タワー" → ["東京", "京タ", "タワ", "ワー"]
+
+## Term ID Blinding
+
+Term IDs are computed using HMAC-SHA256:
+
+- No plaintext tokens are stored on disk
+- Term ID = HMAC-SHA256(master_key, normalized_token)
+- This provides privacy: the disk contents do not reveal what terms are indexed
+
+## Postings Storage
+
+Postings lists are stored in B-tree with compression:
+
+- **Delta encoding**: Document IDs are stored as deltas from the previous ID
+- **Varint compression**: Deltas are encoded as variable-length integers
+- Postings are stored in the same B-tree infrastructure as regular data
+
+## Scoring
+
+- **Algorithm**: BM25 (Okapi BM25)
+- Used in NATURAL LANGUAGE MODE for relevance ranking
+
+## Phrase Matching
+
+Phrase queries (e.g., `"東京タワー"`) verify consecutive bigram positions:
+
+1. Tokenize the phrase into bigrams
+2. Find postings for each bigram
+3. Verify that positions are consecutive across all bigrams
+
+## Snippet Generation
+
+`fts_snippet()` uses a local scan approach:
+
+1. Find matching positions in the document
+2. Select the best window around matches
+3. Apply highlight tags (open/close) around matched regions
+4. Truncate to the specified maximum length

--- a/docs-site/src/internals/storage.md
+++ b/docs-site/src/internals/storage.md
@@ -1,0 +1,39 @@
+# Storage
+
+## Page Layout
+
+- **Page size**: 4096 bytes (slotted page layout)
+- **Encryption**: Each page encrypted with AES-256-GCM-SIV
+  - AAD (Additional Authenticated Data) = (page_id, epoch)
+- **Cache**: LRU page cache (default 256 pages)
+
+## Encryption
+
+All data at rest is encrypted:
+
+- **Algorithm**: AES-256-GCM-SIV (nonce-misuse resistant AEAD)
+- **KDF**: Argon2 derives the master key from the user's passphrase + random salt
+- **Per-page encryption**: Each page is independently encrypted with its own nonce
+- **AAD binding**: page_id and epoch are bound as additional authenticated data, preventing page swap attacks
+
+## Freelist
+
+Freed pages are tracked in a freelist for reuse:
+
+- Stored as a multi-page chain on disk
+- Each page has the format: `[magic "FLMP": 4B] [next_freelist_page_id: u64] [count: u64] [page_id entries: u64...]`
+- `next_freelist_page_id = 0` indicates end of chain
+- The header's `freelist_page_id` points to the first page in the chain
+- Legacy single-page format (without `FLMP` magic) is supported for backward compatibility
+
+## Data File Header
+
+Format v2 header layout:
+
+```
+Magic (8B) + Version (4B) + Salt (16B) + CatalogRoot (8B)
++ PageCount (8B) + Epoch (8B) + FreelistPageId (8B) + CRC32 (4B)
+```
+
+- CRC32 covers bytes 0..60 for header corruption detection
+- `freelist_page_id` persists the freelist root across restarts

--- a/docs-site/src/internals/wal.md
+++ b/docs-site/src/internals/wal.md
@@ -1,0 +1,134 @@
+# WAL & Crash Resilience
+
+MuroDB uses a Write-Ahead Log (WAL) for crash recovery. All writes go through the WAL before being applied to the data file.
+
+## WAL Record Types
+
+| Record | Description |
+|---|---|
+| BEGIN | Start of a transaction |
+| PAGE_PUT | Write a page (page_id + page data) |
+| META_UPDATE | Metadata update (catalog_root, freelist_page_id, page_count) |
+| COMMIT | Transaction commit marker |
+| ABORT | Transaction abort marker |
+
+All WAL records are encrypted.
+
+## Write Path
+
+### Auto-Commit Mode (no explicit BEGIN)
+
+```
+Session::execute_auto_commit(stmt)
+  1. Transaction::begin(txid, snapshot_lsn)
+  2. Create TxPageStore (dirty page buffer)
+  3. execute_statement(stmt, tx_page_store, catalog)
+       → BTree::insert(tx_page_store, key, value)
+         → TxPageStore::write_page()
+           → Transaction::write_page()  ← stored in HashMap (memory only)
+  4. tx.commit(&mut pager, &mut wal)    ← WAL-first commit
+       → Write Begin + PagePut + MetaUpdate + Commit records to WAL
+       → wal.sync()                     ← fsync WAL
+       → Write dirty pages to data file
+       → pager.flush_meta()             ← fsync data file
+  (on error: tx.rollback_no_wal() + restore catalog)
+```
+
+### Explicit Transaction (BEGIN ... COMMIT)
+
+```
+BEGIN
+  → Transaction::begin(txid, wal.current_lsn())
+
+exec_insert() / exec_update() / exec_delete()
+  → Write to dirty page buffer via TxPageStore
+
+COMMIT
+  → tx.commit(&mut pager, &mut wal)   ← WAL-first commit
+    1. Write Begin record to WAL
+    2. Write PagePut record for each dirty page
+    3. Write MetaUpdate (catalog_root, freelist_page_id, page_count)
+    4. Write Commit record
+    5. wal.sync()                      ← fsync WAL
+    6. Write dirty pages to data file
+    7. pager.flush_meta()              ← fsync data file
+
+ROLLBACK
+  → tx.rollback_no_wal()              ← discard dirty buffer (no WAL write)
+  → Session post_rollback_checkpoint() keeps WAL clean
+  → Reload catalog from disk
+```
+
+## Recovery (Database::open)
+
+```
+Database::open(path, master_key)
+  1. If WAL file exists, run recovery::recover()
+     → Scan WAL and validate transaction state transitions
+       (reject PagePut/MetaUpdate/Commit/Abort before Begin)
+       (reject records after Commit/Abort)
+       (reject Commit.lsn mismatch with actual LSN)
+     → Collect latest page images from committed transactions
+     → Replay to data file
+  2. Truncate WAL file (empty it)
+     → fsync WAL file
+     → best-effort fsync parent directory
+  3. Build Session with Pager + Catalog + WalWriter
+```
+
+## Recovery Modes
+
+- **strict** (default): Fails on any WAL protocol violation
+- **permissive**: Skips invalid transactions, recovers only valid committed ones
+
+See [Recovery](../user-guide/recovery.md) for user-facing documentation.
+
+## Secondary Index Consistency
+
+All index updates happen within the same transaction as the data update:
+
+### INSERT
+1. Insert row into data B-tree
+2. Insert entry into each secondary index (column_value → PK)
+3. Check UNIQUE constraint before insertion
+
+### DELETE
+1. Scan for rows to delete (collect PK + all column values)
+2. Delete entries from each secondary index
+3. Delete row from data B-tree
+
+### UPDATE
+1. Scan for rows to update (collect PK + old column values)
+2. Compute new values
+3. Check UNIQUE constraints (for changed values)
+4. Update secondary indexes (delete old entry + insert new entry)
+5. Write new row data to data B-tree
+
+## Remaining Constraints
+
+### fsync granularity
+
+`Pager::write_page_to_disk()` does not call `sync_all()` individually. Only `flush_meta()` calls `sync_all()`. WAL `sync()` guarantees data durability, so this is safe in normal operation.
+
+### allocate_page counter
+
+`Pager::allocate_page()` increments in-memory `page_count`, which is not persisted until `flush_meta()` after WAL commit.
+
+### WAL file size
+
+After successful commits and explicit `ROLLBACK`, the Session auto-checkpoints the WAL (truncates to empty). Checkpoint is best-effort and does not affect commit success.
+
+## TLA+ Correspondence
+
+See [Formal Verification](formal-verification.md) for the TLA+ model and its mapping to implementation.
+
+| TLA+ Intent | Implementation | Regression Test |
+|---|---|---|
+| Only valid state transitions are recovered | State transition validation in `recovery.rs` | `test_recovery_rejects_pageput_before_begin` |
+| Commit/Abort is terminal | Reject duplicate terminal / post-terminal records | `test_recovery_rejects_duplicate_terminal_record_for_tx` |
+| Commit has consistent terminal info | Validate `Commit.lsn == actual LSN` | `test_recovery_rejects_commit_lsn_mismatch` |
+| Commit requires metadata | Reject Commit without MetaUpdate | `test_recovery_rejects_commit_without_meta_update` |
+| PagePut matches target page | Validate `PagePut.page_id` vs page header | `test_recovery_rejects_pageput_page_id_mismatch` |
+| Tail corruption tolerated, mid-log rejected | Reader tolerates tail only | `test_tail_truncation_tolerated`, `test_mid_log_corruption_is_error` |
+| Oversized frames handled safely | Frame length limit in Reader/Writer | `test_oversized_tail_frame_tolerated` |
+| Freelist recovered from committed MetaUpdate | `freelist_page_id` in WAL MetaUpdate | `test_freelist_wal_recovery` |

--- a/docs-site/src/introduction.md
+++ b/docs-site/src/introduction.md
@@ -1,0 +1,55 @@
+# MuroDB
+
+Encrypted embedded SQL database with B-Tree + Full-Text Search (Bigram), written in Rust.
+
+## Features
+
+- **Transparent encryption** - AES-256-GCM-SIV (nonce-misuse resistant) for all pages and WAL
+- **B-tree storage** - PRIMARY KEY (TINYINT/SMALLINT/INT/BIGINT), UNIQUE indexes (single column)
+- **Full-text search** - Bigram (n=2) with NFKC normalization
+  - MySQL-style `MATCH(col) AGAINST(...)` syntax
+  - NATURAL LANGUAGE MODE with BM25 scoring
+  - BOOLEAN MODE with `+term`, `-term`, `"phrase"` operators
+  - `fts_snippet()` for highlighted excerpts
+- **ACID transactions** - WAL-based crash recovery
+- **Concurrency** - Multiple readers / single writer (thread RwLock + process file lock)
+- **Single file** - Database file + WAL file
+
+## Components
+
+| Component | Description |
+|---|---|
+| `crypto/` | AES-256-GCM-SIV page encryption, Argon2 KDF, HMAC-SHA256 term blinding |
+| `storage/` | 4096B slotted pages, encrypted pager with LRU cache, freelist |
+| `btree/` | Insert/split, delete, search, scan, order-preserving key encoding |
+| `wal/` | Encrypted WAL records, writer/reader, crash recovery |
+| `tx/` | Transaction with dirty page buffer, commit/rollback |
+| `schema/` | System catalog, table/index definitions |
+| `sql/` | Hand-written lexer/parser, AST, rule-based planner, executor |
+| `fts/` | Bigram tokenizer, delta+varint postings, BM25, NATURAL/BOOLEAN queries, snippets |
+| `concurrency/` | parking_lot RwLock + fs4 file lock |
+
+## Dependencies
+
+| Crate | Purpose |
+|---|---|
+| `aes-gcm-siv` | AEAD encryption |
+| `argon2` | Passphrase KDF |
+| `hmac` + `sha2` | FTS term ID blinding |
+| `nom` | SQL lexer |
+| `unicode-normalization` | NFKC normalization |
+| `parking_lot` | RwLock |
+| `fs4` | File lock |
+| `lru` | Page cache |
+| `rand` | Nonce generation |
+| `thiserror` | Error types |
+
+## Non-goals
+
+- Network server protocol
+- Full access-pattern obfuscation (ORAM, etc.)
+- Stored procedures / triggers
+
+## License
+
+MIT License. See [LICENSE](https://github.com/tokuhirom/murodb/blob/main/LICENSE) for details.

--- a/docs-site/src/roadmap.md
+++ b/docs-site/src/roadmap.md
@@ -1,0 +1,98 @@
+# Roadmap
+
+## Implemented
+
+- [x] Basic CRUD (INSERT, SELECT, UPDATE, DELETE)
+- [x] CREATE TABLE (PRIMARY KEY, UNIQUE, NOT NULL)
+- [x] CREATE INDEX / CREATE UNIQUE INDEX (single column)
+- [x] CREATE FULLTEXT INDEX (bigram, BM25, NATURAL/BOOLEAN mode, snippet)
+- [x] MySQL-compatible integer types (TINYINT, SMALLINT, INT, BIGINT)
+- [x] VARCHAR(n), VARBINARY(n), TEXT with size validation
+- [x] WHERE with comparison operators (=, !=, <, >, <=, >=)
+- [x] AND, OR logical operators
+- [x] ORDER BY (ASC/DESC, multi-column), LIMIT
+- [x] JOIN (INNER, LEFT, CROSS) with table aliases
+- [x] BEGIN / COMMIT / ROLLBACK
+- [x] SHOW TABLES
+- [x] Multi-row INSERT
+- [x] Hidden _rowid auto-generation for tables without explicit PK
+- [x] AES-256-GCM-SIV encryption, Argon2 KDF
+- [x] WAL-based crash recovery
+- [x] CLI with REPL
+- [x] DROP TABLE / DROP TABLE IF EXISTS
+- [x] DROP INDEX
+- [x] IF NOT EXISTS for CREATE TABLE / CREATE INDEX
+- [x] SHOW CREATE TABLE
+- [x] DESCRIBE / DESC table
+- [x] LIKE / NOT LIKE (% and _ wildcards)
+- [x] IN (value list)
+- [x] BETWEEN ... AND ...
+- [x] IS NULL / IS NOT NULL
+- [x] NOT operator (general)
+- [x] OFFSET (SELECT ... LIMIT n OFFSET m)
+- [x] DEFAULT column values
+- [x] AUTO_INCREMENT
+- [x] Arithmetic operators in expressions (+, -, *, /, %)
+- [x] BOOLEAN type (alias for TINYINT)
+- [x] CHECK constraint
+
+## Phase 2 — Built-in Functions
+
+MySQL-compatible scalar functions.
+
+- [ ] String: LENGTH, CHAR_LENGTH, CONCAT, SUBSTRING/SUBSTR, UPPER, LOWER
+- [ ] String: TRIM, LTRIM, RTRIM, REPLACE, REVERSE, REPEAT
+- [ ] String: LEFT, RIGHT, LPAD, RPAD, INSTR/LOCATE
+- [ ] String: REGEXP / REGEXP_LIKE
+- [ ] Numeric: ABS, CEIL/CEILING, FLOOR, ROUND, MOD, POWER/POW
+- [ ] NULL handling: COALESCE, IFNULL, NULLIF, IF
+- [ ] Type conversion: CAST(expr AS type)
+- [ ] CASE WHEN ... THEN ... ELSE ... END
+
+## Phase 3 — Aggregation & Grouping
+
+- [ ] COUNT, SUM, AVG, MIN, MAX
+- [ ] COUNT(DISTINCT ...)
+- [ ] GROUP BY
+- [ ] HAVING
+- [ ] SELECT DISTINCT
+
+## Phase 4 — Schema Evolution
+
+- [ ] ALTER TABLE ADD COLUMN
+- [ ] ALTER TABLE DROP COLUMN
+- [ ] ALTER TABLE MODIFY COLUMN / CHANGE COLUMN
+- [ ] RENAME TABLE
+- [ ] Composite PRIMARY KEY
+- [ ] Composite UNIQUE / composite INDEX
+
+## Phase 5 — Advanced Query
+
+- [ ] Subqueries (WHERE col IN (SELECT ...), scalar subquery)
+- [ ] UNION / UNION ALL
+- [ ] EXISTS / NOT EXISTS
+- [ ] INSERT ... ON DUPLICATE KEY UPDATE
+- [ ] REPLACE INTO
+- [ ] EXPLAIN (query plan display)
+- [ ] RIGHT JOIN
+
+## Phase 6 — Types & Storage
+
+- [ ] FLOAT / DOUBLE
+- [ ] DATE, DATETIME, TIMESTAMP
+- [ ] Date/time functions: NOW, CURRENT_TIMESTAMP, DATE_FORMAT, etc.
+- [ ] BLOB
+- [ ] Overflow pages (posting list > 4096B)
+
+## Phase 7 — Performance & Internals
+
+- [ ] Auto-checkpoint (threshold-based WAL)
+- [ ] Composite index range scan
+- [ ] Query optimizer improvements (cost-based)
+- [ ] FTS stop-ngram filtering
+- [ ] fts_snippet acceleration (pos-to-offset map)
+
+## Phase 8 — Security (Future)
+
+- [ ] Key rotation (epoch-based re-encryption)
+- [ ] Collation support (Japanese sort order, etc.)

--- a/docs-site/src/user-guide/cli.md
+++ b/docs-site/src/user-guide/cli.md
@@ -1,0 +1,64 @@
+# CLI Options
+
+## Basic usage
+
+```bash
+murodb <database-file> [options]
+```
+
+## Options
+
+| Option | Description |
+|---|---|
+| `-e <SQL>` | Execute SQL and exit |
+| `--create` | Create a new database |
+| `--password <PW>` | Password (prompts if omitted) |
+| `--recovery-mode <strict\|permissive>` | WAL recovery policy for open |
+| `--inspect-wal <PATH>` | Analyze WAL consistency and exit |
+| `--format <text\|json>` | Output format (mainly for `--inspect-wal`) |
+
+## Examples
+
+```bash
+# Create a new database
+murodb mydb.db --create -e "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)"
+
+# Insert data
+murodb mydb.db -e "INSERT INTO t (id, name) VALUES (1, 'hello')"
+
+# Query
+murodb mydb.db -e "SELECT * FROM t"
+
+# Interactive REPL
+murodb mydb.db
+
+# Open with permissive recovery mode
+murodb mydb.db --recovery-mode permissive
+
+# Inspect WAL consistency
+murodb mydb.db --inspect-wal mydb.wal --recovery-mode permissive
+
+# Inspect as JSON
+murodb mydb.db --inspect-wal mydb.wal --recovery-mode permissive --format json
+```
+
+## `--inspect-wal` exit codes
+
+| Exit Code | Meaning |
+|---|---|
+| `0` | No malformed transactions detected |
+| `10` | Malformed transactions detected (inspection succeeded) |
+| `20` | Fatal error (decrypt/IO/strict failure, etc.) |
+
+## JSON output
+
+When using `--format json`, the output includes stable fields:
+
+- `schema_version` - Schema version for the JSON format
+- `mode` - Recovery mode used
+- `wal_path` - Path to the WAL file
+- `generated_at` - Timestamp of the inspection
+- `status` - `ok`, `warning`, or `fatal`
+- `exit_code` - Exit code
+- `skipped[].code` - Machine-readable classification of skipped transactions
+- `fatal_error` / `fatal_error_code` - Present on fatal failures

--- a/docs-site/src/user-guide/full-text-search.md
+++ b/docs-site/src/user-guide/full-text-search.md
@@ -1,0 +1,68 @@
+# Full-Text Search
+
+MuroDB provides MySQL-compatible full-text search with bigram tokenization.
+
+## Creating a fulltext index
+
+```sql
+CREATE FULLTEXT INDEX t_body_fts ON t(body)
+  WITH PARSER ngram
+  OPTIONS (n=2, normalize='nfkc');
+```
+
+## NATURAL LANGUAGE MODE
+
+BM25-based relevance ranking.
+
+```sql
+SELECT id, MATCH(body) AGAINST('東京タワー' IN NATURAL LANGUAGE MODE) AS score
+FROM t
+WHERE MATCH(body) AGAINST('東京タワー' IN NATURAL LANGUAGE MODE) > 0
+ORDER BY score DESC
+LIMIT 20;
+```
+
+## BOOLEAN MODE
+
+Supports `+term` (required), `-term` (excluded), and `"phrase"` (exact phrase) operators.
+
+```sql
+SELECT id
+FROM t
+WHERE MATCH(body) AGAINST('"東京タワー" +夜景 -混雑' IN BOOLEAN MODE) > 0;
+```
+
+### Boolean operators
+
+| Operator | Meaning | Example |
+|---|---|---|
+| `+term` | Term must be present | `+東京` |
+| `-term` | Term must not be present | `-混雑` |
+| `"phrase"` | Exact phrase match | `"東京タワー"` |
+| `term` | Term is optional (contributes to score) | `夜景` |
+
+## Snippet with highlight
+
+Use `fts_snippet()` to generate highlighted excerpts.
+
+```sql
+SELECT id,
+  fts_snippet(body, '"東京タワー"', '<mark>', '</mark>', 30) AS snippet
+FROM t
+WHERE MATCH(body) AGAINST('"東京タワー"' IN BOOLEAN MODE) > 0
+LIMIT 10;
+```
+
+### fts_snippet() parameters
+
+| Parameter | Description |
+|---|---|
+| column | The column to extract snippet from |
+| query | The search query (same as AGAINST) |
+| open tag | Opening highlight tag (e.g., `<mark>`) |
+| close tag | Closing highlight tag (e.g., `</mark>`) |
+| max length | Maximum snippet length in characters |
+
+## Internal design
+
+See [FTS Internals](../internals/fts-internals.md) for implementation details.

--- a/docs-site/src/user-guide/recovery.md
+++ b/docs-site/src/user-guide/recovery.md
@@ -1,0 +1,84 @@
+# Recovery
+
+MuroDB uses WAL-based crash recovery with two recovery modes.
+
+## Recovery modes
+
+### strict (default)
+
+The default mode. Fails on any WAL protocol violation.
+
+```bash
+murodb mydb.db
+```
+
+Detects and rejects:
+- Records before BEGIN
+- Commit LSN mismatches
+- Duplicate terminal records
+- PagePut integrity mismatches
+
+### permissive
+
+Skips invalid transactions and recovers only valid committed transactions. Useful for salvaging data from corrupted databases.
+
+```bash
+murodb mydb.db --recovery-mode permissive
+```
+
+When transactions are skipped, the original WAL is quarantined to `*.wal.quarantine.*`.
+
+## WAL Inspection
+
+Analyze WAL consistency without modifying the database.
+
+```bash
+# Text output
+murodb mydb.db --inspect-wal mydb.wal --recovery-mode permissive
+
+# JSON output (for automation)
+murodb mydb.db --inspect-wal mydb.wal --recovery-mode permissive --format json
+```
+
+Quarantine files can also be inspected directly:
+
+```bash
+murodb mydb.db --inspect-wal mydb.wal.quarantine.20240101_120000
+```
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | No malformed transactions detected |
+| `10` | Malformed transactions detected (inspection succeeded) |
+| `20` | Fatal error (decrypt/IO/strict failure, etc.) |
+
+## API
+
+```rust
+use murodb::{Database, RecoveryMode};
+
+// strict (default)
+let db = Database::open("mydb.db", &master_key)?;
+
+// permissive
+let db = Database::open_with_recovery_mode(
+    "mydb.db", &master_key, RecoveryMode::Permissive
+)?;
+
+// permissive with report
+let (db, report) = Database::open_with_recovery_mode_and_report(
+    "mydb.db", &master_key, RecoveryMode::Permissive
+)?;
+for skip in &report.skipped {
+    eprintln!("Skipped tx {}: {:?}", skip.txid, skip.reason);
+}
+```
+
+## JSON Schema Versioning Policy
+
+- `schema_version` increments only on breaking changes (key removal, type changes)
+- New keys are added without version bump (consumers should ignore unknown keys)
+- `RecoverySkipCode` string values are frozen (regression-tested)
+- `InspectFatalKind` string values are frozen (regression-tested)

--- a/docs-site/src/user-guide/sql-reference.md
+++ b/docs-site/src/user-guide/sql-reference.md
@@ -1,0 +1,208 @@
+# SQL Reference
+
+## Data Types
+
+| Type | Storage | Range |
+|------|---------|-------|
+| TINYINT | 1 byte | -128 to 127 |
+| SMALLINT | 2 bytes | -32,768 to 32,767 |
+| INT | 4 bytes | -2,147,483,648 to 2,147,483,647 |
+| BIGINT | 8 bytes | -2^63 to 2^63-1 |
+| BOOLEAN | 1 byte | Alias for TINYINT |
+| VARCHAR(n) | variable | max n bytes (optional) |
+| TEXT | variable | unbounded text |
+| VARBINARY(n) | variable | max n bytes (optional) |
+| NULL | 0 bytes | null value |
+
+## DDL (Data Definition Language)
+
+### CREATE TABLE
+
+```sql
+CREATE TABLE t (
+  id BIGINT PRIMARY KEY,
+  body VARCHAR,
+  blob VARBINARY,
+  uniq VARCHAR UNIQUE
+);
+
+-- With additional features
+CREATE TABLE users (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  name VARCHAR NOT NULL,
+  email VARCHAR UNIQUE,
+  age INT DEFAULT 0,
+  active BOOLEAN DEFAULT 1,
+  CONSTRAINT chk_age CHECK (age >= 0)
+);
+
+-- IF NOT EXISTS
+CREATE TABLE IF NOT EXISTS t (id BIGINT PRIMARY KEY);
+```
+
+### CREATE INDEX
+
+```sql
+CREATE UNIQUE INDEX idx_email ON users(email);
+
+-- IF NOT EXISTS
+CREATE INDEX IF NOT EXISTS idx_name ON users(name);
+```
+
+### CREATE FULLTEXT INDEX
+
+```sql
+CREATE FULLTEXT INDEX t_body_fts ON t(body)
+  WITH PARSER ngram
+  OPTIONS (n=2, normalize='nfkc');
+```
+
+### DROP TABLE / DROP INDEX
+
+```sql
+DROP TABLE t;
+DROP TABLE IF EXISTS t;
+DROP INDEX idx_email;
+```
+
+### Schema Inspection
+
+```sql
+SHOW TABLES;
+SHOW CREATE TABLE t;
+DESCRIBE t;
+DESC t;
+```
+
+## DML (Data Manipulation Language)
+
+### INSERT
+
+```sql
+INSERT INTO t (id, name) VALUES (1, 'Alice');
+
+-- Multi-row insert
+INSERT INTO t (id, name) VALUES (1, 'Alice'), (2, 'Bob');
+```
+
+### SELECT
+
+```sql
+SELECT * FROM t WHERE id = 42 ORDER BY id DESC LIMIT 10;
+
+-- With OFFSET
+SELECT * FROM t LIMIT 10 OFFSET 20;
+```
+
+### UPDATE
+
+```sql
+UPDATE t SET name = 'Alicia' WHERE id = 1;
+```
+
+### DELETE
+
+```sql
+DELETE FROM t WHERE id = 1;
+```
+
+## WHERE Clause
+
+### Comparison operators
+
+```sql
+WHERE id = 1
+WHERE id != 1
+WHERE id < 10
+WHERE id > 5
+WHERE id <= 10
+WHERE id >= 5
+```
+
+### Logical operators
+
+```sql
+WHERE id > 1 AND name = 'Alice'
+WHERE id = 1 OR id = 2
+WHERE NOT (id = 1)
+```
+
+### LIKE / NOT LIKE
+
+```sql
+WHERE name LIKE 'Ali%'
+WHERE name LIKE '_ob'
+WHERE name NOT LIKE '%test%'
+```
+
+### IN
+
+```sql
+WHERE id IN (1, 2, 3)
+```
+
+### BETWEEN
+
+```sql
+WHERE id BETWEEN 1 AND 10
+```
+
+### IS NULL / IS NOT NULL
+
+```sql
+WHERE name IS NULL
+WHERE name IS NOT NULL
+```
+
+## ORDER BY / LIMIT
+
+```sql
+SELECT * FROM t ORDER BY id ASC;
+SELECT * FROM t ORDER BY name DESC, id ASC;
+SELECT * FROM t LIMIT 10;
+SELECT * FROM t LIMIT 10 OFFSET 5;
+```
+
+## Expressions
+
+### Arithmetic operators
+
+```sql
+SELECT id, price * quantity AS total FROM orders;
+SELECT id, (a + b) / 2 AS average FROM t;
+-- Supported: +, -, *, /, %
+```
+
+## JOIN
+
+```sql
+-- INNER JOIN
+SELECT * FROM t1 INNER JOIN t2 ON t1.id = t2.t1_id;
+
+-- LEFT JOIN
+SELECT * FROM t1 LEFT JOIN t2 ON t1.id = t2.t1_id;
+
+-- CROSS JOIN
+SELECT * FROM t1 CROSS JOIN t2;
+
+-- Table aliases
+SELECT a.id, b.name FROM t1 AS a JOIN t2 AS b ON a.id = b.t1_id;
+```
+
+## Transactions
+
+```sql
+BEGIN;
+INSERT INTO t (id, name) VALUES (1, 'Alice');
+INSERT INTO t (id, name) VALUES (2, 'Bob');
+COMMIT;
+
+-- Or rollback
+BEGIN;
+INSERT INTO t (id, name) VALUES (3, 'Charlie');
+ROLLBACK;
+```
+
+## Hidden _rowid
+
+Tables without an explicit PRIMARY KEY automatically get a hidden `_rowid` column with auto-generated values.


### PR DESCRIPTION
## Summary

- Set up `docs-site/` with mdBook, reorganizing existing documentation (README.md, docs/crash-resilience.md, docs/format-migration.md) into structured sections
- Sections: Getting Started, User Guide (CLI, SQL Reference, FTS, Recovery), Internals (Architecture, Storage, B-tree, WAL, FTS, Format Migration, Formal Verification), Roadmap
- Add GitHub Actions workflow (`deploy-docs.yml`) for automatic deployment to GitHub Pages on push to `main`

## Test plan

- [x] `mdbook build docs-site` succeeds without errors
- [ ] After merge, enable GitHub Pages in repo Settings > Pages > Source: GitHub Actions
- [ ] Verify site is accessible at https://tokuhirom.github.io/murodb/

🤖 Generated with [Claude Code](https://claude.com/claude-code)