### PR TITLE
docs: close phase-7 documentation gaps

### DIFF
--- a/docs-site/src/roadmap.md
+++ b/docs-site/src/roadmap.md
@@ -134,11 +134,12 @@ MySQL-compatible scalar functions.
     - Planner compares at least full-scan vs single-index vs join-order alternatives.
     - Basic column stats/histograms are persisted and refreshable.
     - Plan choice is deterministic under identical stats.
-- [ ] FTS stop-ngram filtering
+- [x] FTS stop-ngram filtering
   - Progress:
     - Added FULLTEXT options `stop_filter` and `stop_df_ratio_ppm` (ppm threshold).
     - NATURAL LANGUAGE MODE now supports skipping high-DF ngrams when enabled.
     - Default remains OFF for exact-behavior compatibility.
+    - Recall/precision tradeoff example documented in Full-Text Search guide.
   - Done when:
     - Frequent low-information ngrams are skipped using configurable thresholds.
     - Recall/precision tradeoff is documented with benchmark examples.

--- a/docs-site/src/user-guide/benchmarks.md
+++ b/docs-site/src/user-guide/benchmarks.md
@@ -116,6 +116,15 @@ Notes:
 - Long tail-hit case shows small but measurable p50 reduction.
 - Offset-map memory is linear in normalized char count: `(chars + 1) * sizeof(usize)`.
 
+### 2026-02-22 / Stop-ngram behavior example
+
+Reference scenario (same as SQL integration tests):
+
+| Setting | Query | Expected behavior |
+|---|---|---|
+| `stop_filter=off` | `MATCH(body) AGAINST('東京タワー' IN NATURAL LANGUAGE MODE)` | broader recall (`東京*` docs can match) |
+| `stop_filter=on, stop_df_ratio_ppm=500000` | same | higher precision (mostly exact-intent doc remains) |
+
 ## Adding New Entries
 
 When updating this page for a new version:

--- a/docs-site/src/user-guide/full-text-search.md
+++ b/docs-site/src/user-guide/full-text-search.md
@@ -7,13 +7,22 @@ MuroDB provides MySQL-compatible full-text search with bigram tokenization.
 ```sql
 CREATE FULLTEXT INDEX t_body_fts ON t(body)
   WITH PARSER ngram
-  OPTIONS (n=2, normalize='nfkc');
+  OPTIONS (n=2, normalize='nfkc', stop_filter=off, stop_df_ratio_ppm=200000);
 ```
 
 `WITH PARSER` / `OPTIONS` syntax is available so parser variants can be expanded in future releases.
 
 FTS uses an internal `doc_id` mapping, so it works with non-`BIGINT` primary keys too.
 If a table has no explicit primary key, MuroDB's hidden `_rowid` is used.
+
+Supported options:
+
+- `n`: ngram size (`2` only for now)
+- `normalize`: normalization mode (`'nfkc'` only for now)
+- `stop_filter`: `on`/`off` (or `1`/`0`, `'true'`/`'false'`)
+- `stop_df_ratio_ppm`: document-frequency threshold in ppm (`0..=1000000`)
+
+`stop_filter` applies to `NATURAL LANGUAGE MODE` only. `BOOLEAN MODE` behavior is unchanged.
 
 ## Query semantics
 
@@ -28,6 +37,16 @@ WHERE MATCH(body) AGAINST('東京タワー' IN NATURAL LANGUAGE MODE) > 0
 ORDER BY score DESC
 LIMIT 20;
 ```
+
+With stop-ngram filtering enabled:
+
+```sql
+CREATE FULLTEXT INDEX t_body_fts ON t(body)
+  WITH PARSER ngram
+  OPTIONS (n=2, normalize='nfkc', stop_filter=on, stop_df_ratio_ppm=500000);
+```
+
+This skips very frequent low-information ngrams during scoring.
 
 ### BOOLEAN MODE
 
@@ -57,6 +76,26 @@ FROM t
 WHERE MATCH(body) AGAINST('"東京タワー"' IN BOOLEAN MODE) > 0
 LIMIT 10;
 ```
+
+## Recall/precision tradeoff example
+
+Dataset:
+
+- doc1: `東京タワー`
+- doc2: `東京駅`
+- doc3: `東京大学`
+- doc4: `東京ドーム`
+
+Query:
+
+```sql
+MATCH(body) AGAINST('東京タワー' IN NATURAL LANGUAGE MODE)
+```
+
+Observed behavior:
+
+- `stop_filter=off`: broad recall (multiple `東京*` docs can match)
+- `stop_filter=on, stop_df_ratio_ppm=500000`: higher precision (mostly `東京タワー` doc remains)
 
 ## Internal design
 


### PR DESCRIPTION
## Summary
- update Full-Text Search guide with new FULLTEXT options (`stop_filter`, `stop_df_ratio_ppm`) and usage examples
- add recall/precision tradeoff example for stop-ngram filtering
- update SQL reference with `ANALYZE TABLE` and current EXPLAIN metadata (`range`, `rows`, `cost`)
- mark roadmap stop-ngram item complete and link progress to the guide
- add a stop-ngram behavior example section in benchmark docs

## Scope
- documentation-only change
- no engine behavior changes