### PR TITLE
phase9: pluggable encryption + explicit plaintext mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # MuroDB
 
-Encrypted embedded SQL database written in Rust.
+Embedded SQL database written in Rust.
 
 ## Status
 
 MuroDB is under active development.
 
 - Core storage: encrypted pages + WAL crash recovery
+- Pluggable encryption suite: `aes256-gcm-siv` / `off` (plaintext)
 - SQL engine: practical subset for local/embedded use
 - Documentation: moved to `docs-site/`
 
@@ -21,6 +22,9 @@ cargo install --path .
 ```bash
 # Create a database
 murodb mydb.db --create -e "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)"
+
+# Create a plaintext database (explicit opt-in)
+murodb mydb_plain.db --create --encryption off -e "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)"
 
 # Insert data
 murodb mydb.db -e "INSERT INTO t (id, name) VALUES (1, 'hello')"

--- a/docs-site/src/getting-started/quick-start.md
+++ b/docs-site/src/getting-started/quick-start.md
@@ -8,6 +8,12 @@ murodb mydb.db --create -e "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)
 
 You will be prompted for an encryption password.
 
+If you need plaintext mode, opt in explicitly:
+
+```bash
+murodb mydb_plain.db --create --encryption off -e "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)"
+```
+
 ## Insert data
 
 ```bash

--- a/docs-site/src/introduction.md
+++ b/docs-site/src/introduction.md
@@ -1,10 +1,10 @@
 # MuroDB
 
-Encrypted embedded SQL database with B+Tree (no leaf links) + Full-Text Search (Bigram), written in Rust.
+Embedded SQL database with B+Tree (no leaf links) + Full-Text Search (Bigram), written in Rust.
 
 ## Features
 
-- **Transparent encryption** - AES-256-GCM-SIV (nonce-misuse resistant) for all pages and WAL
+- **Pluggable at-rest mode** - `aes256-gcm-siv` (default) or explicit `off` plaintext mode
 - **B+tree storage (no leaf links)** - PRIMARY KEY (TINYINT/SMALLINT/INT/BIGINT), UNIQUE indexes (single column)
 - **Full-text search** - Bigram (n=2) with NFKC normalization
   - MySQL-style `MATCH(col) AGAINST(...)` syntax
