### PR TITLE
sql: adopt binary collation naming and wire ORDER BY path

### DIFF
--- a/src/sql/executor/ddl.rs
+++ b/src/sql/executor/ddl.rs
@@ -9,13 +9,22 @@ pub(super) fn validate_column_collation(
     if collation.is_none() {
         return Ok(());
     }
-    if matches!(data_type, DataType::Varchar(_) | DataType::Text) {
-        return Ok(());
+    if !matches!(data_type, DataType::Varchar(_) | DataType::Text) {
+        return Err(MuroError::Schema(format!(
+            "COLLATE is only supported for VARCHAR/TEXT columns: '{}'",
+            column_name
+        )));
     }
-    Err(MuroError::Schema(format!(
-        "COLLATE is only supported for VARCHAR/TEXT columns: '{}'",
-        column_name
-    )))
+
+    let name = collation.unwrap();
+    if name.eq_ignore_ascii_case("binary") {
+        Ok(())
+    } else {
+        Err(MuroError::Schema(format!(
+            "Unsupported collation '{}' for column '{}': currently only binary is supported",
+            name, column_name
+        )))
+    }
 }
 
 pub(super) fn exec_create_table(

--- a/src/sql/executor/select_query.rs
+++ b/src/sql/executor/select_query.rs
@@ -414,7 +414,7 @@ pub(super) fn exec_select(
 
         // ORDER BY
         if let Some(order_items) = &sel.order_by {
-            sort_rows(&mut rows, order_items);
+            sort_rows_with_table(&mut rows, order_items, &table_def)?;
         }
 
         // OFFSET
@@ -694,7 +694,7 @@ pub(super) fn exec_select(
 
         // ORDER BY
         if let Some(order_items) = &sel.order_by {
-            sort_rows(&mut rows, order_items);
+            sort_rows_with_table(&mut rows, order_items, &table_def)?;
         }
 
         // OFFSET
@@ -729,6 +729,28 @@ pub(super) fn exec_select_returning_rows(
     }
 }
 
+fn cmp_values_with_collation(
+    a: Option<&Value>,
+    b: Option<&Value>,
+    collation: Option<&str>,
+) -> Result<std::cmp::Ordering> {
+    let Some(collation) = collation else {
+        return Ok(cmp_values(a, b));
+    };
+    if !collation.eq_ignore_ascii_case("binary") {
+        return Err(MuroError::Execution(format!(
+            "Unsupported collation '{}' in ORDER BY: currently only binary is supported",
+            collation
+        )));
+    }
+    match (a, b) {
+        (Some(Value::Varchar(left)), Some(Value::Varchar(right))) => {
+            Ok(left.as_bytes().cmp(right.as_bytes()))
+        }
+        _ => Ok(cmp_values(a, b)),
+    }
+}
+
 pub(super) fn sort_rows(rows: &mut [Row], order_items: &[OrderByItem]) {
     rows.sort_by(|a, b| {
         for item in order_items {
@@ -743,6 +765,43 @@ pub(super) fn sort_rows(rows: &mut [Row], order_items: &[OrderByItem]) {
         }
         std::cmp::Ordering::Equal
     });
+}
+
+pub(super) fn sort_rows_with_table(
+    rows: &mut [Row],
+    order_items: &[OrderByItem],
+    table_def: &TableDef,
+) -> Result<()> {
+    let mut sort_error: Option<MuroError> = None;
+    rows.sort_by(|a, b| {
+        if sort_error.is_some() {
+            return std::cmp::Ordering::Equal;
+        }
+        for item in order_items {
+            if let Expr::ColumnRef(col) = &item.expr {
+                let va = a.get(col);
+                let vb = b.get(col);
+                let collation = table_def
+                    .column_index(col)
+                    .and_then(|i| table_def.columns[i].collation.as_deref());
+                let ord = match cmp_values_with_collation(va, vb, collation) {
+                    Ok(ord) => ord,
+                    Err(e) => {
+                        sort_error = Some(e);
+                        return std::cmp::Ordering::Equal;
+                    }
+                };
+                if ord != std::cmp::Ordering::Equal {
+                    return if item.descending { ord.reverse() } else { ord };
+                }
+            }
+        }
+        std::cmp::Ordering::Equal
+    });
+    if let Some(err) = sort_error {
+        return Err(err);
+    }
+    Ok(())
 }
 
 pub(super) fn matches_where(


### PR DESCRIPTION
## Summary
- use semantic collation naming: support COLLATE binary for textual columns and reject other names
- keep type guard: COLLATE is valid only on VARCHAR/TEXT columns
- wire SELECT ORDER BY to consult column collation metadata and apply binary byte-order comparison for VARCHAR values
- add executor tests for unsupported collation rejection and binary-collation ORDER BY behavior

## Tests
- cargo test -q test_create_table_rejects_collate_on_non_text_column
- cargo test -q test_alter_table_rejects_collate_on_non_text_column
- cargo test -q test_create_table_rejects_unsupported_collation_name
- cargo test -q test_order_by_uses_binary_collation_path