### PR TITLE
Split WAL inspection into dedicated CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ license = "MIT"
 authors = ["Tokuhiro Matsuno"]
 description = "Encrypted embedded SQL database with B-Tree + FTS (Bigram)"
 
+[[bin]]
+name = "murodb-wal-inspect"
+path = "src/bin/murodb_wal_inspect.rs"
+
 [dependencies]
 nom = "7"
 aes-gcm-siv = "0.11"

--- a/HANDSOVER.md
+++ b/HANDSOVER.md
@@ -8,7 +8,7 @@
 ## Current Focus
 - WAL リカバリの堅牢性強化
 - checkpoint 失敗時の耐性と可観測性強化
-- `inspect-wal --format json` の機械可読契約の安定化
+- `murodb-wal-inspect --format json` の機械可読契約の安定化
 
 ## Implementation Plan (Next)
 1. Checkpoint reliability hardening
@@ -40,7 +40,7 @@
 - CI（build/test/clippy/fmt）緑
 - 主要 failure-path がテストで固定されている
 - `docs/crash-resilience.md` が実装と一致
-- `inspect-wal` JSON 契約が機械利用で安定
+- `murodb-wal-inspect` JSON 契約が機械利用で安定
 
 ## Working Agreement
 - 小粒で止めず、関連変更をまとめた中〜大粒コミットを継続

--- a/docs-site/src/SUMMARY.md
+++ b/docs-site/src/SUMMARY.md
@@ -10,6 +10,7 @@
 # User Guide
 
 - [CLI Options](user-guide/cli.md)
+- [WAL Inspection](user-guide/wal-inspect.md)
 - [SQL Reference](user-guide/sql-reference.md)
 - [Full-Text Search](user-guide/full-text-search.md)
 - [Recovery](user-guide/recovery.md)

--- a/docs-site/src/internals/wal.md
+++ b/docs-site/src/internals/wal.md
@@ -85,7 +85,7 @@ See [Recovery](../user-guide/recovery.md) for user-facing documentation.
 
 ### Inspect-WAL JSON Contract
 
-`--inspect-wal --format json` returns machine-readable diagnostics with a stable schema contract:
+`murodb-wal-inspect --format json` returns machine-readable diagnostics with a stable schema contract:
 
 - `schema_version=1` for the current contract
 - `status`: `ok` / `warning` / `fatal`

--- a/docs-site/src/user-guide/cli.md
+++ b/docs-site/src/user-guide/cli.md
@@ -14,8 +14,6 @@ murodb <database-file> [options]
 | `--create` | Create a new database |
 | `--password <PW>` | Password (prompts if omitted) |
 | `--recovery-mode <strict\|permissive>` | WAL recovery policy for open |
-| `--inspect-wal <PATH>` | Analyze WAL consistency and exit |
-| `--format <text\|json>` | Output format (mainly for `--inspect-wal`) |
 
 ## Examples
 
@@ -35,30 +33,14 @@ murodb mydb.db
 # Open with permissive recovery mode
 murodb mydb.db --recovery-mode permissive
 
-# Inspect WAL consistency
-murodb mydb.db --inspect-wal mydb.wal --recovery-mode permissive
-
-# Inspect as JSON
-murodb mydb.db --inspect-wal mydb.wal --recovery-mode permissive --format json
 ```
 
-## `--inspect-wal` exit codes
+## WAL inspection
 
-| Exit Code | Meaning |
-|---|---|
-| `0` | No malformed transactions detected |
-| `10` | Malformed transactions detected (inspection succeeded) |
-| `20` | Fatal error (decrypt/IO/strict failure, etc.) |
+WAL inspection is handled by a dedicated command so the query CLI stays simple:
 
-## JSON output
+```bash
+murodb-wal-inspect mydb.db --wal mydb.wal --recovery-mode permissive
+```
 
-When using `--format json`, the output includes stable fields:
-
-- `schema_version` - Schema version for the JSON format
-- `mode` - Recovery mode used
-- `wal_path` - Path to the WAL file
-- `generated_at` - Timestamp of the inspection
-- `status` - `ok`, `warning`, or `fatal`
-- `exit_code` - Exit code
-- `skipped[].code` - Machine-readable classification of skipped transactions
-- `fatal_error` / `fatal_error_code` - Present on fatal failures
+See [WAL Inspection](wal-inspect.md) for exit codes and JSON schema.

--- a/docs-site/src/user-guide/recovery.md
+++ b/docs-site/src/user-guide/recovery.md
@@ -34,16 +34,16 @@ Analyze WAL consistency without modifying the database.
 
 ```bash
 # Text output
-murodb mydb.db --inspect-wal mydb.wal --recovery-mode permissive
+murodb-wal-inspect mydb.db --wal mydb.wal --recovery-mode permissive
 
 # JSON output (for automation)
-murodb mydb.db --inspect-wal mydb.wal --recovery-mode permissive --format json
+murodb-wal-inspect mydb.db --wal mydb.wal --recovery-mode permissive --format json
 ```
 
 Quarantine files can also be inspected directly:
 
 ```bash
