### PR TITLE
storage: drop pre-v4 database format support

### DIFF
--- a/docs-site/src/internals/format-migration.md
+++ b/docs-site/src/internals/format-migration.md
@@ -1,68 +1,38 @@
 # Format Migration
 
-## Format Versions
+## Current Policy (as of 2026-02-22)
 
-### Version 1 (Legacy)
+MuroDB supports **database format v4 only**.
 
-Header layout:
+- Opening v4 works.
+- Opening v1/v2/v3 is rejected.
+- Opening future versions (>v4) is also rejected.
+
+This project currently has no production users on pre-v4 formats, so compatibility-migration code is intentionally removed to keep core storage logic simple and safer.
+
+## v4 Header Layout
+
 ```
 Magic (8B) + Version (4B) + Salt (16B) + CatalogRoot (8B)
-+ PageCount (8B) + Epoch (8B)
++ PageCount (8B) + Epoch (8B) + FreelistPageId (8B)
++ NextTxId (8B) + EncryptionSuiteId (4B) + CRC32 (4B)
 ```
 
-- No freelist page ID field
-- No header CRC32
+- Header size: 76 bytes
+- CRC32 covers bytes `0..72`
 
-### Version 2 (Current)
+## Rejection Behavior
 
-Header layout:
-```
-Magic (8B) + Version (4B) + Salt (16B) + CatalogRoot (8B)
-+ PageCount (8B) + Epoch (8B) + FreelistPageId (8B) + CRC32 (4B)
-```
+Opening an unsupported version returns:
 
-- Added freelist page ID for persistent freelist storage
-- Added CRC32 over bytes 0..60 for header corruption detection
-
-## Auto-Migration: v1 to v2
-
-When MuroDB opens a database file with format version 1:
-
-1. The header is read using v1 layout rules (no CRC validation)
-2. `freelist_page_id` defaults to 0 (no persisted freelist)
-3. The header is immediately rewritten as v2 with CRC32
-4. The file is fsynced to ensure the upgrade is durable
-
-This is a safe, non-destructive upgrade: v1 databases have no freelist page, so defaulting to 0 preserves correctness.
-
-## Forward Incompatibility Policy
-
-MuroDB **rejects** database files with a format version higher than the current `FORMAT_VERSION`. This prevents data corruption from attempting to read formats that require features not yet implemented.
-
-Opening a database with an unsupported future version returns:
 ```
 WAL error: unsupported database format version N
 ```
-
-Users must upgrade their MuroDB binary to open databases created by newer versions.
-
-## Freelist Multi-Page Chain (v2)
-
-In format version 2, the freelist may span multiple pages linked as a chain:
-
-```
-[magic "FLMP": 4B] [next_freelist_page_id: u64] [count_in_this_page: u64] [page_id entries: u64...]
-```
-
-- `next_freelist_page_id = 0` indicates end of chain
-- Each page holds up to `ENTRIES_PER_FREELIST_PAGE` entries
-- The header's `freelist_page_id` points to the first page in the chain
-- For backward compatibility, pages without `FLMP` magic are treated as legacy single-page freelist format (`[count:u64][entries...]`)
 
 ## WAL Format Version History
 
 | Version | Changes |
 |---|---|
 | v1 | Initial: Begin, PagePut, MetaUpdate(catalog_root, page_count), Commit, Abort |
-| v2 | MetaUpdate adds `freelist_page_id` field. Data file header adds CRC32. Legacy v1 MetaUpdate (25 bytes) decoded with `freelist_page_id=0` (backward compatible) |
+| v2 | MetaUpdate adds `freelist_page_id` field. Legacy v1 MetaUpdate (25 bytes) decoded with `freelist_page_id=0` (backward compatible) |
 | v3 | MetaUpdate adds `epoch` field. Legacy v1/v2 MetaUpdate records decode with `epoch=0` (backward compatible) |

