### PR TITLE
Rework checkpoint/truncate policy with threshold-based auto-checkpoint

### DIFF
--- a/docs-site/src/internals/wal.md
+++ b/docs-site/src/internals/wal.md
@@ -137,7 +137,13 @@ All index updates happen within the same transaction as the data update:
 
 ### WAL file size
 
-After successful commits and explicit `ROLLBACK`, the Session auto-checkpoints the WAL (truncates to empty). Checkpoint is best-effort and does not affect commit success.
+After successful commits and explicit `ROLLBACK`, the Session auto-checkpoints the WAL according to policy. Checkpoint is best-effort and does not affect commit success.
+
+Default policy is per-transaction (`MURODB_CHECKPOINT_TX_THRESHOLD=1`), and can be tuned with:
+
+- `MURODB_CHECKPOINT_TX_THRESHOLD`
+- `MURODB_CHECKPOINT_WAL_BYTES_THRESHOLD`
+- `MURODB_CHECKPOINT_INTERVAL_MS`
 
 When checkpoint truncate fails, MuroDB emits a warning with `wal_path` and `wal_size_bytes` so operators can detect and triage WAL growth.
 

--- a/docs-site/src/roadmap.md
+++ b/docs-site/src/roadmap.md
@@ -87,7 +87,7 @@ MySQL-compatible scalar functions.
 
 ## Phase 7 — Performance & Internals
 
-- [ ] Auto-checkpoint (threshold-based WAL)
+- [x] Auto-checkpoint (threshold-based WAL)
 - [ ] Composite index range scan
 - [ ] Query optimizer improvements (cost-based)
 - [ ] FTS stop-ngram filtering

--- a/docs-site/src/user-guide/alerting.md
+++ b/docs-site/src/user-guide/alerting.md
@@ -48,6 +48,25 @@ IF failed_checkpoints > 0 THEN ALERT
   message: "Checkpoint failures detected. WAL may be growing. Monitor WAL file size on disk."
 ```
 
+### deferred_checkpoints / checkpoint_pending_ops
+
+`deferred_checkpoints` is the number of transactions where checkpoint was intentionally skipped by policy.
+`checkpoint_pending_ops` is the current backlog since the last successful checkpoint.
+
+High `deferred_checkpoints` is expected with batch policies. Alert only when `checkpoint_pending_ops` keeps growing together with WAL size.
+
+### checkpoint_policy_*
+
+The active checkpoint policy is surfaced as:
+- `checkpoint_policy_tx_threshold`
+- `checkpoint_policy_wal_bytes_threshold`
+- `checkpoint_policy_interval_ms`
+
+Policy is configured via environment variables:
+- `MURODB_CHECKPOINT_TX_THRESHOLD` (default `1`, `0` disables tx-count trigger)
+- `MURODB_CHECKPOINT_WAL_BYTES_THRESHOLD` (default `0`, disabled)
+- `MURODB_CHECKPOINT_INTERVAL_MS` (default `0`, disabled)
+
 ### freelist_sanitize_count
 
 **Alert threshold**: `> 0` (informational)

--- a/docs-site/src/user-guide/sql-reference.md
+++ b/docs-site/src/user-guide/sql-reference.md
@@ -147,6 +147,13 @@ Both commands return two columns: `stat` and `value`.
 - `pager_cache_misses`
 - `pager_cache_hit_rate_pct`
 
+It also exposes checkpoint policy/runtime fields:
+- `deferred_checkpoints`
+- `checkpoint_pending_ops`
+- `checkpoint_policy_tx_threshold`
+- `checkpoint_policy_wal_bytes_threshold`
+- `checkpoint_policy_interval_ms`
+
 ## DML (Data Manipulation Language)
 
 ### INSERT


### PR DESCRIPTION
## Summary
- add threshold-based auto-checkpoint policy in `Session` instead of forcing truncate on every commit/rollback
- keep default behavior backward-compatible (`MURODB_CHECKPOINT_TX_THRESHOLD=1`)
- add optional triggers:
  - `MURODB_CHECKPOINT_TX_THRESHOLD` (`0` disables tx-count trigger)
  - `MURODB_CHECKPOINT_WAL_BYTES_THRESHOLD`
  - `MURODB_CHECKPOINT_INTERVAL_MS`
- add observability fields to `SHOW DATABASE STATS`:
  - `deferred_checkpoints`
  - `checkpoint_pending_ops`
  - `checkpoint_policy_tx_threshold`
  - `checkpoint_policy_wal_bytes_threshold`
  - `checkpoint_policy_interval_ms`
- update docs (`sql-reference`, `alerting`, `internals/wal`, `roadmap`)

## Correctness
- commit durability boundary is unchanged (WAL `sync` point)
- this change only defers WAL truncate timing; recovery correctness remains on WAL replay path

## Tests
- `cargo test sql::session::tests:: -- --nocapture`
- includes new tests for defer-by-tx-threshold and trigger-by-wal-size-threshold

## Benchmark (update/insert-heavy)
Command (both runs):
`cargo run --quiet --bin murodb_bench -- --initial-rows 5000 --select-ops 500 --update-ops 6000 --insert-ops 6000 --scan-ops 200 --mixed-ops 1000 --warmup-ops 100 --batch-size 500`

Baseline (default policy):
- `point_update_pk`: **226.60 ops/s**
- `insert_autocommit`: **155.27 ops/s**

With `MURODB_CHECKPOINT_TX_THRESHOLD=64`:
- `point_update_pk`: **269.45 ops/s** (**+18.9%**)
- `insert_autocommit`: **164.92 ops/s** (**+6.2%**)

Closes #98