### PR TITLE
Fix mdBook install URL in deploy workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -21,7 +21,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install mdBook
         run: |
-          curl -sSL https://github.com/rust-lang/mdBook/releases/latest/download/mdbook-v0.4.44-x86_64-unknown-linux-gnu.tar.gz | tar -xz
+          tag=$(curl -sSL https://api.github.com/repos/rust-lang/mdBook/releases/latest | jq -r '.tag_name')
+          curl -sSL "https://github.com/rust-lang/mdBook/releases/download/${tag}/mdbook-${tag}-x86_64-unknown-linux-gnu.tar.gz" | tar -xz
           echo "$PWD" >> $GITHUB_PATH
       - name: Build docs
         run: mdbook build docs-site


### PR DESCRIPTION
## Summary

- Fix deploy-docs workflow failure: the hardcoded download URL used `/latest/download/mdbook-v0.4.44-...` which doesn't resolve correctly (GitHub's `/latest/download/` redirect doesn't match versioned filenames)
- Now dynamically resolves the latest tag via GitHub API and constructs the correct download URL

## Test plan

- [ ] Workflow runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)