### PR TITLE
Phase 7: planner-side join loop-order choice

### DIFF
--- a/docs-site/src/roadmap.md
+++ b/docs-site/src/roadmap.md
@@ -132,7 +132,7 @@ MySQL-compatible scalar functions.
     - EXPLAIN row estimation now prefers persisted `table_rows` when available.
     - Planner cost model now incorporates persisted `table_rows`/`index_distinct_keys` when available, with conservative fallback selectivity when stats are missing.
     - EXPLAIN `rows`/`cost` now uses the same planner estimation logic (with table-row fallback), so estimates reflect planner tradeoffs.
-    - JOIN execution now compares simple nested-loop alternatives for `INNER`/`CROSS` joins and iterates the smaller side as the outer loop while preserving row shape (`left + right`).
+    - JOIN loop-order choice for `INNER`/`CROSS` now uses planner-side estimated row counts (stats-aware with runtime fallback) and keeps row shape (`left + right`) stable.
     - `ANALYZE TABLE` now persists numeric min/max bounds for single-column numeric B-tree indexes, and range row estimation uses those bounds when available.
   - Done when:
     - Planner compares at least full-scan vs single-index vs join-order alternatives.

--- a/src/sql/executor.rs
+++ b/src/sql/executor.rs
@@ -17,8 +17,8 @@ use crate::sql::ast::*;
 use crate::sql::eval::{eval_expr, is_truthy};
 use crate::sql::parser::parse_sql;
 use crate::sql::planner::{
-    estimate_plan_rows_hint, plan_cost_hint_with_stats, plan_select, IndexPlanStat, Plan,
-    PlannerStats,
+    choose_nested_loop_order, estimate_plan_rows_hint, plan_cost_hint_with_stats, plan_select,
+    IndexPlanStat, JoinLoopOrder, Plan, PlannerStats,
 };
 use crate::storage::page::PageId;
 use crate::storage::page_store::PageStore;


### PR DESCRIPTION
## Summary
- add planner helper (`choose_nested_loop_order`) for nested-loop alternative comparison
- use planner-side estimated row counts in join execution for `INNER`/`CROSS` outer-loop choice
- keep `left + right` row shape and predicate semantics unchanged
- add planner unit test and update roadmap progress wording

## Validation
- cargo test -q --lib planner::tests::test_choose_nested_loop_order_prefers_smaller_outer
- cargo test -q --test join_tests
- cargo test -q
