### PR TITLE
Improve CLI help verbosity and include docs URL

### DIFF
--- a/src/bin/murodb.rs
+++ b/src/bin/murodb.rs
@@ -39,32 +39,52 @@ impl From<RecoveryModeArg> for RecoveryMode {
 }
 
 #[derive(Parser)]
-#[command(name = "murodb", about = "MuroDB - Encrypted embedded SQL database")]
+#[command(
+    name = "murodb",
+    about = "MuroDB - Encrypted embedded SQL database",
+    long_about = "MuroDB command-line interface for creating, opening, and querying an encrypted embedded SQL database.\n\nPrimary modes:\n- REPL mode: run interactive SQL when no `-e` is provided.\n- One-shot mode: run a single SQL statement with `-e` and exit.\n- Create mode: initialize a new database file with `--create`.\n\nOutput behavior:\n- `--format text`: human-readable table output.\n- `--format json`: stable JSON envelope for programmatic parsing.\n\nEncryption behavior:\n- `--encryption aes256-gcm-siv` (default): requires password.\n- `--encryption off`: plaintext database file, no password needed.\n\nIf `--password` is omitted in encrypted mode, the CLI prompts on TTY.",
+    after_long_help = "Examples:\n  murodb my.db\n  murodb my.db -e \"SELECT 1\"\n  murodb my.db --format json -e \"SELECT id, name FROM users\"\n  murodb my.db --create --encryption aes256-gcm-siv\n  murodb my.db --recovery-mode permissive\n\nDocumentation:\n  https://tokuhirom.github.io/murodb/"
+)]
 struct Cli {
-    /// Path to the database file
+    /// Path to the database file.
+    ///
+    /// If omitted, defaults to `muro.db` in the current working directory.
     db_path: Option<PathBuf>,
 
-    /// Execute SQL and exit
+    /// Execute one SQL statement and exit (non-interactive mode).
+    ///
+    /// Example: `-e "SELECT * FROM t LIMIT 10"`.
     #[arg(short = 'e')]
     execute: Option<String>,
 
-    /// Create a new database
+    /// Create a new database file before opening.
+    ///
+    /// Fails if the target path already exists.
     #[arg(long)]
     create: bool,
 
-    /// Password (if omitted, will prompt)
+    /// Password used for key derivation in encrypted mode.
+    ///
+    /// If omitted and encryption is enabled, the CLI prompts on TTY.
     #[arg(long)]
     password: Option<String>,
 
-    /// Encryption mode (must match database mode on open)
+    /// Encryption mode used for create/open.
+    ///
+    /// Must match the existing database encryption mode when opening.
     #[arg(long, value_enum, default_value = "aes256-gcm-siv")]
     encryption: EncryptionModeArg,
 
-    /// WAL recovery behavior when opening existing DB
+    /// WAL recovery behavior used when opening an existing database.
+    ///
+    /// `strict` aborts on malformed WAL records.
+    /// `permissive` skips malformed records where recovery can continue.
     #[arg(long, value_enum, default_value = "strict")]
     recovery_mode: RecoveryModeArg,
 
-    /// Output format for query results
+    /// Output format for query results and errors.
+    ///
+    /// `text` is human-readable; `json` is intended for tool integration.
     #[arg(long, value_enum, default_value = "text")]
     format: OutputFormatArg,
 }

--- a/src/bin/murodb_bench.rs
+++ b/src/bin/murodb_bench.rs
@@ -10,45 +10,60 @@ use rand::{Rng, SeedableRng};
 #[derive(Parser, Debug)]
 #[command(
     name = "murodb-bench",
