### PR TITLE
wal: persist epoch in MetaUpdate as key-rotation groundwork

### DIFF
--- a/docs-site/src/internals/format-migration.md
+++ b/docs-site/src/internals/format-migration.md
@@ -65,3 +65,4 @@ In format version 2, the freelist may span multiple pages linked as a chain:
 |---|---|
 | v1 | Initial: Begin, PagePut, MetaUpdate(catalog_root, page_count), Commit, Abort |
 | v2 | MetaUpdate adds `freelist_page_id` field. Data file header adds CRC32. Legacy v1 MetaUpdate (25 bytes) decoded with `freelist_page_id=0` (backward compatible) |
+| v3 | MetaUpdate adds `epoch` field. Legacy v1/v2 MetaUpdate records decode with `epoch=0` (backward compatible) |

--- a/docs-site/src/internals/wal.md
+++ b/docs-site/src/internals/wal.md
@@ -8,7 +8,7 @@ MuroDB uses a Write-Ahead Log (WAL) for crash recovery. All writes go through th
 |---|---|
 | BEGIN | Start of a transaction |
 | PAGE_PUT | Write a page (page_id + page data) |
-| META_UPDATE | Metadata update (catalog_root, freelist_page_id, page_count) |
+| META_UPDATE | Metadata update (catalog_root, freelist_page_id, page_count, epoch) |
 | COMMIT | Transaction commit marker |
 | ABORT | Transaction abort marker |
 
@@ -58,7 +58,7 @@ COMMIT
   → tx.commit(&mut pager, &mut wal)   ← WAL-first commit
     1. Write Begin record to WAL
     2. Write PagePut record for each dirty page
-    3. Write MetaUpdate (catalog_root, freelist_page_id, page_count)
+    3. Write MetaUpdate (catalog_root, freelist_page_id, page_count, epoch)
     4. Write Commit record
     5. wal.sync()                      ← fsync WAL
     6. Write dirty pages to data file

--- a/docs-site/src/roadmap.md
+++ b/docs-site/src/roadmap.md
@@ -158,6 +158,10 @@ MySQL-compatible scalar functions.
 ## Phase 8 — Security (Future)
 
 - [ ] Key rotation (epoch-based re-encryption)
+  - Progress:
+    - Extended WAL `MetaUpdate` to persist `epoch` alongside `catalog_root` / `page_count` / `freelist_page_id`.
+    - WAL recovery now restores the latest committed `epoch` value into DB metadata.
+    - Added backward-compatible decode defaults (`epoch=0`) for legacy WAL MetaUpdate records.
   - Done when:
     - Online/offline rotation flow is available with resumable progress.
     - WAL + data file epoch mismatch handling is crash-safe.

--- a/src/storage/pager.rs
+++ b/src/storage/pager.rs
@@ -474,6 +474,11 @@ impl Pager {
         self.epoch
     }
 
+    /// Set current epoch (used by WAL recovery / key rotation paths).
+    pub fn set_epoch(&mut self, epoch: u64) {
+        self.epoch = epoch;
+    }
+
     /// Get catalog root page ID.
     pub fn catalog_root(&self) -> u64 {
         self.catalog_root

--- a/src/tx/transaction.rs
+++ b/src/tx/transaction.rs
@@ -181,6 +181,7 @@ impl Transaction {
             catalog_root,
             page_count,
             freelist_page_id,
+            epoch: pager.epoch(),
         })?;
 
         // Write Commit record

--- a/tests/crash_matrix.rs
+++ b/tests/crash_matrix.rs
@@ -156,6 +156,7 @@ fn write_wal_up_to(
         catalog_root,
         page_count,
         freelist_page_id,
+        epoch: 0,
     })
     .unwrap();
     if matches!(crash_point, CrashPoint::AfterMetaUpdate) {

--- a/tests/wal_recovery.rs
+++ b/tests/wal_recovery.rs
@@ -33,6 +33,7 @@ fn test_wal_write_and_read() {
                 txid: 1,
                 catalog_root: 0,
                 freelist_page_id: 0,
+                epoch: 0,
                 page_count: 6,
             })
             .unwrap();
