### PR TITLE
Phase 7: reduce nested-loop join cost for inner/cross

### DIFF
--- a/docs-site/src/roadmap.md
+++ b/docs-site/src/roadmap.md
@@ -132,6 +132,7 @@ MySQL-compatible scalar functions.
     - EXPLAIN row estimation now prefers persisted `table_rows` when available.
     - Planner cost model now incorporates persisted `table_rows`/`index_distinct_keys` when available, with conservative fallback selectivity when stats are missing.
     - EXPLAIN `rows`/`cost` now uses the same planner estimation logic (with table-row fallback), so estimates reflect planner tradeoffs.
+    - JOIN execution now compares simple nested-loop alternatives for `INNER`/`CROSS` joins and iterates the smaller side as the outer loop while preserving row shape (`left + right`).
   - Done when:
     - Planner compares at least full-scan vs single-index vs join-order alternatives.
     - Basic column stats/histograms are persisted and refreshable.


### PR DESCRIPTION
## Summary
- for INNER JOIN and CROSS JOIN, compare simple loop-order alternatives at execution time
- iterate the smaller input as the outer loop to reduce nested-loop overhead
- preserve logical combined row shape as left+right so projection semantics stay unchanged
- update Phase 7 roadmap progress notes for join-order alternatives

## Validation
- cargo test -q --test join_tests
- cargo test -q
