### PR TITLE
Implement FLOAT/DOUBLE support across SQL engine

### DIFF
--- a/docs-site/src/roadmap.md
+++ b/docs-site/src/roadmap.md
@@ -78,7 +78,7 @@ MySQL-compatible scalar functions.
 
 ## Phase 6 — Types & Storage
 
-- [ ] FLOAT / DOUBLE
+- [x] FLOAT / DOUBLE
 - [ ] DATE, DATETIME, TIMESTAMP
 - [ ] Date/time functions: NOW, CURRENT_TIMESTAMP, DATE_FORMAT, etc.
 - [ ] BLOB

--- a/docs-site/src/user-guide/sql-reference.md
+++ b/docs-site/src/user-guide/sql-reference.md
@@ -518,7 +518,7 @@ SELECT CAST(42 AS VARCHAR);    -- '42'
 SELECT CAST(val AS BIGINT) FROM t;
 ```
 
-Supported target types: TINYINT, SMALLINT, INT, BIGINT, VARCHAR, TEXT, VARBINARY.
+Supported target types: TINYINT, SMALLINT, INT, BIGINT, FLOAT, DOUBLE, VARCHAR, TEXT, VARBINARY.
 
 ## Aggregation & GROUP BY
 
@@ -529,7 +529,7 @@ SELECT COUNT(*) FROM t;              -- count all rows
 SELECT COUNT(col) FROM t;            -- count non-NULL values
 SELECT COUNT(DISTINCT col) FROM t;   -- count distinct non-NULL values
 SELECT SUM(amount) FROM orders;      -- sum (skips NULLs)
-SELECT AVG(amount) FROM orders;      -- average (integer division, skips NULLs)
+SELECT AVG(amount) FROM orders;      -- average (integer for integer inputs, float otherwise)
 SELECT MIN(amount) FROM orders;      -- minimum (skips NULLs)
 SELECT MAX(amount) FROM orders;      -- maximum (skips NULLs)
 ```

