### PR TITLE
Phase 7: expose join loop-order choice in EXPLAIN

### DIFF
--- a/docs-site/src/roadmap.md
+++ b/docs-site/src/roadmap.md
@@ -134,6 +134,7 @@ MySQL-compatible scalar functions.
     - EXPLAIN `rows`/`cost` now uses the same planner estimation logic (with table-row fallback), so estimates reflect planner tradeoffs.
     - JOIN loop-order choice for `INNER`/`CROSS` now uses planner-side estimated row counts (stats-aware with runtime fallback) and keeps row shape (`left + right`) stable.
     - `ANALYZE TABLE` now persists numeric min/max bounds and equal-width histogram bins for single-column numeric B-tree indexes; range row estimation uses these stats when available.
+    - EXPLAIN for JOIN now reports nested-loop outer-side choice with estimated left/right row counts in `Extra`.
   - Done when:
     - Planner compares at least full-scan vs single-index vs join-order alternatives.
     - Basic column stats/histograms are persisted and refreshable.


### PR DESCRIPTION
## Summary
- add JOIN loop-order diagnostics to `EXPLAIN SELECT` `Extra` for `INNER`/`CROSS` joins
- diagnostics include per-join outer-side choice (`left_outer`/`right_outer`) and estimated L/R row counts
- preserve existing access-path reporting (`type/key/rows/cost`)
- update roadmap progress note to reflect EXPLAIN visibility

## Validation
- cargo test -q --test explain_tests
- cargo test -q
