### PR TITLE
sql: validate COLLATE only on text columns

### DIFF
--- a/src/sql/executor.rs
+++ b/src/sql/executor.rs
@@ -831,4 +831,37 @@ mod tests {
         );
         assert!(invalid_timestamp.is_err());
     }
+
+    #[test]
+    fn test_create_table_rejects_collate_on_non_text_column() {
+        let (mut pager, mut catalog, _dir) = setup();
+        let err = execute(
+            "CREATE TABLE t (id BIGINT COLLATE utf8mb4_bin PRIMARY KEY)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("COLLATE is only supported for VARCHAR/TEXT columns"));
+    }
+
+    #[test]
+    fn test_alter_table_rejects_collate_on_non_text_column() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE t (id BIGINT PRIMARY KEY, v INT)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        let err = execute(
+            "ALTER TABLE t MODIFY COLUMN v INT COLLATE utf8mb4_bin",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("COLLATE is only supported for VARCHAR/TEXT columns"));
+    }
 }

--- a/src/sql/executor/alter.rs
+++ b/src/sql/executor/alter.rs
@@ -36,6 +36,12 @@ pub(super) fn exec_alter_add_column(
     pager: &mut impl PageStore,
     catalog: &mut SystemCatalog,
 ) -> Result<ExecResult> {
+    validate_column_collation(
+        &col_spec.name,
+        col_spec.data_type,
+        col_spec.collation.as_deref(),
+    )?;
+
     // Validate: column doesn't already exist
     if table_def.column_index(&col_spec.name).is_some() {
         return Err(MuroError::Schema(format!(
@@ -213,6 +219,12 @@ pub(super) fn exec_alter_modify_column(
     pager: &mut impl PageStore,
     catalog: &mut SystemCatalog,
 ) -> Result<ExecResult> {
+    validate_column_collation(
+        &col_spec.name,
+        col_spec.data_type,
+        col_spec.collation.as_deref(),
+    )?;
+
     let col_idx = table_def.column_index(&col_spec.name).ok_or_else(|| {
         MuroError::Schema(format!(
             "Column '{}' not found in table '{}'",
@@ -282,6 +294,12 @@ pub(super) fn exec_alter_change_column(
     pager: &mut impl PageStore,
     catalog: &mut SystemCatalog,
 ) -> Result<ExecResult> {
+    validate_column_collation(
+        &col_spec.name,
+        col_spec.data_type,
+        col_spec.collation.as_deref(),
+    )?;
+
     let col_idx = table_def.column_index(old_name).ok_or_else(|| {
         MuroError::Schema(format!(
             "Column '{}' not found in table '{}'",

--- a/src/sql/executor/ddl.rs
+++ b/src/sql/executor/ddl.rs
@@ -1,6 +1,23 @@
 use super::*;
 use std::collections::HashSet;
 
+pub(super) fn validate_column_collation(
+    column_name: &str,
+    data_type: DataType,
+    collation: Option<&str>,
+) -> Result<()> {
+    if collation.is_none() {
+        return Ok(());
+    }
+    if matches!(data_type, DataType::Varchar(_) | DataType::Text) {
+        return Ok(());
+    }
+    Err(MuroError::Schema(format!(
+        "COLLATE is only supported for VARCHAR/TEXT columns: '{}'",
+        column_name
+    )))
+}
+
 pub(super) fn exec_create_table(
     ct: &CreateTable,
     pager: &mut impl PageStore,
@@ -66,6 +83,11 @@ pub(super) fn exec_create_table(
         .map(|(name, _)| name.clone())
         .collect();
     for col_spec in &ct.columns {
+        validate_column_collation(
+            &col_spec.name,
+            col_spec.data_type,
+            col_spec.collation.as_deref(),
+        )?;
         if col_spec.is_unique && !col_spec.is_primary_key {
             let idx_name = format!("auto_unique_{}_{}", ct.table_name, col_spec.name);
             if all_index_names.contains(&idx_name) {


### PR DESCRIPTION
## Summary
- add column-definition validation that allows COLLATE only for VARCHAR/TEXT columns
- apply the same validation to ALTER TABLE ADD/MODIFY/CHANGE column paths
- add executor tests that verify CREATE/ALTER reject COLLATE on INT/BIGINT columns

## Tests
- cargo test -q test_create_table_rejects_collate_on_non_text_column
- cargo test -q test_alter_table_rejects_collate_on_non_text_column
- cargo test -q test_parse_column_with_collate