### PR TITLE
fts: add overflow page chains for large segment payloads

### DIFF
--- a/docs-site/src/roadmap.md
+++ b/docs-site/src/roadmap.md
@@ -98,6 +98,10 @@ MySQL-compatible scalar functions.
     - Operational limits are documented (max size, indexing restrictions, comparison semantics).
 - [ ] Overflow pages (posting list > 4096B)
   - Scope: support values/postings that exceed single-page capacity.
+  - Progress:
+    - Implemented FTS segment overflow chains (`__segovf__`) with typed page format (`OFG1`).
+    - Read/write/delete + vacuum path now reclaims overflow pages without orphaning.
+    - Covered by unit/integration tests (`cargo test` green as of 2026-02-22).
   - Done when:
     - Overflow chain format is versioned and crash-safe.
     - WAL/recovery covers partial-write and torn-tail scenarios for overflow chains.


### PR DESCRIPTION
## Summary
- add overflow-page backed storage for large v2 FTS segment payloads via __segovf__ references
- load/store/delete segmented payloads through unified helpers so vacuum also reclaims overflow pages
- extend tests for large single-doc postings and stale-generation vacuum behavior; update roadmap progress notes

## Testing
- cargo test -q test_store_postings_spills_large_single_doc_positions_to_overflow_pages
- cargo test -q test_vacuum_stale_segments_removes_previous_generation_payload