@@ -90,6 +91,7 @@ fn test_recovery_replays_committed_only() {
                 txid: 1,
                 catalog_root: 0,
                 freelist_page_id: 0,
+                epoch: 0,
                 page_count: 2,
             })
             .unwrap();
@@ -243,6 +245,7 @@ fn test_truncated_wal_tail_recovery() {
                 txid: 1,
                 catalog_root: 0,
                 freelist_page_id: 0,
+                epoch: 0,
                 page_count: 1,
             })
             .unwrap();
@@ -307,6 +310,7 @@ fn test_corrupt_tail_frame_recovery() {
                 txid: 1,
                 catalog_root: 0,
                 freelist_page_id: 0,
+                epoch: 0,
                 page_count: 1,
             })
             .unwrap();
@@ -603,6 +607,7 @@ fn test_interleaved_txs_with_tail_corruption() {
                 txid: 1,
                 catalog_root: 0,
                 freelist_page_id: 0,
+                epoch: 0,
                 page_count: 1,
             })
             .unwrap();
@@ -679,6 +684,7 @@ fn test_corruption_at_transaction_boundary() {
                 txid: 1,
                 catalog_root: 0,
                 freelist_page_id: 0,
+                epoch: 0,
                 page_count: 1,
             })
             .unwrap();
@@ -739,6 +745,7 @@ fn test_committed_tx_then_aborted_tx_then_crash() {
                 txid: 1,
                 catalog_root: 0,
                 freelist_page_id: 0,
+                epoch: 0,
                 page_count: 1,
             })
             .unwrap();
@@ -936,6 +943,7 @@ fn test_recovery_truncates_wal_durably() {
                 txid: 1,
                 catalog_root: 0,
                 freelist_page_id: 0,
+                epoch: 0,
                 page_count: 1,
             })
             .unwrap();
@@ -988,7 +996,8 @@ fn test_recovery_truncates_wal_durably() {
     assert_eq!(page.cell(0), Some(b"wal data".as_slice()));
 }
 
-/// MetaUpdate backward compatibility: old WAL records (25 bytes) without freelist_page_id
+/// MetaUpdate backward compatibility: old WAL records (25 bytes) without
+/// freelist_page_id/epoch must default both fields to 0.
 #[test]
 fn test_meta_update_backward_compat() {
     use murodb::wal::record::WalRecord;
@@ -1007,12 +1016,14 @@ fn test_meta_update_backward_compat() {
         catalog_root,
         page_count,
         freelist_page_id,
+        epoch,
     } = record
     {
         assert_eq!(txid, 1);
         assert_eq!(catalog_root, 42);
         assert_eq!(page_count, 100);
         assert_eq!(freelist_page_id, 0, "Old records should default to 0");
+        assert_eq!(epoch, 0, "Old records should default epoch to 0");
     } else {
         panic!("Expected MetaUpdate");
     }


### PR DESCRIPTION
## Summary
- extend WAL `MetaUpdate` with `epoch` field
- include current pager epoch in transaction commit WAL metadata
- restore committed epoch during WAL recovery (`Pager::set_epoch`)
- keep backward compatibility for legacy WAL records by decoding missing epoch as `0`
- add/update WAL record and recovery tests, including legacy decode coverage
- update internals docs and roadmap progress for Phase 8 groundwork

## Why
This is a safe foundation for Phase 8 key rotation. Epoch is now part of committed WAL metadata, which is required for crash-safe synchronization between data-file metadata and WAL replay state.

## Tests
- cargo test wal::record::tests::test_meta_update_deserialize_legacy_without_epoch -- --nocapture
- cargo test --test wal_recovery -- --nocapture
- cargo test --test crash_matrix -- --nocapture