### PR TITLE
Implement shared-lock read path and CLI query routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Main entry points:
 - `docs-site/src/user-guide/recovery.md`
 - `docs-site/src/internals/architecture.md`
 
+## API Notes
+
+- `Database::execute(sql)` is the general SQL entrypoint (read/write, exclusive lock).
+- `Database::query(sql)` is read-only (shared lock, rejects write SQL).
+- CLI auto-routes read-only SQL to the read path; inside explicit transactions it always uses execute semantics.
+
 ## Repository Layout
 
 - `src/` - database implementation

--- a/docs-site/src/internals/architecture.md
+++ b/docs-site/src/internals/architecture.md
@@ -41,3 +41,7 @@ Additional modules:
 
 - **Thread-level**: `parking_lot::RwLock` - multiple readers, single writer
 - **Process-level**: `fs4` file lock - prevents concurrent access from multiple processes
+- **API routing**:
+  - `Database::query` acquires a shared lock for read-only statements.
+  - `Database::execute` acquires an exclusive lock for general SQL execution.
+  - CLI routes read-only statements to `query` unless an explicit transaction is active.

--- a/docs-site/src/internals/wal.md
+++ b/docs-site/src/internals/wal.md
@@ -16,6 +16,17 @@ All WAL records are encrypted.
 
 ## Write Path
 
+### Read-Only Query Path (`Database::query`)
+
+```
+Database::query(sql)
+  1. Acquire shared lock
+  2. Parse and validate statement is read-only
+  3. Execute directly on pager/catalog (no implicit tx, no WAL append)
+```
+
+If an explicit transaction is active, read statements are executed in the transaction context (`execute_in_tx`) so uncommitted writes remain visible to that session.
+
 ### Auto-Commit Mode (no explicit BEGIN)
 
 ```

--- a/docs-site/src/roadmap.md
+++ b/docs-site/src/roadmap.md
@@ -75,6 +75,7 @@ MySQL-compatible scalar functions.
 - [x] REPLACE INTO
 - [x] EXPLAIN (query plan display)
 - [x] RIGHT JOIN
+- [x] Shared-lock read path (`Database::query`) with CLI auto routing
 
 ## Phase 6 — Types & Storage
 

--- a/docs-site/src/user-guide/cli.md
+++ b/docs-site/src/user-guide/cli.md
@@ -39,6 +39,14 @@ murodb mydb.db --format json -e "SELECT * FROM t"
 
 ```
 
+## Query routing behavior
+
+The CLI parses each statement and routes execution automatically:
+
+- Read-only statements (`SELECT`, `UNION`, `EXPLAIN SELECT`, `SHOW ...`, `DESCRIBE`) use the read path.
+- Write and transaction-control statements (`INSERT`, `UPDATE`, `DELETE`, DDL, `BEGIN`/`COMMIT`/`ROLLBACK`) use the write path.
+- While an explicit transaction is active (`BEGIN` ... `COMMIT`/`ROLLBACK`), all statements (including `SELECT`) run with execute semantics.
+
 ## JSON output
 
 When using `--format json`, results are emitted as a single JSON object per statement.

--- a/docs-site/src/user-guide/sql-reference.md
+++ b/docs-site/src/user-guide/sql-reference.md
@@ -690,6 +690,10 @@ INSERT INTO t (id, name) VALUES (3, 'Charlie');
 ROLLBACK;
 ```
 
+Rust API note:
+- `Database::query()` accepts read-only SQL only.
+- Inside an explicit transaction (`BEGIN` ... `COMMIT`/`ROLLBACK`), run statements through `Database::execute()`, including `SELECT`.
+
 ## Hidden _rowid
 
 Tables without an explicit PRIMARY KEY automatically get a hidden `_rowid` column with auto-generated values.


### PR DESCRIPTION
## Summary
- make `Database::query` use shared lock and enforce read-only SQL
- add `Session::execute_read_only_query` to avoid WAL append for non-transactional reads
- route CLI statements automatically to `query`/`execute` and keep `execute` for all statements inside explicit transactions
- update README and docs-site pages to describe new routing and lock behavior

## Testing
- cargo fmt
- cargo test -q --lib
- cargo test -q --bin murodb
- cargo test -q --lib test_read_only_query_select_does_not_create_wal_records
- cargo test -q --lib test_read_only_query_rejects_writes
- cargo test -q --lib test_read_only_query_in_explicit_tx_reads_uncommitted_state
- cargo test -q --bin murodb choose_route_select_outside_tx_uses_query
- cargo test -q --bin murodb choose_route_select_inside_tx_uses_execute
- cargo test -q --bin murodb choose_route_insert_uses_execute