### PR TITLE
docs: clarify B+Tree terminology

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 authors = ["Tokuhiro Matsuno"]
-description = "Encrypted embedded SQL database with B-Tree + FTS (Bigram)"
+description = "Encrypted embedded SQL database with B+Tree (no leaf links) + FTS (Bigram)"
 
 [[bin]]
 name = "murodb-wal-inspect"

--- a/docs-site/src/introduction.md
+++ b/docs-site/src/introduction.md
@@ -1,11 +1,11 @@
 # MuroDB
 
-Encrypted embedded SQL database with B-Tree + Full-Text Search (Bigram), written in Rust.
+Encrypted embedded SQL database with B+Tree (no leaf links) + Full-Text Search (Bigram), written in Rust.
 
 ## Features
 
 - **Transparent encryption** - AES-256-GCM-SIV (nonce-misuse resistant) for all pages and WAL
-- **B-tree storage** - PRIMARY KEY (TINYINT/SMALLINT/INT/BIGINT), UNIQUE indexes (single column)
+- **B+tree storage (no leaf links)** - PRIMARY KEY (TINYINT/SMALLINT/INT/BIGINT), UNIQUE indexes (single column)
 - **Full-text search** - Bigram (n=2) with NFKC normalization
   - MySQL-style `MATCH(col) AGAINST(...)` syntax
   - NATURAL LANGUAGE MODE with BM25 scoring

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! MuroDB: Encrypted Embedded SQL Database with B-Tree + FTS (Bigram)
+//! MuroDB: Encrypted Embedded SQL Database with B+Tree (no leaf links) + FTS (Bigram)
 //!
 //! A single-file encrypted database with:
 //! - AES-256-GCM-SIV transparent encryption


### PR DESCRIPTION
## Summary
- clarify B+Tree terminology in docs and crate metadata

## Testing
- clippy
- fmt