### PR TITLE
Add FTS workloads to benchmark runner

### DIFF
--- a/docs-site/src/user-guide/benchmarks.md
+++ b/docs-site/src/user-guide/benchmarks.md
@@ -14,15 +14,22 @@ Workloads:
 - `insert_autocommit`: single-row insert per transaction (auto-commit)
 - `range_scan_limit_100`: range read (`WHERE id >= ? ORDER BY id LIMIT 100`)
 - `mixed_80r_15u_5i`: mixed OLTP-like workload (80% read / 15% update / 5% insert)
+- `fts_select_natural`: fulltext natural-language search (`MATCH(body) AGAINST(... IN NATURAL LANGUAGE MODE)`)
+- `fts_update_point`: point update on FTS-indexed `TEXT` column
+- `fts_mixed_70q_30u`: FTS-focused mixed workload (70% search / 30% update)
 
 Default dataset/config:
 
 - initial rows: `20,000`
+- fts initial rows: `256`
 - select ops: `20,000`
 - update ops: `5,000`
 - insert ops: `5,000`
 - scan ops: `2,000`
 - mixed ops: `10,000`
+- fts select ops: `5,000`
+- fts update ops: `2,000`
+- fts mixed ops: `5,000`
 - warmup ops: `200`
 - batch size (initial load): `500`
 
@@ -31,6 +38,9 @@ Run command:
 ```bash
 cargo run --release --bin murodb_bench
 ```
+
+> Migration note: as of 2026-02-22, benchmark scope includes additional FTS workloads.
+> Older entries without FTS metrics are not directly comparable on total runtime.
 
 ## Versioned Results
 


### PR DESCRIPTION
## Summary
- extend `murodb_bench` with FTS benchmark cases
- add FTS dataset setup (`docs_fts` table + FULLTEXT index)
- add three FTS workloads:
  - `fts_select_natural`
  - `fts_update_point`
  - `fts_mixed_70q_30u`
- add new CLI knobs:
  - `--fts-initial-rows` (default `256`)
  - `--fts-select-ops`
  - `--fts-update-ops`
  - `--fts-mixed-ops`
- update benchmark docs to include the new FTS workloads and config fields

## Notes
- FTS setup now uses a dedicated internal `fts_batch_size=min(batch_size, 32)` for stable index maintenance during dataset load.
- Existing non-FTS workloads and output format are preserved; new metrics are appended to the CSV output.

## Validation
- `cargo run --release --bin murodb_bench -- --initial-rows 500 --select-ops 20 --update-ops 20 --insert-ops 20 --scan-ops 10 --mixed-ops 20 --fts-select-ops 20 --fts-update-ops 10 --fts-mixed-ops 20 --warmup-ops 5 --batch-size 100`