### PR TITLE
Add DATE/DATETIME/TIMESTAMP types with strict coercion and timezone-aware TIMESTAMP

### DIFF
--- a/src/bin/murodb.rs
+++ b/src/bin/murodb.rs
@@ -151,6 +151,9 @@ fn format_value(val: &Value) -> String {
     match val {
         Value::Integer(n) => n.to_string(),
         Value::Float(n) => n.to_string(),
+        Value::Date(n) => murodb::types::format_date(*n),
+        Value::DateTime(n) => murodb::types::format_datetime(*n),
+        Value::Timestamp(n) => murodb::types::format_datetime(*n),
         Value::Varchar(s) => s.clone(),
         Value::Varbinary(b) => format!("0x{}", hex_encode(b)),
         Value::Null => "NULL".to_string(),

--- a/src/schema/column.rs
+++ b/src/schema/column.rs
@@ -96,6 +96,9 @@ impl ColumnDef {
             DataType::Text => 7,
             DataType::Float => 8,
             DataType::Double => 9,
+            DataType::Date => 10,
+            DataType::DateTime => 11,
+            DataType::Timestamp => 12,
         });
         // flags
         let mut flags: u8 = 0;
@@ -205,6 +208,9 @@ impl ColumnDef {
             7 => DataType::Text,
             8 => DataType::Float,
             9 => DataType::Double,
+            10 => DataType::Date,
+            11 => DataType::DateTime,
+            12 => DataType::Timestamp,
             _ => return None,
         };
 
@@ -320,6 +326,9 @@ mod tests {
             DataType::BigInt,
             DataType::Float,
             DataType::Double,
+            DataType::Date,
+            DataType::DateTime,
+            DataType::Timestamp,
             DataType::Varchar(None),
             DataType::Varchar(Some(100)),
             DataType::Varbinary(None),

--- a/src/sql/lexer.rs
+++ b/src/sql/lexer.rs
@@ -104,6 +104,9 @@ pub enum Token {
     BigIntType,    // "BIGINT"
     FloatType,     // "FLOAT"
     DoubleType,    // "DOUBLE"
+    DateType,      // "DATE"
+    DateTimeType,  // "DATETIME"
+    TimestampType, // "TIMESTAMP"
     VarcharType,   // "VARCHAR"
     VarbinaryType, // "VARBINARY"
     TextType,      // "TEXT"
@@ -395,6 +398,9 @@ fn lex_keyword_or_ident(input: &str) -> IResult<&str, Token> {
         "BIGINT" => Token::BigIntType,
         "FLOAT" => Token::FloatType,
         "DOUBLE" => Token::DoubleType,
+        "DATE" => Token::DateType,
+        "DATETIME" => Token::DateTimeType,
+        "TIMESTAMP" => Token::TimestampType,
         "VARCHAR" => Token::VarcharType,
         "VARBINARY" => Token::VarbinaryType,
         "TEXT" => Token::TextType,

--- a/src/sql/parser.rs
+++ b/src/sql/parser.rs
@@ -421,6 +421,9 @@ impl Parser {
                 Some(Token::BigIntType) => Ok(DataType::BigInt),
                 Some(Token::FloatType) => Ok(DataType::Float),
                 Some(Token::DoubleType) => Ok(DataType::Double),
+                Some(Token::DateType) => Ok(DataType::Date),
+                Some(Token::DateTimeType) => Ok(DataType::DateTime),
+                Some(Token::TimestampType) => Ok(DataType::Timestamp),
                 Some(Token::VarcharType) => {
                     let size = self.parse_optional_size()?;
                     Ok(DataType::Varchar(size))


### PR DESCRIPTION
## Summary\n- add DATE, DATETIME, TIMESTAMP to SQL type system (lexer/parser/schema/value)\n- implement temporal coercion/cast/validation, serialization/deserialization, and index key encoding\n- add timezone-aware TIMESTAMP parser with UTC normalization\n- tighten coercion semantics and fix temporal behavior in GROUP BY/DISTINCT, subquery materialization, and composite/index seeks\n- add regression tests for parsing safety, temporal equality semantics, and seek/materialization edge cases\n\n## Validation\n- cargo test -q\n