--- a/tests/format_migration.rs
+++ b/tests/format_migration.rs
@@ -1,7 +1,6 @@
-/// Tests for database format version migration policy.
-use murodb::crypto::aead::{MasterKey, PageCrypto};
+/// Tests for database format validation policy (v4-only).
+use murodb::crypto::aead::MasterKey;
 use murodb::crypto::suite::EncryptionSuite;
-use murodb::storage::page::Page;
 use murodb::storage::pager::Pager;
 use murodb::wal::record::crc32;
 use std::io::{Seek, SeekFrom, Write};
@@ -11,164 +10,6 @@ fn test_key() -> MasterKey {
     MasterKey::new([0x42u8; 32])
 }
 
-/// Helper: write a raw v1 header (no CRC, no freelist_page_id).
-fn write_v1_header(
-    path: &std::path::Path,
-    salt: [u8; 16],
-    catalog_root: u64,
-    page_count: u64,
-    epoch: u64,
-) {
-    let mut header = [0u8; 64];
-    header[0..8].copy_from_slice(b"MURODB01");
-    header[8..12].copy_from_slice(&1u32.to_le_bytes()); // version 1
-    header[12..28].copy_from_slice(&salt);
-    header[28..36].copy_from_slice(&catalog_root.to_le_bytes());
-    header[36..44].copy_from_slice(&page_count.to_le_bytes());
-    header[44..52].copy_from_slice(&epoch.to_le_bytes());
-    // bytes 52..64 are zero (no freelist_page_id, no CRC in v1)
-
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .open(path)
-        .unwrap();
-    file.write_all(&header).unwrap();
-    file.sync_all().unwrap();
-}
-
-/// Helper: read the raw header bytes from a file.
-fn read_raw_header(path: &std::path::Path) -> Vec<u8> {
-    use std::io::Read;
-    let mut file = std::fs::File::open(path).unwrap();
-    let mut bytes = Vec::new();
-    file.read_to_end(&mut bytes).unwrap();
-    bytes
-}
-
-#[test]
-fn test_v1_header_is_preserved() {
-    let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("test.db");
-
-    // Write a v1 header with page_count=0 (no pages needed for key verification)
-    write_v1_header(&db_path, [0u8; 16], 0, 0, 0);
-
-    // Open should succeed without changing header format/size.
-    {
-        let _pager = Pager::open(&db_path, &test_key()).unwrap();
-    }
-
-    // Verify v1 header format is preserved.
-    let header = read_raw_header(&db_path);
-    assert_eq!(header.len(), 64);
-    let version = u32::from_le_bytes(header[8..12].try_into().unwrap());
-    assert_eq!(version, 1, "v1 header version should be preserved");
-
-    // Reopen should succeed without issues
-    {
-        let _pager = Pager::open(&db_path, &test_key()).unwrap();
-    }
-}
-
-#[test]
-fn test_future_version_rejected() {
-    let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("test.db");
-
-    // Write a header with version=99
-    let mut header = [0u8; 76];
-    header[0..8].copy_from_slice(b"MURODB01");
-    header[8..12].copy_from_slice(&99u32.to_le_bytes());
-
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .read(true)
-        .open(&db_path)
-        .unwrap();
-    file.write_all(&header).unwrap();
-    file.sync_all().unwrap();
-
-    let result = Pager::open(&db_path, &test_key());
-    match result {
-        Err(e) => {
-            let err_msg = format!("{}", e);
-            assert!(
-                err_msg.contains("unsupported database format version 99"),
-                "error should mention version: {}",
-                err_msg
-            );
-        }
-        Ok(_) => panic!("future version should be rejected"),
-    }
-}
-
-#[test]
-fn test_v4_roundtrip() {
-    let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("test.db");
-
-    // Create a v4 database with some metadata
-    {
-        let mut pager = Pager::create(&db_path, &test_key()).unwrap();
-        pager.set_catalog_root(42);
-        pager.flush_meta().unwrap();
-    }
-
-    // Reopen and verify all fields preserved
-    {
-        let pager = Pager::open(&db_path, &test_key()).unwrap();
-        assert_eq!(pager.catalog_root(), 42);
-        assert_eq!(pager.page_count(), 0);
-    }
-
-    // Verify header is v4
-    let header = read_raw_header(&db_path);
-    let version = u32::from_le_bytes(header[8..12].try_into().unwrap());
-    assert_eq!(version, 4);
-
-    // Verify CRC is valid (v4: CRC over 0..72 at offset 72..76)
-    let stored_crc = u32::from_le_bytes(header[72..76].try_into().unwrap());
-    let computed_crc = murodb::wal::record::crc32(&header[0..72]);
-    assert_eq!(stored_crc, computed_crc);
-    let suite_id = u32::from_le_bytes(header[68..72].try_into().unwrap());
-    assert_eq!(suite_id, EncryptionSuite::Aes256GcmSiv.id());
-}
-
-/// Helper: write a raw v2 header (with freelist_page_id and CRC over 0..60).
-fn write_v2_header(
-    path: &std::path::Path,
-    salt: [u8; 16],
-    catalog_root: u64,
-    page_count: u64,
-    epoch: u64,
-    freelist_page_id: u64,
-) {
-    let mut header = [0u8; 64];
-    header[0..8].copy_from_slice(b"MURODB01");
-    header[8..12].copy_from_slice(&2u32.to_le_bytes()); // version 2
-    header[12..28].copy_from_slice(&salt);
-    header[28..36].copy_from_slice(&catalog_root.to_le_bytes());
-    header[36..44].copy_from_slice(&page_count.to_le_bytes());
-    header[44..52].copy_from_slice(&epoch.to_le_bytes());
-    header[52..60].copy_from_slice(&freelist_page_id.to_le_bytes());
-    let checksum = crc32(&header[0..60]);
-    header[60..64].copy_from_slice(&checksum.to_le_bytes());
-
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .open(path)
-        .unwrap();
-    file.write_all(&header).unwrap();
-    file.sync_all().unwrap();
-}
-
-/// Helper: write raw bytes to a file (truncating any existing content).
 fn write_raw(path: &std::path::Path, data: &[u8]) {
     let mut file = std::fs::OpenOptions::new()
         .create(true)
@@ -180,61 +21,104 @@ fn write_raw(path: &std::path::Path, data: &[u8]) {
     file.sync_all().unwrap();
 }
 
-// ── Crash-interruption tests for header format auto-migration ──
+fn read_raw_header_v4(path: &std::path::Path) -> [u8; 76] {
+    let mut file = std::fs::File::open(path).unwrap();
+    let mut header = [0u8; 76];
+    use std::io::Read;
+    file.read_exact(&mut header).unwrap();
+    header
+}
 
 #[test]
-fn test_v2_header_is_preserved() {
+fn test_v4_roundtrip() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
 
-    write_v2_header(&db_path, [0u8; 16], 0, 0, 0, 0);
-
     {
-        let _pager = Pager::open(&db_path, &test_key()).unwrap();
+        let mut pager = Pager::create(&db_path, &test_key()).unwrap();
+        pager.set_catalog_root(42);
+        pager.flush_meta().unwrap();
     }
 
-    let header = read_raw_header(&db_path);
-    assert_eq!(header.len(), 64);
-    let version = u32::from_le_bytes(header[8..12].try_into().unwrap());
-    assert_eq!(version, 2, "v2 header version should be preserved");
+    {
+        let pager = Pager::open(&db_path, &test_key()).unwrap();
+        assert_eq!(pager.catalog_root(), 42);
+        assert_eq!(pager.page_count(), 0);
+    }
 
-    let stored_crc = u32::from_le_bytes(header[60..64].try_into().unwrap());
-    let computed_crc = crc32(&header[0..60]);
+    let header = read_raw_header_v4(&db_path);
+    let version = u32::from_le_bytes(header[8..12].try_into().unwrap());
+    assert_eq!(version, 4);
+    let suite_id = u32::from_le_bytes(header[68..72].try_into().unwrap());
+    assert_eq!(suite_id, EncryptionSuite::Aes256GcmSiv.id());
+    let stored_crc = u32::from_le_bytes(header[72..76].try_into().unwrap());
+    let computed_crc = crc32(&header[0..72]);
     assert_eq!(stored_crc, computed_crc);
 }
 
 #[test]
-fn test_v2_header_crc_mismatch_rejected() {
+fn test_future_version_rejected() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
 
-    write_v2_header(&db_path, [0u8; 16], 0, 0, 0, 0);
-
-    // Corrupt a field covered by the v2 CRC
-    {
-        let mut file = std::fs::OpenOptions::new()
-            .write(true)
-            .open(&db_path)
-            .unwrap();
-        file.seek(SeekFrom::Start(28)).unwrap();
-        file.write_all(&99u64.to_le_bytes()).unwrap(); // corrupt catalog_root
-        file.sync_all().unwrap();
-    }
+    let mut header = [0u8; 76];
+    header[0..8].copy_from_slice(b"MURODB01");
+    header[8..12].copy_from_slice(&99u32.to_le_bytes());
+    write_raw(&db_path, &header);
 
     let result = Pager::open(&db_path, &test_key());
     assert!(result.is_err());
-    let err = format!(
+    let msg = format!(
         "{}",
         match result {
             Err(e) => e,
             Ok(_) => panic!("expected error"),
         }
     );
-    assert!(
-        err.contains("header corrupted"),
-        "v2 CRC mismatch should report corruption, got: {}",
-        err
-    );
+    assert!(msg.contains("unsupported database format version 99"));
+}
+
+#[test]
+fn test_pre_v4_rejected() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+
+    for version in [1u32, 2u32, 3u32] {
+        let mut header = [0u8; 76];
+        header[0..8].copy_from_slice(b"MURODB01");
+        header[8..12].copy_from_slice(&version.to_le_bytes());
+        write_raw(&db_path, &header);
+
+        let result = Pager::open(&db_path, &test_key());
+        assert!(result.is_err());
+        let msg = format!(
+            "{}",
+            match result {
+                Err(e) => e,
+                Ok(_) => panic!("expected error"),
+            }
+        );
+        assert!(
+            msg.contains(&format!("unsupported database format version {}", version)),
+            "unexpected error for version {}: {}",
+            version,
+            msg
+        );
+    }
+}
+
+#[test]
+fn test_truncated_header_rejected() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+
+    let mut header = [0u8; 12];
+    header[0..8].copy_from_slice(b"MURODB01");
+    header[8..12].copy_from_slice(&4u32.to_le_bytes());
+    write_raw(&db_path, &header);
+
+    let result = Pager::open(&db_path, &test_key());
+    assert!(result.is_err());
 }
 
 #[test]
