### PR TITLE
Poison session after CommitInDoubt

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -56,6 +56,9 @@ pub enum MuroError {
     #[error("Commit in doubt: WAL durable but data flush failed: {0}")]
     CommitInDoubt(String),
 
+    #[error("Session poisoned: {0}. Database must be reopened to trigger WAL recovery.")]
+    SessionPoisoned(String),
+
     #[error("Internal error: {0}")]
     Internal(String),
 }


### PR DESCRIPTION
## Summary
- Add `SessionPoisoned` error variant that blocks all operations after `CommitInDoubt`
- Session sets `poisoned` flag when `CommitInDoubt` occurs in both explicit commit and auto-commit paths
- All subsequent `execute()` calls fail with `SessionPoisoned`, forcing the user to reopen the DB (which triggers WAL recovery)

Closes #59

## Test plan
- [x] `test_session_poisoned_after_commit_in_doubt` — verifies SELECT/DDL rejected after poisoning
- [x] `test_reopen_after_commit_in_doubt_recovers_data` — verifies Database::open recovers both rows
- [x] `test_explicit_tx_commit_in_doubt_poisons_session` — verifies BEGIN/COMMIT path also poisons
- [x] Full test suite passes (`cargo test --features test-utils`)
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)