### PR TITLE
sql: persist secondary index roots after B-tree splits

### DIFF
--- a/src/schema/catalog.rs
+++ b/src/schema/catalog.rs
@@ -332,6 +332,15 @@ impl SystemCatalog {
         }
     }
 
+    /// Update an existing index definition.
+    pub fn update_index(&mut self, pager: &mut impl PageStore, index_def: &IndexDef) -> Result<()> {
+        let key = format!("index:{}", index_def.name);
+        let serialized = index_def.serialize();
+        self.catalog_btree
+            .insert(pager, key.as_bytes(), &serialized)?;
+        Ok(())
+    }
+
     /// Get all indexes for a table.
     pub fn get_indexes_for_table(
         &self,

--- a/src/sql/executor.rs
+++ b/src/sql/executor.rs
@@ -55,7 +55,7 @@ use indexing::{
     check_unique_index_constraints, check_unique_index_constraints_excluding,
     delete_from_secondary_indexes, encode_index_key_from_row, encode_pk_key, eval_index_seek_key,
     eval_pk_seek_key, find_unique_index_conflict, index_seek_pk_keys,
-    insert_into_secondary_indexes, replace_delete_unique_conflicts,
+    insert_into_secondary_indexes, persist_indexes, replace_delete_unique_conflicts,
 };
 use insert::*;
 use mutation::*;


### PR DESCRIPTION
## Summary
- fix secondary-index root drift by propagating updated `btree_root` after insert/delete operations
- persist updated index definitions back to system catalog via new `SystemCatalog::update_index`
- apply the same root propagation for FULLTEXT metadata + posting updates so both paths share the latest root
- add regression test `test_sql_fulltext_insert_keeps_index_reachable_after_root_splits`

## Testing
- cargo test -q test_sql_fulltext_insert_keeps_index_reachable_after_root_splits
- cargo test -q sql_fulltext
- cargo run --release --bin murodb_bench
  - point_select_pk: 161,949.51 ops/s
  - point_update_pk: 613.77 ops/s
  - insert_autocommit: 576.32 ops/s
  - range_scan_limit_100: 107.66 ops/s
  - mixed_80r_15u_5i: 2,757.60 ops/s
  - fts_select_natural: 1,787.18 ops/s
  - fts_update_point: 174.47 ops/s
  - fts_mixed_70q_30u: 460.19 ops/s