-    about = "Embedded DB benchmark for typical OLTP-style workloads"
+    about = "Embedded DB benchmark for typical OLTP-style workloads",
+    long_about = "Run deterministic micro-benchmarks against a temporary MuroDB database.\n\nThe benchmark currently covers:\n- point selects and updates on a primary-key table (`kv`)\n- batched inserts\n- range scans\n- mixed read/write workloads\n- full-text search (FTS) point-select/update/mixed workloads\n\nResults include throughput and latency percentiles (p50/p95/p99) per scenario.\n\nThis is intended for local performance profiling and regression checks.",
+    after_long_help = "Examples:\n  murodb_bench\n  murodb_bench --initial-rows 50000 --batch-size 1000\n  murodb_bench --select-ops 100000 --mixed-ops 50000\n\nDocumentation:\n  https://tokuhirom.github.io/murodb/"
 )]
 struct Cli {
+    /// Number of rows preloaded into `kv` before measurements.
     #[arg(long, default_value_t = 20_000, value_parser = value_parser!(u64).range(1..))]
     initial_rows: u64,
 
+    /// Number of rows preloaded into `docs_fts` before FTS measurements.
     #[arg(long, default_value_t = 256, value_parser = value_parser!(u64).range(1..))]
     fts_initial_rows: u64,
 
+    /// Number of primary-key point SELECT operations.
     #[arg(long, default_value_t = 20_000)]
     select_ops: u64,
 
+    /// Number of primary-key point UPDATE operations.
     #[arg(long, default_value_t = 5_000)]
     update_ops: u64,
 
+    /// Number of INSERT operations for expansion workload.
     #[arg(long, default_value_t = 5_000)]
     insert_ops: u64,
 
+    /// Number of range-scan operations.
     #[arg(long, default_value_t = 2_000)]
     scan_ops: u64,
 
+    /// Number of mixed read/write operations on `kv`.
     #[arg(long, default_value_t = 10_000)]
     mixed_ops: u64,
 
+    /// Number of FTS query operations.
     #[arg(long, default_value_t = 5_000)]
     fts_select_ops: u64,
 
+    /// Number of FTS update operations.
     #[arg(long, default_value_t = 2_000)]
     fts_update_ops: u64,
 
+    /// Number of mixed FTS read/write operations.
     #[arg(long, default_value_t = 5_000)]
     fts_mixed_ops: u64,
 
+    /// Number of warmup point-select operations before measurements.
     #[arg(long, default_value_t = 200)]
     warmup_ops: u64,
 
+    /// Transaction batch size for preload and parts of mixed workload.
     #[arg(long, default_value_t = 500, value_parser = value_parser!(u64).range(1..))]
     batch_size: u64,
 
+    /// Keep the temporary benchmark database file under `/tmp` after run.
     #[arg(long)]
     keep_db: bool,
 }

--- a/src/bin/murodb_wal_inspect.rs
+++ b/src/bin/murodb_wal_inspect.rs
@@ -34,24 +34,36 @@ impl From<RecoveryModeArg> for RecoveryMode {
 }
 
 #[derive(Parser)]
-#[command(name = "murodb-wal-inspect", about = "Inspect MuroDB WAL consistency")]
+#[command(
+    name = "murodb-wal-inspect",
+    about = "Inspect MuroDB WAL consistency",
+    long_about = "Inspect a MuroDB WAL file (or quarantine WAL file) without opening the database for normal SQL operations.\n\nThis command validates transaction boundaries and replay eligibility under a selected recovery policy.\n\nExit codes:\n- 0: inspection succeeded and no malformed transaction was skipped.\n- 10: inspection succeeded but malformed transaction(s) were skipped.\n- 20: fatal error (cannot inspect).",
+    after_long_help = "Examples:\n  murodb-wal-inspect my.db --wal my.db.wal\n  murodb-wal-inspect my.db --wal quarantine.wal --recovery-mode permissive\n  murodb-wal-inspect my.db --wal my.db.wal --format json\n\nDocumentation:\n  https://tokuhirom.github.io/murodb/"
+)]
 struct Cli {
-    /// Path to the database file
+    /// Path to the database file whose encryption metadata is used.
     db_path: PathBuf,
 
-    /// WAL file path (or quarantine file)
+    /// WAL file path (or quarantine WAL file) to inspect.
     #[arg(long, value_name = "PATH")]
     wal: PathBuf,
 
-    /// Password (if omitted, will prompt)
+    /// Password used to derive the database encryption key.
+    ///
+    /// If omitted, the CLI prompts on TTY.
     #[arg(long)]
     password: Option<String>,
 
-    /// WAL recovery behavior used during inspection
+    /// Recovery policy used by the WAL inspector.
+    ///
+    /// `strict` aborts on malformed data.
+    /// `permissive` reports and skips malformed transactions when possible.
     #[arg(long, value_enum, default_value = "strict")]
     recovery_mode: RecoveryModeArg,
 
-    /// Output format for inspection/reporting
+    /// Output format for the inspection report.
+    ///
+    /// `text` prints readable diagnostics; `json` emits machine-parseable output.
     #[arg(long, value_enum, default_value = "text")]
     format: OutputFormatArg,
 }


### PR DESCRIPTION
## Summary
- expand murodb CLI help with richer long descriptions and option guidance
- expand murodb-wal-inspect help with behavior details and exit code semantics
- expand murodb_bench help with benchmark scope and argument descriptions
- add documentation link to help output:
  - https://tokuhirom.github.io/murodb/

## Validation
- cargo check --bins
- verified --help output for murodb, murodb-wal-inspect, and murodb_bench
