### PR TITLE
docs: add checkpoint policy tuning guide

### DIFF
--- a/docs-site/src/SUMMARY.md
+++ b/docs-site/src/SUMMARY.md
@@ -15,6 +15,7 @@
 - [Benchmarks](user-guide/benchmarks.md)
 - [Full-Text Search](user-guide/full-text-search.md)
 - [Recovery](user-guide/recovery.md)
+- [Checkpoint Policy Tuning](user-guide/checkpoint-policy.md)
 - [Alerting & Monitoring](user-guide/alerting.md)
 - [Incident Response Runbook](user-guide/runbook.md)
 

--- a/docs-site/src/user-guide/alerting.md
+++ b/docs-site/src/user-guide/alerting.md
@@ -67,6 +67,8 @@ Policy is configured via environment variables:
 - `MURODB_CHECKPOINT_WAL_BYTES_THRESHOLD` (default `0`, disabled)
 - `MURODB_CHECKPOINT_INTERVAL_MS` (default `0`, disabled)
 
+See [Checkpoint Policy Tuning](checkpoint-policy.md) for recommended starting values and rollout procedure.
+
 ### freelist_sanitize_count
 
 **Alert threshold**: `> 0` (informational)

--- a/docs-site/src/user-guide/checkpoint-policy.md
+++ b/docs-site/src/user-guide/checkpoint-policy.md
@@ -1,0 +1,89 @@
+# Checkpoint Policy Tuning
+
+MuroDB can defer WAL truncate (checkpoint) using policy thresholds.
+This helps reduce commit-time overhead on write-heavy workloads.
+
+## Configuration Knobs
+
+Set these environment variables before starting your process:
+
+- `MURODB_CHECKPOINT_TX_THRESHOLD`
+- `MURODB_CHECKPOINT_WAL_BYTES_THRESHOLD`
+- `MURODB_CHECKPOINT_INTERVAL_MS`
+
+Semantics:
+
+- Checkpoint runs when **any** enabled trigger fires.
+- `MURODB_CHECKPOINT_TX_THRESHOLD=1` (default): checkpoint every commit/rollback.
+- `MURODB_CHECKPOINT_TX_THRESHOLD=0`: disable tx-count trigger.
+- `*_WAL_BYTES_THRESHOLD=0` / `*_INTERVAL_MS=0`: disabled.
+
+## Recommended Starting Profiles
+
+### Low-latency / conservative
+
+```bash
+MURODB_CHECKPOINT_TX_THRESHOLD=8
+MURODB_CHECKPOINT_WAL_BYTES_THRESHOLD=1048576
+MURODB_CHECKPOINT_INTERVAL_MS=1000
+```
+
+Use this when you want modest commit-speed gains with tight WAL growth control.
+
+### Write-throughput focused
+
+```bash
+MURODB_CHECKPOINT_TX_THRESHOLD=64
+MURODB_CHECKPOINT_WAL_BYTES_THRESHOLD=8388608
+MURODB_CHECKPOINT_INTERVAL_MS=5000
+```
+
+Use this for update/insert-heavy workloads where throughput is prioritized over immediate WAL truncation.
+
+### Time-driven only
+
+```bash
+MURODB_CHECKPOINT_TX_THRESHOLD=0
+MURODB_CHECKPOINT_WAL_BYTES_THRESHOLD=0
+MURODB_CHECKPOINT_INTERVAL_MS=1000
+```
+
+Useful when transaction size/shape is bursty and you want predictable checkpoint cadence.
+
+## Tuning Procedure
+
+1. Start from the conservative profile.
+2. Run workload benchmark and record throughput/latency.
+3. Increase `MURODB_CHECKPOINT_TX_THRESHOLD` stepwise (for example: `8 -> 16 -> 32 -> 64`).
+4. Keep safety bounds with either `MURODB_CHECKPOINT_WAL_BYTES_THRESHOLD` or `MURODB_CHECKPOINT_INTERVAL_MS`.
+5. Stop increasing when throughput gain flattens or WAL/recovery cost becomes unacceptable.
+
+## What to Monitor
+
+Use:
+
+```sql
+SHOW DATABASE STATS;
+```
+
+Track at least:
+
+- `failed_checkpoints`
+- `deferred_checkpoints`
+- `checkpoint_pending_ops`
+- `checkpoint_policy_tx_threshold`
+- `checkpoint_policy_wal_bytes_threshold`
+- `checkpoint_policy_interval_ms`
+
+And from filesystem:
+
+```bash
+ls -lh mydb.wal
+```
+
+## Guardrails
+
+- `failed_checkpoints > 0` means truncate is failing; investigate disk I/O.
+- `checkpoint_pending_ops` growing continuously with WAL size means policy is too loose for current workload.
+- Larger deferred windows can increase restart recovery time because WAL replay work increases.
+- Durability boundary is unchanged: commit durability still depends on WAL `sync`.


### PR DESCRIPTION
## Summary
- add a dedicated checkpoint policy tuning guide (`user-guide/checkpoint-policy.md`)
- link the new guide from `SUMMARY.md`
- add cross-link from `alerting.md` to the tuning guide

## Why
- provide concrete starting profiles and guardrails for rollout
- document how to tune tx/wal/time triggers while monitoring WAL growth and recovery impact

## Included guidance
- recommended profiles (low-latency, throughput-focused, time-driven)
- stepwise tuning procedure
- key metrics and filesystem checks
- operational guardrails