### PR TITLE
docs: improve first-time onboarding and quick-start flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,22 @@
 
 Embedded SQL database written in Rust.
 
+## Why Try MuroDB
+
+- SQL-first workflow: create tables, insert rows, query immediately from CLI.
+- Safe-by-default storage: encrypted pages + WAL crash recovery.
+- Single-process simplicity: embed locally, no server setup required.
+- Built-in full-text search: bigram index + relevance scoring.
+
 ## Status
 
 MuroDB is under active development.
 
-- Core storage: encrypted pages + WAL crash recovery
-- Pluggable encryption suite: `aes256-gcm-siv` / `off` (plaintext)
-- SQL engine: practical subset for local/embedded use
-- Documentation: moved to `docs-site/`
+Current core capabilities:
+
+- Storage engine with WAL-based durability
+- Pluggable at-rest mode: `aes256-gcm-siv` (default) or explicit `off` (plaintext)
+- Practical SQL subset for local application use
 
 ## Install
 
@@ -17,23 +25,28 @@ MuroDB is under active development.
 cargo install --path .
 ```
 
-## Quick Start
+## Two-Minute Run
 
 ```bash
-# Create a database
-murodb mydb.db --create -e "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)"
+# 1) Create a database and table (password prompt appears in encrypted mode)
+murodb mydb.db --create -e "CREATE TABLE notes (id BIGINT PRIMARY KEY, title VARCHAR, body TEXT)"
 
-# Create a plaintext database (explicit opt-in)
-murodb mydb_plain.db --create --encryption off -e "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)"
+# 2) Insert rows
+murodb mydb.db -e "INSERT INTO notes (id, title, body) VALUES
+  (1, 'first', 'hello murodb'),
+  (2, 'todo', 'ship docs')"
 
-# Insert data
-murodb mydb.db -e "INSERT INTO t (id, name) VALUES (1, 'hello')"
+# 3) Query rows
+murodb mydb.db -e "SELECT id, title FROM notes ORDER BY id"
 
-# Query
-murodb mydb.db -e "SELECT * FROM t"
-
-# Interactive REPL
+# 4) Open REPL
 murodb mydb.db
+```
+
+If you need plaintext mode, opt in explicitly:
+
+```bash
+murodb mydb_plain.db --create --encryption off -e "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)"
 ```
 
 ## Documentation
@@ -47,12 +60,13 @@ The detailed manual and internals docs are in `docs-site/`.
 mdbook build docs-site
 ```
 
-Main entry points:
+Recommended reading order:
 
+- `docs-site/src/getting-started/first-session.md`
 - `docs-site/src/getting-started/quick-start.md`
 - `docs-site/src/user-guide/sql-reference.md`
+- `docs-site/src/user-guide/full-text-search.md`
 - `docs-site/src/user-guide/recovery.md`
-- `docs-site/src/internals/architecture.md`
 
 ## API Notes
 

--- a/docs-site/src/SUMMARY.md
+++ b/docs-site/src/SUMMARY.md
@@ -5,6 +5,7 @@
 # Getting Started
 
 - [Installation](getting-started/installation.md)
+- [First Session (10 Minutes)](getting-started/first-session.md)
 - [Quick Start](getting-started/quick-start.md)
 
 # User Guide

