### PR TITLE
Add CommitInDoubt error variant for post-WAL-sync failures

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -53,6 +53,9 @@ pub enum MuroError {
     #[error("Data corruption: {0}")]
     Corruption(String),
 
+    #[error("Commit in doubt: WAL durable but data flush failed: {0}")]
+    CommitInDoubt(String),
+
     #[error("Internal error: {0}")]
     Internal(String),
 }


### PR DESCRIPTION
## Summary

- Add `MuroError::CommitInDoubt(String)` variant so callers can distinguish a durable-but-unflushed commit from a pre-commit failure
- Wrap post-WAL-sync data flush (write_page, flush_meta) in `Transaction::commit()` to return `CommitInDoubt` instead of raw `Io` errors
- Update failpoint tests to assert the specific `CommitInDoubt` variant

Closes #11

## Test plan

- [x] `cargo test --features test-utils --test post_wal_sync_failpoints` — all 10 tests pass
- [x] `cargo clippy` — clean
- [x] `cargo test` — all 202 unit tests + all integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)