--- a/src/bin/murodb.rs
+++ b/src/bin/murodb.rs
@@ -150,6 +150,7 @@ fn format_rows(result: &ExecResult) -> String {
 fn format_value(val: &Value) -> String {
     match val {
         Value::Integer(n) => n.to_string(),
+        Value::Float(n) => n.to_string(),
         Value::Varchar(s) => s.clone(),
         Value::Varbinary(b) => format!("0x{}", hex_encode(b)),
         Value::Null => "NULL".to_string(),

--- a/src/sql/ast.rs
+++ b/src/sql/ast.rs
@@ -185,6 +185,7 @@ pub struct Delete {
 #[derive(Debug, Clone)]
 pub enum Expr {
     IntLiteral(i64),
+    FloatLiteral(f64),
     StringLiteral(String),
     BlobLiteral(Vec<u8>),
     Null,

--- a/src/sql/parser.rs
+++ b/src/sql/parser.rs
@@ -419,6 +419,8 @@ impl Parser {
                 Some(Token::SmallIntType) => Ok(DataType::SmallInt),
                 Some(Token::IntType) => Ok(DataType::Int),
                 Some(Token::BigIntType) => Ok(DataType::BigInt),
+                Some(Token::FloatType) => Ok(DataType::Float),
+                Some(Token::DoubleType) => Ok(DataType::Double),
                 Some(Token::VarcharType) => {
                     let size = self.parse_optional_size()?;
                     Ok(DataType::Varchar(size))
@@ -1368,13 +1370,13 @@ impl Parser {
             self.advance();
             let operand = self.parse_primary()?;
             // Optimize: if it's an integer literal, negate it directly
-            if let Expr::IntLiteral(n) = operand {
-                Ok(Expr::IntLiteral(-n))
-            } else {
-                Ok(Expr::UnaryOp {
+            match operand {
+                Expr::IntLiteral(n) => Ok(Expr::IntLiteral(-n)),
+                Expr::FloatLiteral(n) => Ok(Expr::FloatLiteral(-n)),
+                _ => Ok(Expr::UnaryOp {
                     op: UnaryOp::Neg,
                     operand: Box::new(operand),
-                })
+                }),
             }
         } else {
             self.parse_primary()
@@ -1386,6 +1388,10 @@ impl Parser {
             Some(Token::Integer(n)) => {
                 self.advance();
                 Ok(Expr::IntLiteral(n))
+            }
+            Some(Token::Float(n)) => {
+                self.advance();
+                Ok(Expr::FloatLiteral(n))
             }
             Some(Token::StringLit(s)) => {
                 self.advance();

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,6 +4,7 @@ use std::hash::{Hash, Hasher};
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
     Integer(i64),
+    Float(f64),
     Varchar(String),
     Varbinary(Vec<u8>),
     Null,
@@ -17,6 +18,14 @@ impl Value {
     pub fn as_i64(&self) -> Option<i64> {
         match self {
             Value::Integer(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    pub fn as_f64(&self) -> Option<f64> {
+        match self {
+            Value::Integer(v) => Some(*v as f64),
+            Value::Float(v) => Some(*v),
             _ => None,
         }
     }
@@ -40,6 +49,7 @@ impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Value::Integer(v) => write!(f, "{}", v),
+            Value::Float(v) => write!(f, "{}", v),
             Value::Varchar(v) => write!(f, "{}", v),
             Value::Varbinary(v) => write!(f, "<binary {} bytes>", v.len()),
             Value::Null => write!(f, "NULL"),
@@ -55,6 +65,14 @@ impl PartialEq for ValueKey {
     fn eq(&self, other: &Self) -> bool {
         match (&self.0, &other.0) {
             (Value::Integer(a), Value::Integer(b)) => a == b,
+            (Value::Float(a), Value::Float(b)) => {
+                match (float_to_exact_i64_key(*a), float_to_exact_i64_key(*b)) {
+                    (Some(x), Some(y)) => x == y,
+                    _ => canonical_f64_bits(*a) == canonical_f64_bits(*b),
+                }
+            }
+            (Value::Integer(a), Value::Float(b)) => int_float_equal(*a, *b),
+            (Value::Float(a), Value::Integer(b)) => int_float_equal(*b, *a),
             (Value::Varchar(a), Value::Varchar(b)) => a == b,
             (Value::Varbinary(a), Value::Varbinary(b)) => a == b,
             (Value::Null, Value::Null) => true,
@@ -67,13 +85,102 @@ impl Eq for ValueKey {}
 
 impl Hash for ValueKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        std::mem::discriminant(&self.0).hash(state);
         match &self.0 {
-            Value::Integer(n) => n.hash(state),
-            Value::Varchar(s) => s.hash(state),
-            Value::Varbinary(b) => b.hash(state),
-            Value::Null => {}
+            Value::Integer(n) => {
+                if in_exact_f64_int_range(*n) {
+                    // Numeric-equivalent domain for int/float (e.g. 1 and 1.0).
+                    0u8.hash(state);
+                    n.hash(state);
+                } else {
+                    1u8.hash(state);
+                    n.hash(state);
+                }
+            }
+            Value::Float(n) => {
+                if let Some(i) = float_to_exact_i64_key(*n) {
+                    0u8.hash(state);
+                    i.hash(state);
+                } else {
+                    2u8.hash(state);
+                    canonical_f64_bits(*n).hash(state);
+                }
+            }
+            Value::Varchar(s) => {
+                3u8.hash(state);
+                s.hash(state);
+            }
+            Value::Varbinary(b) => {
+                4u8.hash(state);
+                b.hash(state);
+            }
+            Value::Null => {
+                5u8.hash(state);
+            }
         }
+    }
+}
+
+const MAX_EXACT_F64_INT: i64 = 1_i64 << 53;
+
+fn in_exact_f64_int_range(i: i64) -> bool {
+    (-MAX_EXACT_F64_INT..=MAX_EXACT_F64_INT).contains(&i)
+}
+
+fn canonical_f64_bits(n: f64) -> u64 {
+    if n == 0.0 {
+        0.0f64.to_bits()
+    } else {
+        n.to_bits()
+    }
+}
+
+fn float_to_exact_i64_key(f: f64) -> Option<i64> {
+    if !f.is_finite() {
+        return None;
+    }
+    let f = if f == 0.0 { 0.0 } else { f };
+    if f.fract() != 0.0 {
+        return None;
+    }
+    if !((-MAX_EXACT_F64_INT as f64)..=(MAX_EXACT_F64_INT as f64)).contains(&f) {
+        return None;
+    }
+    Some(f as i64)
+}
+
+fn int_float_equal(i: i64, f: f64) -> bool {
+    in_exact_f64_int_range(i) && float_to_exact_i64_key(f) == Some(i)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Value, ValueKey};
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_value_key_large_int_float_no_non_transitive_equality() {
+        let a = ValueKey(Value::Integer(9_007_199_254_740_992)); // 2^53
+        let b = ValueKey(Value::Float(9_007_199_254_740_992.0));
+        let c = ValueKey(Value::Integer(9_007_199_254_740_993)); // 2^53 + 1
+
+        assert_eq!(a, b);
+        assert_ne!(b, c);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn test_value_key_hash_for_numeric_equivalent_values() {
+        let mut set = HashSet::new();
+        set.insert(ValueKey(Value::Integer(1)));
+        set.insert(ValueKey(Value::Float(1.0)));
+        assert_eq!(set.len(), 1);
+    }
+
+    #[test]
+    fn test_as_i64_is_strict_integer_only() {
+        assert_eq!(Value::Integer(42).as_i64(), Some(42));
+        assert_eq!(Value::Float(42.0).as_i64(), None);
+        assert_eq!(Value::Float(f64::NAN).as_i64(), None);
     }
 }
 
@@ -83,6 +190,8 @@ pub enum DataType {
     SmallInt,
     Int,
     BigInt,
+    Float,
+    Double,
     Varchar(Option<u32>),
     Varbinary(Option<u32>),
     Text,
@@ -95,6 +204,8 @@ impl fmt::Display for DataType {
             DataType::SmallInt => write!(f, "SMALLINT"),
             DataType::Int => write!(f, "INT"),
             DataType::BigInt => write!(f, "BIGINT"),
+            DataType::Float => write!(f, "FLOAT"),
+            DataType::Double => write!(f, "DOUBLE"),
             DataType::Varchar(None) => write!(f, "VARCHAR"),
             DataType::Varchar(Some(n)) => write!(f, "VARCHAR({})", n),
             DataType::Varbinary(None) => write!(f, "VARBINARY"),

--- a/tests/float_double_tests.rs
+++ b/tests/float_double_tests.rs
@@ -1,0 +1,437 @@
+use murodb::crypto::aead::MasterKey;
+use murodb::schema::catalog::SystemCatalog;
+use murodb::sql::executor::{execute, ExecResult};
+use murodb::storage::pager::Pager;
+use murodb::types::Value;
+use tempfile::TempDir;
+
+fn test_key() -> MasterKey {
+    MasterKey::new([0x42u8; 32])
+}
+
+fn setup() -> (Pager, SystemCatalog, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let mut pager = Pager::create(&db_path, &test_key()).unwrap();
+    let catalog = SystemCatalog::create(&mut pager).unwrap();
+    (pager, catalog, dir)
+}
+
+fn assert_float_eq(val: &Value, expected: f64) {
+    match val {
+        Value::Float(n) => assert!((*n - expected).abs() < 1e-6, "expected {expected}, got {n}"),
+        other => panic!("expected float, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_float_double_insert_and_select() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, f FLOAT, d DOUBLE)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    execute(
+        "INSERT INTO t VALUES (1, 1.25, 2.5), (2, 3, 4.75)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    let result = execute("SELECT f, d FROM t WHERE id = 1", &mut pager, &mut catalog).unwrap();
+    let ExecResult::Rows(rows) = result else {
+        panic!("Expected rows");
+    };
+    assert_float_eq(&rows[0].values[0].1, 1.25);
+    assert_float_eq(&rows[0].values[1].1, 2.5);
+}
+
+#[test]
+fn test_float_order_by() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, score DOUBLE)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    execute(
+        "INSERT INTO t VALUES (1, 10.5), (2, 2.25), (3, 7.75)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    let result = execute(
+        "SELECT score FROM t ORDER BY score ASC",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    let ExecResult::Rows(rows) = result else {
+        panic!("Expected rows");
+    };
+
+    assert_float_eq(&rows[0].values[0].1, 2.25);
+    assert_float_eq(&rows[1].values[0].1, 7.75);
+    assert_float_eq(&rows[2].values[0].1, 10.5);
+}
+
+#[test]
+fn test_float_arithmetic_and_cast() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, x DOUBLE)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute("INSERT INTO t VALUES (1, 1.5)", &mut pager, &mut catalog).unwrap();
+
+    let result = execute(
+        "SELECT x + 0.25, CAST('3.75' AS DOUBLE) FROM t",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    let ExecResult::Rows(rows) = result else {
+        panic!("Expected rows");
+    };
+
+    assert_float_eq(&rows[0].values[0].1, 1.75);
+    assert_float_eq(&rows[0].values[1].1, 3.75);
+}
+
+#[test]
+fn test_float_default_value() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, ratio FLOAT DEFAULT 0.5)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute("INSERT INTO t (id) VALUES (1)", &mut pager, &mut catalog).unwrap();
+
+    let result = execute("SELECT ratio FROM t", &mut pager, &mut catalog).unwrap();
+    let ExecResult::Rows(rows) = result else {
+        panic!("Expected rows");
+    };
+
+    assert_float_eq(&rows[0].values[0].1, 0.5);
+}
+
+#[test]
+fn test_avg_large_integer_precision() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, v BIGINT)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute(
+        "INSERT INTO t VALUES (1, 9007199254740992), (2, 9007199254740994)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    let result = execute("SELECT AVG(v) FROM t", &mut pager, &mut catalog).unwrap();
+    let ExecResult::Rows(rows) = result else {
+        panic!("Expected rows");
+    };
+    assert_eq!(rows[0].values[0].1, Value::Integer(9007199254740993));
+}
+
+#[test]
+fn test_signed_zero_pk_lookup_consistency() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE t (id DOUBLE PRIMARY KEY, v BIGINT)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute("INSERT INTO t VALUES (-0.0, 1)", &mut pager, &mut catalog).unwrap();
+
+    let result = execute("SELECT v FROM t WHERE id = 0.0", &mut pager, &mut catalog).unwrap();
+    let ExecResult::Rows(rows) = result else {
+        panic!("Expected rows");
+    };
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].values[0].1, Value::Integer(1));
+}
+
+#[test]
+fn test_integer_pk_seek_with_float_literal() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, v BIGINT)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute("INSERT INTO t VALUES (1, 42)", &mut pager, &mut catalog).unwrap();
+
+    let result = execute("SELECT v FROM t WHERE id = 1.0", &mut pager, &mut catalog).unwrap();
+    let ExecResult::Rows(rows) = result else {
+        panic!("Expected rows");
+    };
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].values[0].1, Value::Integer(42));
+
+    let result = execute("SELECT v FROM t WHERE id = 1.5", &mut pager, &mut catalog).unwrap();
+    let ExecResult::Rows(rows) = result else {
+        panic!("Expected rows");
+    };
+    assert!(rows.is_empty());
+}
+
+#[test]
+fn test_count_distinct_signed_zero() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, x DOUBLE)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute(
+        "INSERT INTO t VALUES (1, -0.0), (2, 0.0)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    let result = execute("SELECT COUNT(DISTINCT x) FROM t", &mut pager, &mut catalog).unwrap();
+    let ExecResult::Rows(rows) = result else {
+        panic!("Expected rows");
+    };
+    assert_eq!(rows[0].values[0].1, Value::Integer(1));
+}
+
+#[test]
+fn test_insert_float_into_bigint_coerces_not_corrupts() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, v BIGINT)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute("INSERT INTO t VALUES (1, 1.5)", &mut pager, &mut catalog).unwrap();
+
+    let result = execute("SELECT v FROM t WHERE id = 1", &mut pager, &mut catalog).unwrap();
+    let ExecResult::Rows(rows) = result else {
+        panic!("Expected rows");
+    };
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].values[0].1, Value::Integer(1));
+}
+
+#[test]
+fn test_count_distinct_mixed_int_float_numeric() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE t (id BIGINT PRIMARY KEY)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute("INSERT INTO t VALUES (1), (2)", &mut pager, &mut catalog).unwrap();
+
+    let result = execute(
+        "SELECT COUNT(DISTINCT CASE WHEN id = 1 THEN 1 ELSE 1.0 END) FROM t",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    let ExecResult::Rows(rows) = result else {
+        panic!("Expected rows");
+    };
+    assert_eq!(rows[0].values[0].1, Value::Integer(1));
+}
+
+#[test]
+fn test_insert_rejects_non_finite_float_to_bigint() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, v BIGINT)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    let result = execute(
+        "INSERT INTO t VALUES (1, CAST('NaN' AS DOUBLE))",
+        &mut pager,
+        &mut catalog,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_update_rejects_non_finite_float_to_bigint() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, v BIGINT)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute("INSERT INTO t VALUES (1, 10)", &mut pager, &mut catalog).unwrap();
+
+    let result = execute(
+        "UPDATE t SET v = CAST('inf' AS DOUBLE) WHERE id = 1",
+        &mut pager,
+        &mut catalog,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_insert_rejects_out_of_range_float_to_bigint() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, v BIGINT)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    let result = execute(
+        "INSERT INTO t VALUES (1, 9223372036854775808.0)",
+        &mut pager,
+        &mut catalog,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_bigint_seek_out_of_range_float_literal_does_not_hit_max() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, v BIGINT)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute(
+        "INSERT INTO t VALUES (9223372036854775807, 1)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    let result = execute(
+        "SELECT v FROM t WHERE id = 9223372036854775808.0",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    let ExecResult::Rows(rows) = result else {
+        panic!("Expected rows");
+    };
+    assert!(rows.is_empty());
+}
+
+#[test]
+fn test_alter_modify_varchar_to_double_rejects_non_finite() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, v VARCHAR)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute("INSERT INTO t VALUES (1, 'NaN')", &mut pager, &mut catalog).unwrap();
+
+    let result = execute(
+        "ALTER TABLE t MODIFY COLUMN v DOUBLE",
+        &mut pager,
+        &mut catalog,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_count_distinct_large_ints_with_float_is_stable() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE t (id BIGINT PRIMARY KEY)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute(
+        "INSERT INTO t VALUES (1), (2), (3)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    let result = execute(
+        "SELECT COUNT(DISTINCT CASE \
+         WHEN id = 1 THEN 9007199254740992 \
+         WHEN id = 2 THEN 9007199254740993 \
+         ELSE 9007199254740992.0 END) FROM t",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    let ExecResult::Rows(rows) = result else {
+        panic!("Expected rows");
+    };
+    assert_eq!(rows[0].values[0].1, Value::Integer(2));
+}
+
+#[test]
+fn test_composite_pk_seek_float_column_with_integer_literal() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE t (a DOUBLE, b BIGINT, v BIGINT, PRIMARY KEY (a, b))",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    execute(
+        "INSERT INTO t VALUES (1.0, 2, 42)",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    let result = execute(
+        "SELECT v FROM t WHERE a = 1 AND b = 2",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    let ExecResult::Rows(rows) = result else {
+        panic!("Expected rows");
+    };
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].values[0].1, Value::Integer(42));
+}


### PR DESCRIPTION
## Summary
- add FLOAT/DOUBLE types to lexer/parser/AST/value/type systems
- implement float-aware eval/cast/arithmetic/comparison paths with correctness fixes for numeric boundaries and mixed-type semantics
- extend storage, schema serialization, key encoding, and executor coercion/validation for FLOAT/DOUBLE
- add comprehensive regression tests for signed zero, distinct/grouping, boundary casts/coercions, and composite/index seek behavior
- update roadmap and SQL reference docs for FLOAT/DOUBLE support

## Validation
- cargo test -q --test float_double_tests
- cargo test -q