--- a/docs-site/src/getting-started/first-session.md
+++ b/docs-site/src/getting-started/first-session.md
@@ -1,0 +1,65 @@
+# First Session (10 Minutes)
+
+This page is a fast path for SQL users who want to feel MuroDB before reading full details.
+
+## 1. Install
+
+```bash
+cargo install --path .
+```
+
+## 2. Create a database and schema
+
+```bash
+murodb demo.db --create -e "CREATE TABLE notes (
+  id BIGINT PRIMARY KEY,
+  title VARCHAR NOT NULL,
+  body TEXT
+)"
+```
+
+Encrypted mode prompts for a password by default.
+
+If you need plaintext mode, opt in explicitly:
+
+```bash
+murodb demo-plain.db --create --encryption off -e "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)"
+```
+
+## 3. Insert and query rows
+
+```bash
+murodb demo.db -e "INSERT INTO notes (id, title, body) VALUES
+  (1, 'welcome', 'hello from murodb'),
+  (2, 'next', 'test full text search')"
+
+murodb demo.db -e "SELECT id, title FROM notes ORDER BY id"
+```
+
+## 4. Add full-text search
+
+```bash
+murodb demo.db -e "CREATE FULLTEXT INDEX notes_body_fts ON notes(body)
+  WITH PARSER ngram
+  OPTIONS (n=2, normalize='nfkc', stop_filter=off, stop_df_ratio_ppm=200000)"
+
+murodb demo.db -e "SELECT id,
+  MATCH(body) AGAINST('full text' IN NATURAL LANGUAGE MODE) AS score
+FROM notes
+WHERE MATCH(body) AGAINST('full text' IN NATURAL LANGUAGE MODE) > 0
+ORDER BY score DESC"
+```
+
+## 5. Open interactive REPL
+
+```bash
+murodb demo.db
+```
+
+Start without `-e` to enter REPL mode.
+
+## Next
+
+- [Quick Start](quick-start.md) for concise command examples.
+- [SQL Reference](../user-guide/sql-reference.md) for statement details.
+- [Recovery](../user-guide/recovery.md) for durability and incident handling.

--- a/docs-site/src/getting-started/quick-start.md
+++ b/docs-site/src/getting-started/quick-start.md
@@ -1,6 +1,9 @@
 # Quick Start
 
-## Create a new database
+This page is a concise command reference.  
+For a guided first run, see [First Session (10 Minutes)](first-session.md).
+
+## Create a database
 
 ```bash
 murodb mydb.db --create -e "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)"
@@ -14,22 +17,28 @@ If you need plaintext mode, opt in explicitly:
 murodb mydb_plain.db --create --encryption off -e "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)"
 ```
 
-## Insert data
+## Insert rows
 
 ```bash
-murodb mydb.db -e "INSERT INTO t (id, name) VALUES (1, 'hello')"
+murodb mydb.db -e "INSERT INTO t (id, name) VALUES (1, 'hello'), (2, 'world')"
 ```
 
-## Query data
+## Query rows
 
 ```bash
-murodb mydb.db -e "SELECT * FROM t"
+murodb mydb.db -e "SELECT id, name FROM t ORDER BY id"
 ```
 
 ## Show tables
 
 ```bash
 murodb mydb.db -e "SHOW TABLES"
+```
+
+## Run with JSON output
+
+```bash
+murodb mydb.db --format json -e "SELECT id, name FROM t ORDER BY id"
 ```
 
 ## Interactive REPL

--- a/docs-site/src/introduction.md
+++ b/docs-site/src/introduction.md
@@ -1,55 +1,46 @@
 # MuroDB
 
-Embedded SQL database with B+Tree (no leaf links) + Full-Text Search (Bigram), written in Rust.
+MuroDB is an embedded SQL database written in Rust.
 
-## Features
+This documentation is designed for people who already know SQL and want to start building quickly.
 
-- **Pluggable at-rest mode** - `aes256-gcm-siv` (default) or explicit `off` plaintext mode
-- **B+tree storage (no leaf links)** - PRIMARY KEY (TINYINT/SMALLINT/INT/BIGINT), UNIQUE indexes (single column)
-- **Full-text search** - Bigram (n=2) with NFKC normalization
-  - MySQL-style `MATCH(col) AGAINST(...)` syntax
-  - NATURAL LANGUAGE MODE with BM25 scoring
-  - BOOLEAN MODE with `+term`, `-term`, `"phrase"` operators
-  - `fts_snippet()` for highlighted excerpts
-- **ACID transactions** - WAL-based crash recovery
-- **Concurrency** - Multiple readers / single writer (thread RwLock + process file lock)
-- **Single file** - Database file + WAL file
+## What You Can Do Quickly
 
