### PR TITLE
Add RIGHT JOIN support

### DIFF
--- a/src/sql/ast.rs
+++ b/src/sql/ast.rs
@@ -111,6 +111,7 @@ pub struct Insert {
 pub enum JoinType {
     Inner,
     Left,
+    Right,
     Cross,
 }
 

--- a/src/sql/parser.rs
+++ b/src/sql/parser.rs
@@ -660,6 +660,16 @@ impl Parser {
                     self.expect(&Token::Join)?;
                     Some(JoinType::Left)
                 }
+                Some(Token::Right) => {
+                    self.advance();
+                    // optional OUTER keyword (not a token, but could be an ident)
+                    if matches!(self.peek(), Some(Token::Ident(s)) if s.eq_ignore_ascii_case("OUTER"))
+                    {
+                        self.advance();
+                    }
+                    self.expect(&Token::Join)?;
+                    Some(JoinType::Right)
+                }
                 Some(Token::Cross) => {
                     self.advance();
                     self.expect(&Token::Join)?;


### PR DESCRIPTION
## Summary
- Add `RIGHT [OUTER] JOIN` implementation as a mirror of LEFT JOIN
- Track accumulated left-side table definitions for correct NULL row generation (handles empty left table case)
- Add pre-commit DB/SQL expert review rule to CLAUDE.md

## Test plan
- [x] Basic RIGHT JOIN (matched rows)
- [x] Unmatched right rows get NULL left columns
- [x] Empty left table with RIGHT JOIN
- [x] RIGHT JOIN + WHERE clause
- [x] RIGHT JOIN + aliases
- [x] RIGHT OUTER JOIN syntax
- [x] All 17 join tests pass
- [x] cargo clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)