@@ -20,9 +20,9 @@ Encrypted embedded SQL database with B+Tree (no leaf links) + Full-Text Search (
 | Component | Description |
 |---|---|
 | `crypto/` | AES-256-GCM-SIV page encryption, Argon2 KDF, HMAC-SHA256 term blinding |
-| `storage/` | 4096B slotted pages, encrypted pager with LRU cache, freelist |
+| `storage/` | 4096B slotted pages, pager with pluggable at-rest mode + LRU cache, freelist |
 | `btree/` | Insert/split, delete, search, scan, order-preserving key encoding |
-| `wal/` | Encrypted WAL records, writer/reader, crash recovery |
+| `wal/` | WAL records (suite-aligned with DB mode), writer/reader, crash recovery |
 | `tx/` | Transaction with dirty page buffer, commit/rollback |
 | `schema/` | System catalog, table/index definitions |
 | `sql/` | Hand-written lexer/parser, AST, rule-based planner, executor |

--- a/docs-site/src/roadmap.md
+++ b/docs-site/src/roadmap.md
@@ -190,13 +190,13 @@ MySQL-compatible scalar functions.
 
 Real-world deployment features to make MuroDB easier to embed and operate.
 
-- [ ] Encryption OFF mode
+- [x] Encryption OFF mode
   - Motivation: some embedded deployments prefer CPU savings and rely on disk/host-level protection.
   - Done when:
     - DB format can be created/opened in explicit plaintext mode.
     - File header clearly records mode to avoid accidental mis-open.
     - CLI/API require explicit opt-in (no silent downgrade from encrypted DB).
-- [ ] Pluggable encryption suite
+- [x] Pluggable encryption suite
   - Motivation: allow policy-driven algorithm choice without forking storage engine.
   - Done when:
     - Algorithm + KDF are selected by explicit config at DB creation.

--- a/docs-site/src/user-guide/cli.md
+++ b/docs-site/src/user-guide/cli.md
@@ -12,7 +12,8 @@ murodb <database-file> [options]
 |---|---|
 | `-e <SQL>` | Execute SQL and exit |
 | `--create` | Create a new database |
-| `--password <PW>` | Password (prompts if omitted) |
+| `--encryption <aes256-gcm-siv\|off>` | Encryption suite (`off` = plaintext, explicit opt-in) |
+| `--password <PW>` | Password for `aes256-gcm-siv` mode (prompts if omitted) |
 | `--recovery-mode <strict\|permissive>` | WAL recovery policy for open |
 | `--format <text\|json>` | Output format for query results |
 
@@ -21,6 +22,9 @@ murodb <database-file> [options]
 ```bash
 # Create a new database
 murodb mydb.db --create -e "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)"
+
+# Create plaintext DB (explicit)
+murodb mydb_plain.db --create --encryption off -e "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)"
 
 # Insert data
 murodb mydb.db -e "INSERT INTO t (id, name) VALUES (1, 'hello')"

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,3 +1,4 @@
 pub mod aead;
 pub mod hmac_util;
 pub mod kdf;
+pub mod suite;

--- a/src/crypto/suite.rs
+++ b/src/crypto/suite.rs
@@ -1,0 +1,136 @@
+use crate::crypto::aead::{MasterKey, PageCrypto};
+use crate::error::{MuroError, Result};
+use crate::storage::page::PageId;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EncryptionSuite {
+    Plaintext,
+    Aes256GcmSiv,
+}
+
+impl EncryptionSuite {
+    pub const PLAINTEXT_ID: u32 = 0;
+    pub const AES256_GCM_SIV_ID: u32 = 1;
+
+    pub const fn id(self) -> u32 {
+        match self {
+            EncryptionSuite::Plaintext => Self::PLAINTEXT_ID,
+            EncryptionSuite::Aes256GcmSiv => Self::AES256_GCM_SIV_ID,
+        }
+    }
+
+    pub fn from_id(id: u32) -> Result<Self> {
+        match id {
+            Self::PLAINTEXT_ID => Ok(EncryptionSuite::Plaintext),
+            Self::AES256_GCM_SIV_ID => Ok(EncryptionSuite::Aes256GcmSiv),
+            _ => Err(MuroError::Encryption(format!(
+                "unsupported encryption suite id {}",
+                id
+            ))),
+        }
+    }
+
+    pub const fn requires_master_key(self) -> bool {
+        matches!(self, EncryptionSuite::Aes256GcmSiv)
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            EncryptionSuite::Plaintext => "plaintext",
+            EncryptionSuite::Aes256GcmSiv => "aes256-gcm-siv",
+        }
+    }
+}
+
+enum CipherImpl {
+    Plaintext,
+    Aead(Box<PageCrypto>),
+}
+
+pub struct PageCipher {
+    suite: EncryptionSuite,
+    inner: CipherImpl,
+}
+
+impl PageCipher {
+    pub fn new(suite: EncryptionSuite, master_key: Option<&MasterKey>) -> Result<Self> {
+        let inner = match suite {
+            EncryptionSuite::Plaintext => CipherImpl::Plaintext,
+            EncryptionSuite::Aes256GcmSiv => {
+                let key = master_key.ok_or_else(|| {
+                    MuroError::Encryption(
+                        "master key is required for aes256-gcm-siv encryption suite".to_string(),
+                    )
+                })?;
+                CipherImpl::Aead(Box::new(PageCrypto::new(key)))
+            }
+        };
+
+        Ok(Self { suite, inner })
+    }
+
+    pub const fn suite(&self) -> EncryptionSuite {
+        self.suite
+    }
+
+    pub const fn overhead(&self) -> usize {
+        match self.inner {
+            CipherImpl::Plaintext => 0,
+            CipherImpl::Aead(_) => PageCrypto::overhead(),
+        }
+    }
+
+    pub fn encrypt(&self, page_id: PageId, epoch: u64, plaintext: &[u8]) -> Result<Vec<u8>> {
+        match &self.inner {
+            CipherImpl::Plaintext => Ok(plaintext.to_vec()),
+            CipherImpl::Aead(c) => c.encrypt(page_id, epoch, plaintext),
+        }
+    }
+
+    pub fn decrypt(&self, page_id: PageId, epoch: u64, encrypted: &[u8]) -> Result<Vec<u8>> {
+        match &self.inner {
+            CipherImpl::Plaintext => Ok(encrypted.to_vec()),
+            CipherImpl::Aead(c) => c.decrypt(page_id, epoch, encrypted),
+        }
+    }
+
+    pub fn encrypt_into(
+        &self,
+        page_id: PageId,
+        epoch: u64,
+        plaintext: &[u8],
+        out: &mut [u8],
+    ) -> Result<usize> {
+        match &self.inner {
+            CipherImpl::Plaintext => {
+                if out.len() < plaintext.len() {
+                    return Err(MuroError::Encryption(
+                        "output buffer too small for plaintext mode".to_string(),
+                    ));
+                }
+                out[..plaintext.len()].copy_from_slice(plaintext);
+                Ok(plaintext.len())
+            }
+            CipherImpl::Aead(c) => c.encrypt_into(page_id, epoch, plaintext, out),
+        }
+    }
+
+    pub fn decrypt_into(
+        &self,
+        page_id: PageId,
+        epoch: u64,
+        encrypted: &[u8],
+        out: &mut [u8],
+    ) -> Result<usize> {
+        match &self.inner {
+            CipherImpl::Plaintext => {
+                if out.len() < encrypted.len() {
+                    return Err(MuroError::Decryption);
+                }
+                out[..encrypted.len()].copy_from_slice(encrypted);
+                Ok(encrypted.len())
+            }
+            CipherImpl::Aead(c) => c.decrypt_into(page_id, epoch, encrypted, out),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add pluggable encryption abstraction (`EncryptionSuite` / `PageCipher`) with `aes256-gcm-siv` and `plaintext` implementations
- add explicit plaintext mode across Pager/Database/WAL and CLI `--encryption <aes256-gcm-siv|off>`
- record suite id in v4 headers for newly created databases and enforce deterministic wrong-suite errors
- keep legacy header layouts/page offsets for existing v1/v2/v3 DBs to avoid offset corruption regressions
- update docs and roadmap phase 9 checkboxes

## Validation
- `cargo test -q --test format_migration`
- `cargo test -q`

## Notes
- This includes the follow-up fix for the v3 non-empty DB offset regression by preserving per-file header size/version during open+flush.
