### PR TITLE
Fix FTS posting-list overflow by byte-aware segmentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,6 @@ subagent には「あなたはDB/SQLの専門家です」というペルソナ�
 
 ## Known Limitations
 
-- Posting list が 4096B ページを超えるとエラー (大量文書の共通bigramで発生しうる)
 - Subquery は非相関サブクエリのみ対応 (外部行参照は未対応)
 - ALTER TABLE ADD/DROP PRIMARY KEY 未対応
 - ALTER TABLE はトランザクション非対応 (DDL全般と同様)


### PR DESCRIPTION
## Summary
- replace fixed-count posting segmentation with byte-aware segmentation
- split oversized single-document posting entries by positions so each serialized segment stays under payload cap
- add regression test for huge single-doc positions (5000 positions) to ensure no PageOverflow
- remove outdated known limitation note claiming posting lists over 4096B fail

## Testing
- cargo test fts::index::tests:: -- --nocapture