@@ -248,7 +132,6 @@ fn test_v4_header_crc_mismatch_rejected() {
         pager.flush_meta().unwrap();
     }
 
-    // Corrupt catalog_root field (offset 28)
     {
         let mut file = std::fs::OpenOptions::new()
             .write(true)
@@ -261,116 +144,18 @@ fn test_v4_header_crc_mismatch_rejected() {
 
     let result = Pager::open(&db_path, &test_key());
     assert!(result.is_err());
-    let err = format!(
+    let msg = format!(
         "{}",
         match result {
             Err(e) => e,
             Ok(_) => panic!("expected error"),
         }
     );
-    assert!(
-        err.contains("header corrupted"),
-        "v4 CRC mismatch should report corruption, got: {}",
-        err
-    );
+    assert!(msg.contains("header corrupted"));
 }
 
-/// Simulates a crash during v1→v3 upgrade where the version field was
-/// updated to 3 but the CRC was not yet written (torn write: only first
-/// 68 bytes persisted, CRC at 68..72 is still zero from file extend).
 #[test]
-fn test_torn_v1_to_v3_upgrade_version_written_crc_missing() {
-    let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("test.db");
-
-    // Start with a valid v1 header (64 bytes)
-    write_v1_header(&db_path, [0u8; 16], 0, 0, 0);
-
-    // Simulate a torn v3 upgrade: rewrite as v3 but only 68 bytes (no CRC)
-    let mut header = [0u8; 72];
-    header[0..8].copy_from_slice(b"MURODB01");
-    header[8..12].copy_from_slice(&3u32.to_le_bytes()); // version 3
-                                                        // salt, catalog_root, page_count, epoch, freelist_page_id, next_txid = 0
-                                                        // CRC at 68..72 is zero — does NOT match crc32(header[0..68])
-    write_raw(&db_path, &header);
-
-    let result = Pager::open(&db_path, &test_key());
-    assert!(result.is_err());
-    let err = format!(
-        "{}",
-        match result {
-            Err(e) => e,
-            Ok(_) => panic!("expected error"),
-        }
-    );
-    assert!(
-        err.contains("header corrupted"),
-        "torn v1→v3 upgrade with zero CRC should be detected, got: {}",
-        err
-    );
-}
-
-/// Simulates a crash during v2→v3 upgrade where the header was partially
-/// extended: version changed to 3 but CRC at the new offset (68..72)
-/// is still zero/stale.
-#[test]
-fn test_torn_v2_to_v3_upgrade_detected() {
-    let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("test.db");
-
-    // Write a valid v2 header
-    write_v2_header(&db_path, [0u8; 16], 42, 5, 1, 3);
-
-    // Simulate torn upgrade: rewrite with version=3 but keep v2 CRC at
-    // wrong offset (60..64) and zeros at v3 CRC offset (68..72).
-    {
-        let mut file = std::fs::OpenOptions::new()
-            .write(true)
-            .open(&db_path)
-            .unwrap();
-        // Change version to 3
-        file.seek(SeekFrom::Start(8)).unwrap();
-        file.write_all(&3u32.to_le_bytes()).unwrap();
-        // Extend file to 72 bytes (next_txid + CRC = zeros)
-        file.set_len(72).unwrap();
-        file.sync_all().unwrap();
-    }
-
-    let result = Pager::open(&db_path, &test_key());
-    assert!(result.is_err());
-    let err = format!(
-        "{}",
-        match result {
-            Err(e) => e,
-            Ok(_) => panic!("expected error"),
-        }
-    );
-    assert!(
-        err.contains("header corrupted"),
-        "torn v2→v3 upgrade should be detected by CRC, got: {}",
-        err
-    );
-}
-
-/// Header shorter than 64 bytes should fail immediately.
-#[test]
-fn test_truncated_header_too_short() {
-    let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("test.db");
-
-    // Write only the magic + version (12 bytes)
-    let mut header = [0u8; 12];
-    header[0..8].copy_from_slice(b"MURODB01");
-    header[8..12].copy_from_slice(&1u32.to_le_bytes());
-    write_raw(&db_path, &header);
-
-    let result = Pager::open(&db_path, &test_key());
-    assert!(result.is_err(), "header < 64 bytes should fail");
-}
-
-/// v3 header with corrupted next_txid field should fail CRC check.
-#[test]
-fn test_v3_next_txid_corruption_detected() {
+fn test_unknown_suite_id_rejected() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
 
@@ -379,203 +164,32 @@ fn test_v3_next_txid_corruption_detected() {
         pager.flush_meta().unwrap();
     }
 
-    // Corrupt next_txid at offset 60
     {
         let mut file = std::fs::OpenOptions::new()
+            .read(true)
             .write(true)
             .open(&db_path)
             .unwrap();
-        file.seek(SeekFrom::Start(60)).unwrap();
-        file.write_all(&0xBADCAFEu64.to_le_bytes()).unwrap();
+        file.seek(SeekFrom::Start(68)).unwrap();
+        file.write_all(&999u32.to_le_bytes()).unwrap();
+        file.seek(SeekFrom::Start(0)).unwrap();
+        let mut header = [0u8; 76];
+        use std::io::Read;
+        file.read_exact(&mut header).unwrap();
+        let checksum = crc32(&header[0..72]);
+        file.seek(SeekFrom::Start(72)).unwrap();
+        file.write_all(&checksum.to_le_bytes()).unwrap();
         file.sync_all().unwrap();
     }
 
     let result = Pager::open(&db_path, &test_key());
     assert!(result.is_err());
-    let err = format!(
+    let msg = format!(
         "{}",
         match result {
             Err(e) => e,
             Ok(_) => panic!("expected error"),
         }
     );
-    assert!(
-        err.contains("header corrupted"),
-        "corrupted next_txid should fail CRC, got: {}",
-        err
-    );
-}
-
-/// Simulates crash during v1→v3 upgrade that left file at exactly 64 bytes
-/// (original v1 size) but version was changed to 3. The file is too short
-/// for a valid v3 header (needs 72 bytes), so read falls back to reading
-/// 64 bytes with zeros for 64..72 → CRC mismatch.
-#[test]
-fn test_v1_to_v3_upgrade_file_not_extended() {
-    let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("test.db");
-
-    // Write a 64-byte header with version=3 (simulating version byte
-    // written but file not extended to 72 bytes)
-    let mut header = [0u8; 64];
-    header[0..8].copy_from_slice(b"MURODB01");
-    header[8..12].copy_from_slice(&3u32.to_le_bytes());
-    write_raw(&db_path, &header);
-
-    // read_plaintext_header reads 72 bytes but only gets 64 → bytes_read=64 ≥ 64,
-    // version=3 branch reads CRC at 68..72 from the zero-filled buffer → CRC mismatch
-    let result = Pager::open(&db_path, &test_key());
-    assert!(result.is_err());
-    let err = format!(
-        "{}",
-        match result {
-            Err(e) => e,
-            Ok(_) => panic!("expected error"),
-        }
-    );
-    assert!(
-        err.contains("header corrupted"),
-        "64-byte file claiming v3 should fail CRC, got: {}",
-        err
-    );
-}
-
-/// Successful v1→v4 upgrade followed by reopen proves deterministic behavior.
-#[test]
-fn test_v1_upgrade_then_reopen_is_deterministic() {
-    let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("test.db");
-
-    write_v1_header(&db_path, [0u8; 16], 10, 0, 0);
-
-    // First open: auto-upgrades v1→v4
-    {
-        let pager = Pager::open(&db_path, &test_key()).unwrap();
-        assert_eq!(pager.catalog_root(), 10);
-    }
-
-    // Second open: should work with v4 header
-    {
-        let pager = Pager::open(&db_path, &test_key()).unwrap();
-        assert_eq!(pager.catalog_root(), 10);
-    }
-
-    // Third open: still deterministic
-    {
-        let pager = Pager::open(&db_path, &test_key()).unwrap();
-        assert_eq!(pager.catalog_root(), 10);
-    }
-}
-
-/// Successful v2 open preserves metadata fields.
-#[test]
-fn test_v2_upgrade_preserves_metadata() {
-    let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("test.db");
-
-    write_v2_header(&db_path, [0u8; 16], 7, 0, 0, 0);
-
-    {
-        let pager = Pager::open(&db_path, &test_key()).unwrap();
-        assert_eq!(pager.catalog_root(), 7);
-        assert_eq!(pager.freelist_page_id(), 0);
-    }
-
-    // Verify v2 header and fields are preserved in raw header
-    let header = read_raw_header(&db_path);
-    assert_eq!(header.len(), 64);
-    let version = u32::from_le_bytes(header[8..12].try_into().unwrap());
-    assert_eq!(version, 2);
-    let catalog_root = u64::from_le_bytes(header[28..36].try_into().unwrap());
-    assert_eq!(catalog_root, 7);
-    let fl_pid = u64::from_le_bytes(header[52..60].try_into().unwrap());
-    assert_eq!(fl_pid, 0);
-    // v2 CRC is valid
-    let stored_crc = u32::from_le_bytes(header[60..64].try_into().unwrap());
-    let computed_crc = crc32(&header[0..60]);
-    assert_eq!(stored_crc, computed_crc);
-}
-
-/// v2 header with corrupted freelist_page_id field should fail CRC.
-#[test]
-fn test_v2_freelist_page_id_corruption_detected() {
-    let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("test.db");
-
-    write_v2_header(&db_path, [0u8; 16], 0, 0, 0, 0);
-
-    // Corrupt freelist_page_id at offset 52
-    {
-        let mut file = std::fs::OpenOptions::new()
-            .write(true)
-            .open(&db_path)
-            .unwrap();
-        file.seek(SeekFrom::Start(52)).unwrap();
-        file.write_all(&999u64.to_le_bytes()).unwrap();
-        file.sync_all().unwrap();
-    }
-
-    let result = Pager::open(&db_path, &test_key());
-    assert!(result.is_err());
-    let err = format!(
-        "{}",
-        match result {
-            Err(e) => e,
-            Ok(_) => panic!("expected error"),
-        }
-    );
-    assert!(
-        err.contains("header corrupted"),
-        "corrupted v2 freelist_page_id should fail CRC, got: {}",
-        err
-    );
-}
-
-#[test]
-fn test_v3_non_empty_db_preserves_page_offsets_on_open_and_flush() {
-    let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("test_v3_non_empty.db");
-    let key = test_key();
-    let crypto = PageCrypto::new(&key);
-
-    // Build a valid v3 header (72 bytes).
-    let mut header = [0u8; 72];
-    header[0..8].copy_from_slice(b"MURODB01");
-    header[8..12].copy_from_slice(&3u32.to_le_bytes());
-    header[28..36].copy_from_slice(&0u64.to_le_bytes()); // catalog_root
-    header[36..44].copy_from_slice(&1u64.to_le_bytes()); // page_count
-    header[44..52].copy_from_slice(&0u64.to_le_bytes()); // epoch
-    header[52..60].copy_from_slice(&0u64.to_le_bytes()); // freelist_page_id
-    header[60..68].copy_from_slice(&1u64.to_le_bytes()); // next_txid
-    let header_crc = crc32(&header[0..68]);
-    header[68..72].copy_from_slice(&header_crc.to_le_bytes());
-
-    let page0 = Page::new(0);
-    let encrypted_page0 = crypto.encrypt(0, 0, page0.as_bytes()).unwrap();
-    assert_eq!(encrypted_page0.len(), 4124);
-
-    let mut f = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .open(&db_path)
-        .unwrap();
-    f.write_all(&header).unwrap();
-    f.write_all(&encrypted_page0).unwrap();
-    f.sync_all().unwrap();
-
-    // Open + flush must not rewrite to a larger header that shifts page offsets.
-    {
-        let mut pager = Pager::open(&db_path, &key).unwrap();
-        let p0 = pager.read_page(0).unwrap();
-        assert_eq!(p0.page_id(), 0);
-        pager.flush_meta().unwrap();
-    }
-
-    // Reopen and read page0 again; should still decrypt correctly.
-    {
-        let mut pager = Pager::open(&db_path, &key).unwrap();
-        let p0 = pager.read_page(0).unwrap();
-        assert_eq!(p0.page_id(), 0);
-    }
+    assert!(msg.contains("unsupported encryption suite id 999"));
 }


### PR DESCRIPTION
## Summary
- remove database format compatibility paths for v1/v2/v3
- enforce v4-only header support in `Pager` (reject `version != 4`)
- simplify header read/write logic to fixed v4 layout (76-byte header, CRC over `0..72`)
- replace migration-heavy tests with v4-only validation tests
- update internals doc to reflect the v4-only policy

## Why
Current deployment policy is that no users depend on pre-v4 data files, so migration code is unnecessary complexity/risk.

## Validation
- `cargo test -q --test format_migration`
- `cargo test -q`