-## Components
+- Create a local database file and start querying right away.
+- Keep data durable with WAL-based crash recovery.
+- Use encrypted-at-rest mode by default, or explicitly opt into plaintext mode.
+- Add full-text search with bigram tokenization and relevance scoring.
+
+If you want hands-on steps first, start here:
+
+1. [First Session (10 minutes)](getting-started/first-session.md)
+2. [Quick Start](getting-started/quick-start.md)
+3. [SQL Reference](user-guide/sql-reference.md)
+
+## Core Capabilities
+
+- **At-rest mode**: `aes256-gcm-siv` (default) or explicit `off` (plaintext)
+- **Storage engine**: B+tree, WAL, page cache, crash recovery
+- **Transactions**: ACID semantics
+- **Concurrency model**: multiple readers / single writer
+- **Full-text search**: `MATCH(...) AGAINST(...)`, NATURAL/BOOLEAN modes, `fts_snippet()`
+
+## Architecture Map
 
 | Component | Description |
 |---|---|
-| `crypto/` | AES-256-GCM-SIV page encryption, Argon2 KDF, HMAC-SHA256 term blinding |
-| `storage/` | 4096B slotted pages, pager with pluggable at-rest mode + LRU cache, freelist |
-| `btree/` | Insert/split, delete, search, scan, order-preserving key encoding |
-| `wal/` | WAL records (suite-aligned with DB mode), writer/reader, crash recovery |
-| `tx/` | Transaction with dirty page buffer, commit/rollback |
-| `schema/` | System catalog, table/index definitions |
-| `sql/` | Hand-written lexer/parser, AST, rule-based planner, executor |
-| `fts/` | Bigram tokenizer, delta+varint postings, BM25, NATURAL/BOOLEAN queries, snippets |
-| `concurrency/` | parking_lot RwLock + fs4 file lock |
-
-## Dependencies
-
-| Crate | Purpose |
-|---|---|
-| `aes-gcm-siv` | AEAD encryption |
-| `argon2` | Passphrase KDF |
-| `hmac` + `sha2` | FTS term ID blinding |
-| `nom` | SQL lexer |
-| `unicode-normalization` | NFKC normalization |
-| `parking_lot` | RwLock |
-| `fs4` | File lock |
-| `lru` | Page cache |
-| `rand` | Nonce generation |
-| `thiserror` | Error types |
+| `crypto/` | Page encryption, key derivation, and term-ID blinding |
+| `storage/` | Pager, slotted pages, cache, and freelist management |
+| `btree/` | Index/table structures, search, and mutation operations |
+| `wal/` | Write-ahead log, reader/writer, recovery flow |
+| `tx/` | Transaction lifecycle, dirty-page buffering, commit/rollback |
+| `schema/` | Catalog metadata for tables and indexes |
+| `sql/` | Lexer, parser, planner, executor, and session control |
+| `fts/` | Tokenizer, postings, BM25 scoring, snippets |
+| `concurrency/` | In-process and cross-process locking |
 
 ## Non-goals
 
 - Network server protocol
-- Full access-pattern obfuscation (ORAM, etc.)
+- Full access-pattern obfuscation
 - Stored procedures / triggers
-
-## License
-
-MIT License. See [LICENSE](https://github.com/tokuhirom/murodb/blob/main/LICENSE) for details.


### PR DESCRIPTION
## Summary
- rewrite README opening to emphasize immediate value and first-run experience
- add a new Getting Started page: First Session (10 Minutes)
- restructure introduction and quick-start pages to guide SQL-experienced users through a positive, product-neutral onboarding path
- wire the new page into docs-site/src/SUMMARY.md

## Validation
- mdbook build docs-site