-murodb mydb.db --inspect-wal mydb.wal.quarantine.20240101_120000
+murodb-wal-inspect mydb.db --wal mydb.wal.quarantine.20240101_120000
 ```
 
 ### Exit codes

--- a/docs-site/src/user-guide/runbook.md
+++ b/docs-site/src/user-guide/runbook.md
@@ -20,7 +20,7 @@ ls -lh mydb.wal
 If the database cannot be opened, inspect the WAL without modifying it:
 
 ```bash
-murodb mydb.db --inspect-wal mydb.wal --recovery-mode permissive --format json
+murodb-wal-inspect mydb.db --wal mydb.wal --recovery-mode permissive --format json
 ```
 
 ## Scenario: CommitInDoubt Detected
@@ -74,7 +74,7 @@ murodb mydb.db --inspect-wal mydb.wal --recovery-mode permissive --format json
 
 1. **Inspect first** — do not delete any files:
    ```bash
-   murodb mydb.db --inspect-wal mydb.wal --recovery-mode permissive --format json
+   murodb-wal-inspect mydb.db --wal mydb.wal --recovery-mode permissive --format json
    ```
 2. Review the report. If only incomplete (uncommitted) transactions are malformed, they can be safely skipped.
 3. Open with permissive mode to recover valid data:
@@ -119,6 +119,6 @@ Escalate to the development team if:
 When escalating, include:
 
 1. Full `SHOW DATABASE STATS` output.
-2. WAL inspection JSON output (`--format json`).
+2. WAL inspection JSON output (`murodb-wal-inspect --format json`).
 3. Kernel logs around the time of failure (`dmesg`, `journalctl`).
 4. The quarantined WAL file(s), if any.

--- a/docs-site/src/user-guide/wal-inspect.md
+++ b/docs-site/src/user-guide/wal-inspect.md
@@ -1,0 +1,52 @@
+# WAL Inspection
+
+WAL inspection is a separate command so the main `murodb` CLI stays focused on queries.
+
+## Basic usage
+
+```bash
+murodb-wal-inspect <database-file> --wal <WAL-PATH> [options]
+```
+
+## Options
+
+| Option | Description |
+|---|---|
+| `--wal <PATH>` | WAL file path or quarantine file path |
+| `--password <PW>` | Password (prompts if omitted) |
+| `--recovery-mode <strict\|permissive>` | Recovery policy used during inspection |
+| `--format <text\|json>` | Output format for inspection results |
+
+## Examples
+
+```bash
+# Text output
+murodb-wal-inspect mydb.db --wal mydb.wal --recovery-mode permissive
+
+# JSON output (for automation)
+murodb-wal-inspect mydb.db --wal mydb.wal --recovery-mode permissive --format json
+
+# Inspect a quarantine WAL file
+murodb-wal-inspect mydb.db --wal mydb.wal.quarantine.20240101_120000
+```
+
+## Exit codes
+
+| Exit Code | Meaning |
+|---|---|
+| `0` | No malformed transactions detected |
+| `10` | Malformed transactions detected (inspection succeeded) |
+| `20` | Fatal error (decrypt/IO/strict failure, etc.) |
+
+## JSON output
+
+When using `--format json`, the output includes stable fields:
+
+- `schema_version` - Schema version for the JSON format
+- `mode` - Recovery mode used
+- `wal_path` - Path to the WAL file
+- `generated_at` - Timestamp of the inspection
+- `status` - `ok`, `warning`, or `fatal`
+- `exit_code` - Exit code
+- `skipped[].code` - Machine-readable classification of skipped transactions
+- `fatal_error` / `fatal_error_code` - Present on fatal failures

--- a/src/bin/murodb.rs
+++ b/src/bin/murodb.rs
@@ -1,29 +1,16 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use clap::{Parser, ValueEnum};
-use murodb::crypto::kdf;
 use murodb::sql::executor::ExecResult;
-use murodb::storage::pager::Pager;
 use murodb::types::Value;
-use murodb::wal::recovery::{inspect_wal, RecoveryMode, RecoveryResult};
+use murodb::wal::recovery::RecoveryMode;
 use murodb::Database;
-
-const EXIT_OK: i32 = 0;
-const EXIT_MALFORMED_DETECTED: i32 = 10;
-const EXIT_FATAL_ERROR: i32 = 20;
 
 #[derive(Clone, Debug, ValueEnum)]
 enum RecoveryModeArg {
     Strict,
     Permissive,
-}
-
-#[derive(Clone, Debug, ValueEnum)]
-enum OutputFormatArg {
-    Text,
-    Json,
 }
 
 impl From<RecoveryModeArg> for RecoveryMode {
@@ -56,15 +43,6 @@ struct Cli {
     /// WAL recovery behavior when opening existing DB
     #[arg(long, value_enum, default_value = "strict")]
     recovery_mode: RecoveryModeArg,
-
-    /// Inspect WAL file consistency and exit (no DB replay).
-    /// Accepts a primary WAL path or a quarantine file path (*.wal.quarantine.*).
-    #[arg(long)]
-    inspect_wal: Option<PathBuf>,
-
-    /// Output format for inspection/reporting
-    #[arg(long, value_enum, default_value = "text")]
-    format: OutputFormatArg,
 }
 
 fn get_password(cli_password: &Option<String>) -> String {
@@ -164,331 +142,6 @@ fn hex_encode(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{:02x}", b)).collect()
 }
 
-fn json_escape(s: &str) -> String {
-    let mut out = String::with_capacity(s.len() + 8);
-    for ch in s.chars() {
-        match ch {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            c if c.is_control() => out.push_str(&format!("\\u{:04x}", c as u32)),
-            c => out.push(c),
-        }
-    }
-    out
-}
-
-fn json_mode_str(mode: RecoveryMode) -> &'static str {
-    match mode {
-        RecoveryMode::Strict => "strict",
-        RecoveryMode::Permissive => "permissive",
-    }
-}
-
-fn inspect_success_exit_code(report: &RecoveryResult) -> i32 {
-    if report.skipped.is_empty() {
-        EXIT_OK
-    } else {
-        EXIT_MALFORMED_DETECTED
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-enum InspectFatalKind {
-    MissingDbPath,
-    ReadSalt,
-    DeriveKey,
-    InspectFailed,
-}
-
-impl InspectFatalKind {
-    fn as_str(self) -> &'static str {
-        match self {
-            InspectFatalKind::MissingDbPath => "MISSING_DB_PATH",
-            InspectFatalKind::ReadSalt => "READ_SALT_FAILED",
-            InspectFatalKind::DeriveKey => "DERIVE_KEY_FAILED",
-            InspectFatalKind::InspectFailed => "INSPECT_FAILED",
-        }
-    }
-}
-
-fn emit_inspect_json_success(mode: RecoveryMode, wal_path: &Path, report: &RecoveryResult) {
-    println!("{}", build_inspect_json_success(mode, wal_path, report));
-}
-
-fn build_inspect_json_success(
-    mode: RecoveryMode,
-    wal_path: &Path,
-    report: &RecoveryResult,
-) -> String {
-    let generated_at = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    let committed = report
-        .committed_txids
-        .iter()
-        .map(|txid| txid.to_string())
-        .collect::<Vec<_>>()
-        .join(",");
-    let aborted = report
-        .aborted_txids
-        .iter()
-        .map(|txid| txid.to_string())
-        .collect::<Vec<_>>()
-        .join(",");
-    let skipped = report
-        .skipped
-        .iter()
-        .map(|s| {
-            format!(
-                "{{\"txid\":{},\"code\":\"{}\",\"reason\":\"{}\"}}",
-                s.txid,
-                s.code.as_str(),
-                json_escape(&s.reason)
-            )
-        })
-        .collect::<Vec<_>>()
-        .join(",");
-    let quarantine = report
-        .wal_quarantine_path
-        .as_ref()
-        .map(|p| format!("\"{}\"", json_escape(p)))
-        .unwrap_or_else(|| "null".to_string());
-
-    format!(
-        "{{\"schema_version\":1,\"mode\":\"{}\",\"wal_path\":\"{}\",\"generated_at\":{},\"committed_txids\":[{}],\"aborted_txids\":[{}],\"pages_replayed\":{},\"skipped\":[{}],\"wal_quarantine_path\":{},\"status\":\"{}\",\"fatal_error\":null,\"fatal_error_code\":null,\"exit_code\":{}}}",
-        json_mode_str(mode),
-        json_escape(&wal_path.display().to_string()),
-        generated_at,
-        committed,
-        aborted,
-        report.pages_replayed,
-        skipped,
-        quarantine,
-        if report.skipped.is_empty() {
-            "ok"
-        } else {
-            "warning"
-        },
-        inspect_success_exit_code(report)
-    )
-}
-
-fn emit_inspect_json_fatal(mode: RecoveryMode, wal_path: &Path, kind: InspectFatalKind, msg: &str) {
-    println!("{}", build_inspect_json_fatal(mode, wal_path, kind, msg));
-}
-
-fn build_inspect_json_fatal(
-    mode: RecoveryMode,
-    wal_path: &Path,
-    kind: InspectFatalKind,
-    msg: &str,
-) -> String {
-    let generated_at = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    format!(
-        "{{\"schema_version\":1,\"mode\":\"{}\",\"wal_path\":\"{}\",\"generated_at\":{},\"committed_txids\":[],\"aborted_txids\":[],\"pages_replayed\":0,\"skipped\":[],\"wal_quarantine_path\":null,\"status\":\"fatal\",\"fatal_error\":\"{}\",\"fatal_error_code\":\"{}\",\"exit_code\":{}}}",
-        json_mode_str(mode),
-        json_escape(&wal_path.display().to_string()),
-        generated_at,
-        json_escape(msg),
-        kind.as_str(),
-        EXIT_FATAL_ERROR
-    )
-}
-
-fn inspect_fatal_and_exit(
-    format: &OutputFormatArg,
-    mode: RecoveryMode,
-    wal_path: &Path,
-    kind: InspectFatalKind,
-    msg: &str,
-) -> ! {
-    match format {
-        OutputFormatArg::Text => eprintln!("ERROR: {}", msg),
-        OutputFormatArg::Json => emit_inspect_json_fatal(mode, wal_path, kind, msg),
-    }
-    process::exit(EXIT_FATAL_ERROR);
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use murodb::wal::recovery::{RecoverySkipCode, RecoverySkippedTx};
-
-    #[test]
-    fn inspect_json_success_has_null_fatal_error() {
-        let wal_path = Path::new("/tmp/test.wal");
-        let report = RecoveryResult {
-            committed_txids: vec![1, 2],
-            aborted_txids: vec![3],
-            pages_replayed: 4,
-            skipped: vec![RecoverySkippedTx {
-                txid: 9,
-                code: RecoverySkipCode::CommitWithoutMetaUpdate,
-                reason: "missing meta".to_string(),
-            }],
-            wal_quarantine_path: Some("/tmp/test.wal.quarantine".to_string()),
-        };
-
-        let json = build_inspect_json_success(RecoveryMode::Permissive, wal_path, &report);
-        assert!(json.contains("\"schema_version\":1"));
-        assert!(json.contains("\"mode\":\"permissive\""));
-        assert!(json.contains("\"status\":\"warning\""));
-        assert!(json.contains("\"fatal_error\":null"));
-        assert!(json.contains("\"fatal_error_code\":null"));
-        assert!(json.contains("\"code\":\"COMMIT_WITHOUT_META\""));
-        assert!(json.contains("\"exit_code\":10"));
-    }
-
-    #[test]
-    fn inspect_json_fatal_includes_error_message() {
-        let wal_path = Path::new("/tmp/test.wal");
-        let json = build_inspect_json_fatal(
-            RecoveryMode::Strict,
-            wal_path,
-            InspectFatalKind::InspectFailed,
-            "boom",
-        );
-        assert!(json.contains("\"schema_version\":1"));
-        assert!(json.contains("\"mode\":\"strict\""));
-        assert!(json.contains("\"status\":\"fatal\""));
-        assert!(json.contains("\"fatal_error\":\"boom\""));
-        assert!(json.contains("\"fatal_error_code\":\"INSPECT_FAILED\""));
-        assert!(json.contains("\"exit_code\":20"));
-        assert!(json.contains("\"committed_txids\":[]"));
-        assert!(json.contains("\"skipped\":[]"));
-    }
-
-    #[test]
-    fn inspect_success_exit_code_is_zero_when_no_skipped() {
-        let report = RecoveryResult {
-            committed_txids: vec![1],
-            aborted_txids: vec![],
-            pages_replayed: 1,
-            skipped: vec![],
-            wal_quarantine_path: None,
-        };
-        assert_eq!(inspect_success_exit_code(&report), 0);
-    }
-
-    #[test]
-    fn inspect_fatal_kind_codes_are_stable() {
-        assert_eq!(InspectFatalKind::MissingDbPath.as_str(), "MISSING_DB_PATH");
-        assert_eq!(InspectFatalKind::ReadSalt.as_str(), "READ_SALT_FAILED");
-        assert_eq!(InspectFatalKind::DeriveKey.as_str(), "DERIVE_KEY_FAILED");
-        assert_eq!(InspectFatalKind::InspectFailed.as_str(), "INSPECT_FAILED");
-    }
-
-    #[test]
-    fn recovery_skip_code_strings_are_stable() {
-        assert_eq!(RecoverySkipCode::DuplicateBegin.as_str(), "DUPLICATE_BEGIN");
-        assert_eq!(
-            RecoverySkipCode::BeginAfterTerminal.as_str(),
-            "BEGIN_AFTER_TERMINAL"
-        );
-        assert_eq!(
-            RecoverySkipCode::PagePutBeforeBegin.as_str(),
-            "PAGEPUT_BEFORE_BEGIN"
-        );
-        assert_eq!(
-            RecoverySkipCode::PagePutAfterTerminal.as_str(),
-            "PAGEPUT_AFTER_TERMINAL"
-        );
-        assert_eq!(
-            RecoverySkipCode::MetaUpdateBeforeBegin.as_str(),
-            "METAUPDATE_BEFORE_BEGIN"
-        );
-        assert_eq!(
-            RecoverySkipCode::MetaUpdateAfterTerminal.as_str(),
-            "METAUPDATE_AFTER_TERMINAL"
-        );
-        assert_eq!(
-            RecoverySkipCode::CommitBeforeBegin.as_str(),
-            "COMMIT_BEFORE_BEGIN"
-        );
-        assert_eq!(
-            RecoverySkipCode::DuplicateTerminal.as_str(),
-            "DUPLICATE_TERMINAL"
-        );
-        assert_eq!(
-            RecoverySkipCode::CommitWithoutMetaUpdate.as_str(),
-            "COMMIT_WITHOUT_META"
-        );
-        assert_eq!(
-            RecoverySkipCode::CommitLsnMismatch.as_str(),
-            "COMMIT_LSN_MISMATCH"
-        );
-        assert_eq!(
-            RecoverySkipCode::AbortBeforeBegin.as_str(),
-            "ABORT_BEFORE_BEGIN"
-        );
-    }
-
-    #[test]
-    fn inspect_json_fatal_all_variants_have_required_keys() {
-        let wal_path = Path::new("/tmp/test.wal");
-        let variants = [
-            (InspectFatalKind::MissingDbPath, "missing db_path"),
-            (InspectFatalKind::ReadSalt, "salt read failure"),
-            (InspectFatalKind::DeriveKey, "key derivation failure"),
-            (InspectFatalKind::InspectFailed, "inspection failure"),
-        ];
-
-        for (kind, msg) in &variants {
-            let json = build_inspect_json_fatal(RecoveryMode::Strict, wal_path, *kind, msg);
-            assert!(
-                json.contains("\"schema_version\":1"),
-                "missing schema_version for {:?}",
-                kind
-            );
-            assert!(
-                json.contains("\"status\":\"fatal\""),
-                "missing status for {:?}",
-                kind
-            );
-            assert!(
-                json.contains("\"fatal_error\":"),
-                "missing fatal_error for {:?}",
-                kind
-            );
-            assert!(
-                json.contains(&format!("\"fatal_error_code\":\"{}\"", kind.as_str())),
-                "missing fatal_error_code for {:?}",
-                kind
-            );
-            assert!(
-                json.contains("\"exit_code\":20"),
-                "missing exit_code for {:?}",
-                kind
-            );
-        }
-    }
-
-    #[test]
-    fn inspect_json_success_ok_status_when_no_skipped() {
-        let wal_path = Path::new("/tmp/test.wal");
-        let report = RecoveryResult {
-            committed_txids: vec![1],
-            aborted_txids: vec![],
-            pages_replayed: 1,
-            skipped: vec![],
-            wal_quarantine_path: None,
-        };
-
-        let json = build_inspect_json_success(RecoveryMode::Strict, wal_path, &report);
-        assert!(json.contains("\"status\":\"ok\""));
-        assert!(json.contains("\"exit_code\":0"));
-        assert!(json.contains("\"fatal_error\":null"));
-        assert!(json.contains("\"fatal_error_code\":null"));
-    }
-}
-
 fn execute_sql(db: &mut Database, sql: &str) {
     match db.execute(sql) {
         Ok(result) => println!("{}", format_rows(&result)),
@@ -560,70 +213,9 @@ fn main() {
     let password = get_password(&cli.password);
     let recovery_mode: RecoveryMode = cli.recovery_mode.clone().into();
 
-    if let Some(wal_path) = &cli.inspect_wal {
-        let db_path = cli.db_path.as_ref().unwrap_or_else(|| {
-            inspect_fatal_and_exit(
-                &cli.format,
-                recovery_mode,
-                wal_path,
-                InspectFatalKind::MissingDbPath,
-                "db_path is required with --inspect-wal",
-            );
-        });
-        let salt = Pager::read_salt_from_file(db_path).unwrap_or_else(|e| {
-            inspect_fatal_and_exit(
-                &cli.format,
-                recovery_mode,
-                wal_path,
-                InspectFatalKind::ReadSalt,
-                &format!("Failed to read DB salt: {}", e),
-            );
-        });
-        let key = kdf::derive_key(password.as_bytes(), &salt).unwrap_or_else(|e| {
-            inspect_fatal_and_exit(
-                &cli.format,
-                recovery_mode,
-                wal_path,
-                InspectFatalKind::DeriveKey,
-                &format!("Failed to derive key: {}", e),
-            );
-        });
-        let report = inspect_wal(wal_path, &key, recovery_mode).unwrap_or_else(|e| {
-            inspect_fatal_and_exit(
-                &cli.format,
-                recovery_mode,
-                wal_path,
-                InspectFatalKind::InspectFailed,
-                &format!("WAL inspection failed: {}", e),
-            );
-        });
-
-        match cli.format {
-            OutputFormatArg::Text => {
-                println!("WAL inspection summary:");
-                println!("  committed txs: {}", report.committed_txids.len());
-                println!("  aborted txs: {}", report.aborted_txids.len());
-                println!("  replayable pages: {}", report.pages_replayed);
-                println!("  skipped malformed txs: {}", report.skipped.len());
-                for skipped in &report.skipped {
-                    println!(
-                        "  - txid {} [{}]: {}",
-                        skipped.txid,
-                        skipped.code.as_str(),
-                        skipped.reason
-                    );
-                }
-            }
-            OutputFormatArg::Json => {
-                emit_inspect_json_success(recovery_mode, wal_path, &report);
-            }
-        }
-        process::exit(inspect_success_exit_code(&report));
-    }
-
     let mut db = if cli.create {
         let db_path = cli.db_path.as_ref().unwrap_or_else(|| {
-            eprintln!("ERROR: db_path is required unless --inspect-wal is used");
+            eprintln!("ERROR: db_path is required");
             process::exit(1);
         });
         if db_path.exists() {
@@ -636,7 +228,7 @@ fn main() {
         })
     } else {
         let db_path = cli.db_path.as_ref().unwrap_or_else(|| {
-            eprintln!("ERROR: db_path is required unless --inspect-wal is used");
+            eprintln!("ERROR: db_path is required");
             process::exit(1);
         });
         if !db_path.exists() {

--- a/src/bin/murodb_wal_inspect.rs
+++ b/src/bin/murodb_wal_inspect.rs
@@ -1,0 +1,441 @@
+use std::path::{Path, PathBuf};
+use std::process;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use clap::{Parser, ValueEnum};
+use murodb::crypto::kdf;
+use murodb::storage::pager::Pager;
+use murodb::wal::recovery::{inspect_wal, RecoveryMode, RecoveryResult};
+
+const EXIT_OK: i32 = 0;
+const EXIT_MALFORMED_DETECTED: i32 = 10;
+const EXIT_FATAL_ERROR: i32 = 20;
+
+#[derive(Clone, Debug, ValueEnum)]
+enum RecoveryModeArg {
+    Strict,
+    Permissive,
+}
+
+#[derive(Clone, Debug, ValueEnum)]
+enum OutputFormatArg {
+    Text,
+    Json,
+}
+
+impl From<RecoveryModeArg> for RecoveryMode {
+    fn from(value: RecoveryModeArg) -> Self {
+        match value {
+            RecoveryModeArg::Strict => RecoveryMode::Strict,
+            RecoveryModeArg::Permissive => RecoveryMode::Permissive,
+        }
+    }
+}
+
+#[derive(Parser)]
+#[command(name = "murodb-wal-inspect", about = "Inspect MuroDB WAL consistency")]
+struct Cli {
+    /// Path to the database file
+    db_path: PathBuf,
+
+    /// WAL file path (or quarantine file)
+    #[arg(long, value_name = "PATH")]
+    wal: PathBuf,
+
+    /// Password (if omitted, will prompt)
+    #[arg(long)]
+    password: Option<String>,
+
+    /// WAL recovery behavior used during inspection
+    #[arg(long, value_enum, default_value = "strict")]
+    recovery_mode: RecoveryModeArg,
+
+    /// Output format for inspection/reporting
+    #[arg(long, value_enum, default_value = "text")]
+    format: OutputFormatArg,
+}
+
+fn get_password(cli_password: &Option<String>) -> String {
+    if let Some(pw) = cli_password {
+        return pw.clone();
+    }
+    rpassword::read_password_from_tty(Some("Password: ")).unwrap_or_else(|e| {
+        eprintln!("ERROR: Failed to read password: {}", e);
+        process::exit(1);
+    })
+}
+
+fn json_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 8);
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+fn json_mode_str(mode: RecoveryMode) -> &'static str {
+    match mode {
+        RecoveryMode::Strict => "strict",
+        RecoveryMode::Permissive => "permissive",
+    }
+}
+
+fn inspect_success_exit_code(report: &RecoveryResult) -> i32 {
+    if report.skipped.is_empty() {
+        EXIT_OK
+    } else {
+        EXIT_MALFORMED_DETECTED
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum InspectFatalKind {
+    ReadSalt,
+    DeriveKey,
+    InspectFailed,
+}
+
+impl InspectFatalKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            InspectFatalKind::ReadSalt => "READ_SALT_FAILED",
+            InspectFatalKind::DeriveKey => "DERIVE_KEY_FAILED",
+            InspectFatalKind::InspectFailed => "INSPECT_FAILED",
+        }
+    }
+}
+
+fn emit_inspect_json_success(mode: RecoveryMode, wal_path: &Path, report: &RecoveryResult) {
+    println!("{}", build_inspect_json_success(mode, wal_path, report));
+}
+
+fn build_inspect_json_success(
+    mode: RecoveryMode,
+    wal_path: &Path,
+    report: &RecoveryResult,
+) -> String {
+    let generated_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let committed = report
+        .committed_txids
+        .iter()
+        .map(|txid| txid.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    let aborted = report
+        .aborted_txids
+        .iter()
+        .map(|txid| txid.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    let skipped = report
+        .skipped
+        .iter()
+        .map(|s| {
+            format!(
+                "{{\"txid\":{},\"code\":\"{}\",\"reason\":\"{}\"}}",
+                s.txid,
+                s.code.as_str(),
+                json_escape(&s.reason)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    let quarantine = report
+        .wal_quarantine_path
+        .as_ref()
+        .map(|p| format!("\"{}\"", json_escape(p)))
+        .unwrap_or_else(|| "null".to_string());
+
+    format!(
+        "{{\"schema_version\":1,\"mode\":\"{}\",\"wal_path\":\"{}\",\"generated_at\":{},\"committed_txids\":[{}],\"aborted_txids\":[{}],\"pages_replayed\":{},\"skipped\":[{}],\"wal_quarantine_path\":{},\"status\":\"{}\",\"fatal_error\":null,\"fatal_error_code\":null,\"exit_code\":{}}}",
+        json_mode_str(mode),
+        json_escape(&wal_path.display().to_string()),
+        generated_at,
+        committed,
+        aborted,
+        report.pages_replayed,
+        skipped,
+        quarantine,
+        if report.skipped.is_empty() { "ok" } else { "warning" },
+        inspect_success_exit_code(report)
+    )
+}
+
+fn emit_inspect_json_fatal(mode: RecoveryMode, wal_path: &Path, kind: InspectFatalKind, msg: &str) {
+    println!("{}", build_inspect_json_fatal(mode, wal_path, kind, msg));
+}
+
+fn build_inspect_json_fatal(
+    mode: RecoveryMode,
+    wal_path: &Path,
+    kind: InspectFatalKind,
+    msg: &str,
+) -> String {
+    let generated_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    format!(
+        "{{\"schema_version\":1,\"mode\":\"{}\",\"wal_path\":\"{}\",\"generated_at\":{},\"committed_txids\":[],\"aborted_txids\":[],\"pages_replayed\":0,\"skipped\":[],\"wal_quarantine_path\":null,\"status\":\"fatal\",\"fatal_error\":\"{}\",\"fatal_error_code\":\"{}\",\"exit_code\":{}}}",
+        json_mode_str(mode),
+        json_escape(&wal_path.display().to_string()),
+        generated_at,
+        json_escape(msg),
+        kind.as_str(),
+        EXIT_FATAL_ERROR
+    )
+}
+
+fn inspect_fatal_and_exit(
+    format: &OutputFormatArg,
+    mode: RecoveryMode,
+    wal_path: &Path,
+    kind: InspectFatalKind,
+    msg: &str,
+) -> ! {
+    match format {
+        OutputFormatArg::Text => eprintln!("ERROR: {}", msg),
+        OutputFormatArg::Json => emit_inspect_json_fatal(mode, wal_path, kind, msg),
+    }
+    process::exit(EXIT_FATAL_ERROR);
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    let password = get_password(&cli.password);
+    let recovery_mode: RecoveryMode = cli.recovery_mode.clone().into();
+
+    let salt = Pager::read_salt_from_file(&cli.db_path).unwrap_or_else(|e| {
+        inspect_fatal_and_exit(
+            &cli.format,
+            recovery_mode,
+            &cli.wal,
+            InspectFatalKind::ReadSalt,
+            &format!("Failed to read DB salt: {}", e),
+        );
+    });
+    let key = kdf::derive_key(password.as_bytes(), &salt).unwrap_or_else(|e| {
+        inspect_fatal_and_exit(
+            &cli.format,
+            recovery_mode,
+            &cli.wal,
+            InspectFatalKind::DeriveKey,
+            &format!("Failed to derive key: {}", e),
+        );
+    });
+    let report = inspect_wal(&cli.wal, &key, recovery_mode).unwrap_or_else(|e| {
+        inspect_fatal_and_exit(
+            &cli.format,
+            recovery_mode,
+            &cli.wal,
+            InspectFatalKind::InspectFailed,
+            &format!("WAL inspection failed: {}", e),
+        );
+    });
+
+    match cli.format {
+        OutputFormatArg::Text => {
+            println!("WAL inspection summary:");
+            println!("  committed txs: {}", report.committed_txids.len());
+            println!("  aborted txs: {}", report.aborted_txids.len());
+            println!("  replayable pages: {}", report.pages_replayed);
+            println!("  skipped malformed txs: {}", report.skipped.len());
+            for skipped in &report.skipped {
+                println!(
+                    "  - txid {} [{}]: {}",
+                    skipped.txid,
+                    skipped.code.as_str(),
+                    skipped.reason
+                );
+            }
+        }
+        OutputFormatArg::Json => {
+            emit_inspect_json_success(recovery_mode, &cli.wal, &report);
+        }
+    }
+
+    process::exit(inspect_success_exit_code(&report));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use murodb::wal::recovery::{RecoverySkipCode, RecoverySkippedTx};
+
+    #[test]
+    fn inspect_json_success_has_null_fatal_error() {
+        let wal_path = Path::new("/tmp/test.wal");
+        let report = RecoveryResult {
+            committed_txids: vec![1, 2],
+            aborted_txids: vec![3],
+            pages_replayed: 4,
+            skipped: vec![RecoverySkippedTx {
+                txid: 9,
+                code: RecoverySkipCode::CommitWithoutMetaUpdate,
+                reason: "missing meta".to_string(),
+            }],
+            wal_quarantine_path: Some("/tmp/test.wal.quarantine".to_string()),
+        };
+
+        let json = build_inspect_json_success(RecoveryMode::Permissive, wal_path, &report);
+        assert!(json.contains("\"schema_version\":1"));
+        assert!(json.contains("\"mode\":\"permissive\""));
+        assert!(json.contains("\"status\":\"warning\""));
+        assert!(json.contains("\"fatal_error\":null"));
+        assert!(json.contains("\"fatal_error_code\":null"));
+        assert!(json.contains("\"code\":\"COMMIT_WITHOUT_META\""));
+        assert!(json.contains("\"exit_code\":10"));
+    }
+
+    #[test]
+    fn inspect_json_fatal_includes_error_message() {
+        let wal_path = Path::new("/tmp/test.wal");
+        let json = build_inspect_json_fatal(
+            RecoveryMode::Strict,
+            wal_path,
+            InspectFatalKind::InspectFailed,
+            "boom",
+        );
+        assert!(json.contains("\"schema_version\":1"));
+        assert!(json.contains("\"mode\":\"strict\""));
+        assert!(json.contains("\"status\":\"fatal\""));
+        assert!(json.contains("\"fatal_error\":\"boom\""));
+        assert!(json.contains("\"fatal_error_code\":\"INSPECT_FAILED\""));
+        assert!(json.contains("\"exit_code\":20"));
+        assert!(json.contains("\"committed_txids\":[]"));
+        assert!(json.contains("\"skipped\":[]"));
+    }
+
+    #[test]
+    fn inspect_success_exit_code_is_zero_when_no_skipped() {
+        let report = RecoveryResult {
+            committed_txids: vec![1],
+            aborted_txids: vec![],
+            pages_replayed: 1,
+            skipped: vec![],
+            wal_quarantine_path: None,
+        };
+        assert_eq!(inspect_success_exit_code(&report), 0);
+    }
+
+    #[test]
+    fn inspect_fatal_kind_codes_are_stable() {
+        assert_eq!(InspectFatalKind::ReadSalt.as_str(), "READ_SALT_FAILED");
+        assert_eq!(InspectFatalKind::DeriveKey.as_str(), "DERIVE_KEY_FAILED");
+        assert_eq!(InspectFatalKind::InspectFailed.as_str(), "INSPECT_FAILED");
+    }
+
+    #[test]
+    fn recovery_skip_code_strings_are_stable() {
+        assert_eq!(RecoverySkipCode::DuplicateBegin.as_str(), "DUPLICATE_BEGIN");
+        assert_eq!(
+            RecoverySkipCode::BeginAfterTerminal.as_str(),
+            "BEGIN_AFTER_TERMINAL"
+        );
+        assert_eq!(
+            RecoverySkipCode::PagePutBeforeBegin.as_str(),
+            "PAGEPUT_BEFORE_BEGIN"
+        );
+        assert_eq!(
+            RecoverySkipCode::PagePutAfterTerminal.as_str(),
+            "PAGEPUT_AFTER_TERMINAL"
+        );
+        assert_eq!(
+            RecoverySkipCode::MetaUpdateBeforeBegin.as_str(),
+            "METAUPDATE_BEFORE_BEGIN"
+        );
+        assert_eq!(
+            RecoverySkipCode::MetaUpdateAfterTerminal.as_str(),
+            "METAUPDATE_AFTER_TERMINAL"
+        );
+        assert_eq!(
+            RecoverySkipCode::CommitBeforeBegin.as_str(),
+            "COMMIT_BEFORE_BEGIN"
+        );
+        assert_eq!(
+            RecoverySkipCode::DuplicateTerminal.as_str(),
+            "DUPLICATE_TERMINAL"
+        );
+        assert_eq!(
+            RecoverySkipCode::CommitWithoutMetaUpdate.as_str(),
+            "COMMIT_WITHOUT_META"
+        );
+        assert_eq!(
+            RecoverySkipCode::CommitLsnMismatch.as_str(),
+            "COMMIT_LSN_MISMATCH"
+        );
+        assert_eq!(
+            RecoverySkipCode::AbortBeforeBegin.as_str(),
+            "ABORT_BEFORE_BEGIN"
+        );
+    }
+
+    #[test]
+    fn inspect_json_fatal_all_variants_have_required_keys() {
+        let wal_path = Path::new("/tmp/test.wal");
+        let variants = [
+            (InspectFatalKind::ReadSalt, "salt read failure"),
+            (InspectFatalKind::DeriveKey, "key derivation failure"),
+            (InspectFatalKind::InspectFailed, "inspection failure"),
+        ];
+
+        for (kind, msg) in &variants {
+            let json = build_inspect_json_fatal(RecoveryMode::Strict, wal_path, *kind, msg);
+            assert!(
+                json.contains("\"schema_version\":1"),
+                "missing schema_version for {:?}",
+                kind
+            );
+            assert!(
+                json.contains("\"status\":\"fatal\""),
+                "missing status for {:?}",
+                kind
+            );
+            assert!(
+                json.contains("\"fatal_error\":"),
+                "missing fatal_error for {:?}",
+                kind
+            );
+            assert!(
+                json.contains(&format!("\"fatal_error_code\":\"{}\"", kind.as_str())),
+                "missing fatal_error_code for {:?}",
+                kind
+            );
+            assert!(
+                json.contains("\"exit_code\":20"),
+                "missing exit_code for {:?}",
+                kind
+            );
+        }
+    }
+
+    #[test]
+    fn inspect_json_success_ok_status_when_no_skipped() {
+        let wal_path = Path::new("/tmp/test.wal");
+        let report = RecoveryResult {
+            committed_txids: vec![1],
+            aborted_txids: vec![],
+            pages_replayed: 1,
+            skipped: vec![],
+            wal_quarantine_path: None,
+        };
+
+        let json = build_inspect_json_success(RecoveryMode::Strict, wal_path, &report);
+        assert!(json.contains("\"status\":\"ok\""));
+        assert!(json.contains("\"exit_code\":0"));
+        assert!(json.contains("\"fatal_error\":null"));
+        assert!(json.contains("\"fatal_error_code\":null"));
+    }
+}


### PR DESCRIPTION
## Summary
- move WAL inspection into new `murodb-wal-inspect` binary and remove inspect flags from `murodb`
- add new WAL inspection doc page and update references
- keep recovery-mode behavior unchanged for main CLI

## Testing
- `cargo clippy`
- `cargo fmt`