### PR TITLE
Add date/time scalar functions (NOW/CURRENT_TIMESTAMP/DATE_FORMAT)

### DIFF
--- a/docs-site/src/roadmap.md
+++ b/docs-site/src/roadmap.md
@@ -81,7 +81,7 @@ MySQL-compatible scalar functions.
 
 - [x] FLOAT / DOUBLE
 - [ ] DATE, DATETIME, TIMESTAMP
-- [ ] Date/time functions: NOW, CURRENT_TIMESTAMP, DATE_FORMAT, etc.
+- [x] Date/time functions: NOW, CURRENT_TIMESTAMP, DATE_FORMAT, etc.
 - [ ] BLOB
 - [ ] Overflow pages (posting list > 4096B)
 

--- a/docs-site/src/user-guide/sql-reference.md
+++ b/docs-site/src/user-guide/sql-reference.md
@@ -465,6 +465,35 @@ Returns `base` raised to the power of `exp`.
 SELECT POWER(2, 10);  -- 1024
 ```
 
+### Date/Time Functions
+
+#### NOW() / CURRENT_TIMESTAMP[()]
+
+Returns the current UTC datetime as a `DATETIME` value.
+
+```sql
+SELECT NOW();
+SELECT CURRENT_TIMESTAMP();
+SELECT CURRENT_TIMESTAMP; -- parentheses are optional
+```
+
+#### DATE_FORMAT(dt, format)
+
+Formats a date/datetime/timestamp string/value using MySQL-style format specifiers.
+
+```sql
+SELECT DATE_FORMAT('2026-02-22 13:04:05', '%Y/%m/%d %H:%i:%s');
+-- '2026/02/22 13:04:05'
+```
+
+Common specifiers:
+- `%Y` year (4 digits), `%y` year (2 digits)
+- `%m` month (01-12), `%c` month (1-12), `%M` month name, `%b` month abbreviation
+- `%d` day (01-31), `%e` day (1-31)
+- `%H` hour (00-23), `%h`/`%I` hour (01-12), `%i` minute, `%s` second
+- `%W` weekday name, `%a` weekday abbreviation
+- `%T` `HH:MM:SS`, `%r` 12-hour time with AM/PM, `%%` literal percent
+
 ### NULL Handling & Conditional
 
 #### COALESCE(a, b, ...)

--- a/src/sql/parser.rs
+++ b/src/sql/parser.rs
@@ -1556,6 +1556,11 @@ impl Parser {
                         let col = self.expect_ident()?;
                         Ok(Expr::ColumnRef(format!("{}.{}", name, col)))
                     }
+                } else if name.eq_ignore_ascii_case("CURRENT_TIMESTAMP") {
+                    Ok(Expr::FunctionCall {
+                        name: "CURRENT_TIMESTAMP".to_string(),
+                        args: Vec::new(),
+                    })
                 } else {
                     Ok(Expr::ColumnRef(name))
                 }

--- a/tests/functions_tests.rs
+++ b/tests/functions_tests.rs
@@ -400,6 +400,56 @@ fn test_power() {
     );
 }
 
+// ── Date/time functions ──
+
+#[test]
+fn test_now_and_current_timestamp() {
+    let (mut p, mut c, _d) = setup();
+
+    let now = query_one(&mut p, &mut c, "SELECT NOW()");
+    assert!(matches!(now, Value::DateTime(_)));
+
+    let current_ts = query_one(&mut p, &mut c, "SELECT CURRENT_TIMESTAMP()");
+    assert!(matches!(current_ts, Value::DateTime(_)));
+
+    let current_ts_no_paren = query_one(&mut p, &mut c, "SELECT CURRENT_TIMESTAMP");
+    assert!(matches!(current_ts_no_paren, Value::DateTime(_)));
+}
+
+#[test]
+fn test_date_format() {
+    let (mut p, mut c, _d) = setup();
+    assert_eq!(
+        query_one(
+            &mut p,
+            &mut c,
+            "SELECT DATE_FORMAT('2026-02-22 13:04:05', '%Y/%m/%d %H:%i:%s')",
+        ),
+        Value::Varchar("2026/02/22 13:04:05".into())
+    );
+    assert_eq!(
+        query_one(
+            &mut p,
+            &mut c,
+            "SELECT DATE_FORMAT('2026-02-22', '%W, %M %e')",
+        ),
+        Value::Varchar("Sunday, February 22".into())
+    );
+}
+
+#[test]
+fn test_date_format_null_and_invalid_input() {
+    let (mut p, mut c, _d) = setup();
+    assert_eq!(
+        query_one(&mut p, &mut c, "SELECT DATE_FORMAT(NULL, '%Y')"),
+        Value::Null
+    );
+    assert_eq!(
+        query_one(&mut p, &mut c, "SELECT DATE_FORMAT('not-a-date', '%Y')"),
+        Value::Null
+    );
+}
+
 // ── NULL handling & conditional ──
 
 #[test]


### PR DESCRIPTION
## Summary
- add `NOW()` and `CURRENT_TIMESTAMP()` built-in scalar functions returning `DATETIME`
- support `CURRENT_TIMESTAMP` without parentheses in expression parsing
- add `DATE_FORMAT(dt, format)` with common MySQL-style format specifiers
- add integration tests for date/time functions and NULL/invalid input behavior
- update SQL reference and roadmap

## Validation
- cargo test --test functions_tests
- cargo test
