### PR TITLE
Phase 7: finalize optimizer completion with determinism/refresh tests

### DIFF
--- a/docs-site/src/roadmap.md
+++ b/docs-site/src/roadmap.md
@@ -123,7 +123,7 @@ MySQL-compatible scalar functions.
     - Multi-column prefix ranges (`(a,b)` with predicates on `a`, optional range on `b`) use index scan.
     - EXPLAIN shows index-range choice and estimated cardinality.
     - Fallback path remains correct for unsupported predicate shapes.
-- [ ] Query optimizer improvements (cost-based)
+- [x] Query optimizer improvements (cost-based)
   - Progress:
     - Added deterministic heuristic cost hints for `PkSeek` / `IndexSeek` / `IndexRangeSeek` / `FullScan`.
     - Planner now compares index candidates by cost instead of choosing the first matching index.


### PR DESCRIPTION
## Summary
- add EXPLAIN regression for deterministic plan tie-breaking (`idx_a1` vs `idx_a2`)
- add EXPLAIN regression showing stats/histograms are refreshable via re-ANALYZE
- mark `Query optimizer improvements (cost-based)` as completed in roadmap

## Validation
- cargo test -q --test explain_tests
- cargo test -q
