### PR TITLE
fts: accelerate snippet extraction with UTF-8 offset map

### DIFF
--- a/docs-site/src/roadmap.md
+++ b/docs-site/src/roadmap.md
@@ -144,6 +144,9 @@ MySQL-compatible scalar functions.
     - Recall/precision tradeoff is documented with benchmark examples.
     - Toggle exists for exact behavior compatibility.
 - [ ] fts_snippet acceleration (pos-to-offset map)
+  - Progress:
+    - Replaced snippet byte/char conversion loops with a UTF-8 position-to-offset map plus binary search.
+    - Snippet assembly now slices by byte ranges instead of repeatedly collecting char vectors.
   - Done when:
     - Snippet generation avoids repeated UTF-8 rescans for long docs.
     - Latency improvement is measured and documented on representative datasets.


### PR DESCRIPTION
## Summary
- optimize `fts_snippet` by introducing a UTF-8 char/byte offset map
- replace repeated char-vector scans with binary-search offset conversion + byte-range slicing
- keep snippet behavior intact while reducing repeated UTF-8 rescans on long documents
- add multibyte boundary test coverage
- update roadmap progress for snippet acceleration

## Tests
- cargo test fts::snippet::tests -- --nocapture
- cargo test --test fts_tests -- --nocapture