### PR TITLE
test: add boundary value / edge case tests and limits documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ Internals deep dive:
 - `Database::query(sql)` is read-only (shared lock, rejects write SQL).
 - CLI auto-routes read-only SQL to the read path; inside explicit transactions it always uses execute semantics.
 
+## Limitations
+
+- A single row must fit within one 4,096-byte page (~4,048 bytes of user data). Row overflow is not supported.
+- See [Limits Reference](https://tokuhirom.github.io/murodb/user-guide/limits.html) for full details on data type ranges, column counts, and other limits.
+
 ## Repository Layout
 
 - `src/` - database implementation

--- a/docs-site/src/SUMMARY.md
+++ b/docs-site/src/SUMMARY.md
@@ -19,6 +19,7 @@
 - [Checkpoint Policy Tuning](user-guide/checkpoint-policy.md)
 - [Alerting & Monitoring](user-guide/alerting.md)
 - [Incident Response Runbook](user-guide/runbook.md)
+- [Limits Reference](user-guide/limits.md)
 
 # Internals
 

--- a/docs-site/src/user-guide/limits.md
+++ b/docs-site/src/user-guide/limits.md
@@ -1,0 +1,68 @@
+# Limits Reference
+
+This page documents the known limits of MuroDB. These limits arise from the fixed page size,
+serialization formats, and design decisions of the storage engine.
+
+## Page & Row Limits
+
+| Limit | Value | Notes |
+|---|---|---|
+| Page size | 4,096 bytes | Fixed; all data pages, B-tree nodes, and catalog entries use this size |
+| Page header | 14 bytes | page_id (8) + cell_count (2) + free_start (2) + free_end (2) |
+| Max row size | ~4,048 bytes | Depends on key size and column overhead; row overflow is not supported |
+| Max cell payload | ~4,078 bytes | 4,096 − 14 (header) − 2 (cell pointer) − 2 (cell length prefix) |
+
+Rows that exceed the page capacity will produce a **PageOverflow** error.
+MuroDB does not currently support row overflow pages; a single row must fit within one page.
+
+## Column Limits
+
+| Limit | Value | Notes |
+|---|---|---|
+| Max column count | 65,535 (u16) | Serialization limit; practical limit is lower due to page capacity |
+| Column name max length | 65,535 bytes (u16) | Limited in practice by catalog page capacity |
+| Table name max length | 65,535 bytes (u16) | Limited in practice by catalog page capacity |
+
+## Data Type Ranges
+
+| Type | Min | Max | Storage |
+|---|---|---|---|
+| TINYINT | −128 | 127 | 1 byte |
+| SMALLINT | −32,768 | 32,767 | 2 bytes |
+| INT | −2,147,483,648 | 2,147,483,647 | 4 bytes |
+| BIGINT | −2^63 | 2^63 − 1 | 8 bytes |
+| FLOAT | ±1.2×10^−38 | ±3.4×10^38 | 4 bytes (finite values only; NaN/Infinity rejected) |
+| DOUBLE | ±2.2×10^−308 | ±1.7×10^308 | 8 bytes (finite values only; NaN/Infinity rejected) |
+
+## String & Binary Limits
+
+| Limit | Value | Notes |
+|---|---|---|
+| VARCHAR(n) max n | 4,294,967,295 (u32) | Practical max is ~4,048 bytes due to page capacity |
+| VARBINARY(n) max n | 4,294,967,295 (u32) | Practical max is ~4,048 bytes due to page capacity |
+| TEXT max size | ~4,048 bytes | Same as VARCHAR; limited by page capacity |
+| VARCHAR(n) length check | Byte-based | `VARCHAR(100)` allows up to 100 *bytes*, not characters |
+
+> **Note:** MuroDB checks `VARCHAR(n)` against *byte length*, not character count.
+> This differs from MySQL, where `VARCHAR(n)` limits the number of *characters*.
+> Multi-byte UTF-8 characters (e.g., Japanese characters at 3 bytes each, emoji at 4 bytes)
+> consume multiple bytes of the VARCHAR(n) budget.
+
+## Internal Limits
+
+| Limit | Value | Notes |
+|---|---|---|
+| B-tree max depth | 64 | Exceeded depth indicates corruption |
+| WAL max frame length | 5,120 bytes | |
+| FTS inline segment limit | 3,000 bytes | Larger posting lists use overflow pages |
+| FTS max payload | 65,536 bytes | |
+| LRU cache default size | 256 pages | Configurable |
+
+## NULL Behavior
+
+- Primary key columns cannot be NULL
+- `NULL = NULL` evaluates to UNKNOWN (not TRUE); use `IS NULL` instead
+- Aggregate functions (SUM, AVG, MIN, MAX) skip NULL values
+- `COUNT(*)` counts all rows; `COUNT(column)` counts non-NULL values only
+- Multiple NULL values are allowed in UNIQUE indexes (SQL standard)
+- NULL values in ORDER BY are grouped together

--- a/tests/column_count_tests.rs
+++ b/tests/column_count_tests.rs
@@ -1,0 +1,222 @@
+use murodb::crypto::aead::MasterKey;
+use murodb::schema::catalog::SystemCatalog;
+use murodb::sql::executor::{execute, ExecResult};
+use murodb::storage::pager::Pager;
+use murodb::types::Value;
+use tempfile::TempDir;
+
+fn test_key() -> MasterKey {
+    MasterKey::new([0x42u8; 32])
+}
+
+fn setup() -> (Pager, SystemCatalog, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let mut pager = Pager::create(&db_path, &test_key()).unwrap();
+    let catalog = SystemCatalog::create(&mut pager).unwrap();
+    (pager, catalog, dir)
+}
+
+fn exec(pager: &mut Pager, catalog: &mut SystemCatalog, sql: &str) {
+    execute(sql, pager, catalog).unwrap();
+}
+
+fn query_rows(
+    pager: &mut Pager,
+    catalog: &mut SystemCatalog,
+    sql: &str,
+) -> Vec<murodb::sql::executor::Row> {
+    match execute(sql, pager, catalog).unwrap() {
+        ExecResult::Rows(rows) => rows,
+        other => panic!("Expected rows, got {:?}", other),
+    }
+}
+
+/// Single column (PK only).
+#[test]
+fn test_single_column() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY)",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1)");
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT id FROM t");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get("id"), Some(&Value::Integer(1)));
+}
+
+/// 100 columns: create, insert, and retrieve all.
+#[test]
+fn test_100_columns() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    let cols: Vec<String> = (0..100)
+        .map(|i| {
+            if i == 0 {
+                "c0 BIGINT PRIMARY KEY".to_string()
+            } else {
+                format!("c{} INT", i)
+            }
+        })
+        .collect();
+    let create_sql = format!("CREATE TABLE t ({})", cols.join(", "));
+    exec(&mut pager, &mut catalog, &create_sql);
+
+    let vals: Vec<String> = (0..100).map(|i| i.to_string()).collect();
+    let insert_sql = format!("INSERT INTO t VALUES ({})", vals.join(", "));
+    exec(&mut pager, &mut catalog, &insert_sql);
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT * FROM t");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get("c0"), Some(&Value::Integer(0)));
+    assert_eq!(rows[0].get("c99"), Some(&Value::Integer(99)));
+}
+
+/// NULL bitmap boundary: 8 nullable columns (exactly 1 byte bitmap).
+#[test]
+fn test_null_bitmap_8_columns() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    let mut cols = vec!["id BIGINT PRIMARY KEY".to_string()];
+    for i in 1..=8 {
+        cols.push(format!("c{} INT", i));
+    }
+    let create_sql = format!("CREATE TABLE t ({})", cols.join(", "));
+    exec(&mut pager, &mut catalog, &create_sql);
+
+    // Insert with alternating NULLs
+    exec(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (1, NULL, 2, NULL, 4, NULL, 6, NULL, 8)",
+    );
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT * FROM t WHERE id = 1");
+    assert_eq!(rows[0].get("c1"), Some(&Value::Null));
+    assert_eq!(rows[0].get("c2"), Some(&Value::Integer(2)));
+    assert_eq!(rows[0].get("c3"), Some(&Value::Null));
+    assert_eq!(rows[0].get("c4"), Some(&Value::Integer(4)));
+    assert_eq!(rows[0].get("c5"), Some(&Value::Null));
+    assert_eq!(rows[0].get("c6"), Some(&Value::Integer(6)));
+    assert_eq!(rows[0].get("c7"), Some(&Value::Null));
+    assert_eq!(rows[0].get("c8"), Some(&Value::Integer(8)));
+}
+
+/// NULL bitmap boundary: 9 nullable columns (crosses 1-byte boundary → 2 bytes).
+#[test]
+fn test_null_bitmap_9_columns() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    let mut cols = vec!["id BIGINT PRIMARY KEY".to_string()];
+    for i in 1..=9 {
+        cols.push(format!("c{} INT", i));
+    }
+    let create_sql = format!("CREATE TABLE t ({})", cols.join(", "));
+    exec(&mut pager, &mut catalog, &create_sql);
+
+    // Insert with last column NULL (tests the 9th bit)
+    let mut vals: Vec<String> = vec!["1".to_string()];
+    for i in 1..=8 {
+        vals.push(i.to_string());
+    }
+    vals.push("NULL".to_string());
+    let insert_sql = format!("INSERT INTO t VALUES ({})", vals.join(", "));
+    exec(&mut pager, &mut catalog, &insert_sql);
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT * FROM t WHERE id = 1");
+    assert_eq!(rows[0].get("c8"), Some(&Value::Integer(8)));
+    assert_eq!(rows[0].get("c9"), Some(&Value::Null));
+}
+
+/// NULL bitmap boundary: 16 columns (exactly 2 bytes bitmap).
+#[test]
+fn test_null_bitmap_16_columns() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    let mut cols = vec!["id BIGINT PRIMARY KEY".to_string()];
+    for i in 1..=16 {
+        cols.push(format!("c{} INT", i));
+    }
+    let create_sql = format!("CREATE TABLE t ({})", cols.join(", "));
+    exec(&mut pager, &mut catalog, &create_sql);
+
+    // All NULLs
+    let mut vals = vec!["1".to_string()];
+    for _ in 1..=16 {
+        vals.push("NULL".to_string());
+    }
+    let insert_sql = format!("INSERT INTO t VALUES ({})", vals.join(", "));
+    exec(&mut pager, &mut catalog, &insert_sql);
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT * FROM t WHERE id = 1");
+    for i in 1..=16 {
+        assert_eq!(
+            rows[0].get(&format!("c{}", i)),
+            Some(&Value::Null),
+            "c{} should be NULL",
+            i
+        );
+    }
+}
+
+/// 17 columns: crosses 2-byte bitmap boundary.
+#[test]
+fn test_null_bitmap_17_columns() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    let mut cols = vec!["id BIGINT PRIMARY KEY".to_string()];
+    for i in 1..=17 {
+        cols.push(format!("c{} INT", i));
+    }
+    let create_sql = format!("CREATE TABLE t ({})", cols.join(", "));
+    exec(&mut pager, &mut catalog, &create_sql);
+
+    // Only c17 is non-NULL
+    let mut vals = vec!["1".to_string()];
+    for _ in 1..=16 {
+        vals.push("NULL".to_string());
+    }
+    vals.push("42".to_string());
+    let insert_sql = format!("INSERT INTO t VALUES ({})", vals.join(", "));
+    exec(&mut pager, &mut catalog, &insert_sql);
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT * FROM t WHERE id = 1");
+    assert_eq!(rows[0].get("c16"), Some(&Value::Null));
+    assert_eq!(rows[0].get("c17"), Some(&Value::Integer(42)));
+}
+
+/// Large column count: all columns with values, verify round-trip.
+#[test]
+fn test_50_columns_all_values() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    let cols: Vec<String> = (0..50)
+        .map(|i| {
+            if i == 0 {
+                "c0 BIGINT PRIMARY KEY".to_string()
+            } else {
+                format!("c{} INT", i)
+            }
+        })
+        .collect();
+    let create_sql = format!("CREATE TABLE t ({})", cols.join(", "));
+    exec(&mut pager, &mut catalog, &create_sql);
+
+    let vals: Vec<String> = (0..50).map(|i| (i * 10).to_string()).collect();
+    let insert_sql = format!("INSERT INTO t VALUES ({})", vals.join(", "));
+    exec(&mut pager, &mut catalog, &insert_sql);
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT * FROM t");
+    assert_eq!(rows.len(), 1);
+    for i in 0..50 {
+        assert_eq!(
+            rows[0].get(&format!("c{}", i)),
+            Some(&Value::Integer(i as i64 * 10)),
+            "c{} mismatch",
+            i
+        );
+    }
+}

--- a/tests/empty_table_edge_tests.rs
+++ b/tests/empty_table_edge_tests.rs
@@ -1,0 +1,211 @@
+use murodb::crypto::aead::MasterKey;
+use murodb::schema::catalog::SystemCatalog;
+use murodb::sql::executor::{execute, ExecResult};
+use murodb::storage::pager::Pager;
+use murodb::types::Value;
+use tempfile::TempDir;
+
+fn test_key() -> MasterKey {
+    MasterKey::new([0x42u8; 32])
+}
+
+fn setup() -> (Pager, SystemCatalog, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let mut pager = Pager::create(&db_path, &test_key()).unwrap();
+    let catalog = SystemCatalog::create(&mut pager).unwrap();
+    (pager, catalog, dir)
+}
+
+fn exec(pager: &mut Pager, catalog: &mut SystemCatalog, sql: &str) {
+    execute(sql, pager, catalog).unwrap();
+}
+
+fn query_rows(
+    pager: &mut Pager,
+    catalog: &mut SystemCatalog,
+    sql: &str,
+) -> Vec<murodb::sql::executor::Row> {
+    match execute(sql, pager, catalog).unwrap() {
+        ExecResult::Rows(rows) => rows,
+        other => panic!("Expected rows, got {:?}", other),
+    }
+}
+
+fn exec_affected(pager: &mut Pager, catalog: &mut SystemCatalog, sql: &str) -> u64 {
+    match execute(sql, pager, catalog).unwrap() {
+        ExecResult::RowsAffected(n) => n,
+        other => panic!("Expected RowsAffected, got {:?}", other),
+    }
+}
+
+/// SELECT on empty table returns empty result set.
+#[test]
+fn test_select_empty_table() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val INT)",
+    );
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT * FROM t");
+    assert_eq!(rows.len(), 0);
+}
+
+/// COUNT(*) on empty table returns 0.
+#[test]
+fn test_count_empty_table() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val INT)",
+    );
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT COUNT(*) AS cnt FROM t");
+    assert_eq!(rows[0].get("cnt"), Some(&Value::Integer(0)));
+}
+
+/// SUM/AVG/MIN/MAX on empty table return NULL.
+#[test]
+fn test_aggregates_empty_table() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val INT)",
+    );
+
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT SUM(val) AS s, MIN(val) AS mi, MAX(val) AS ma FROM t",
+    );
+    assert_eq!(rows[0].get("s"), Some(&Value::Null));
+    assert_eq!(rows[0].get("mi"), Some(&Value::Null));
+    assert_eq!(rows[0].get("ma"), Some(&Value::Null));
+}
+
+/// DELETE on empty table affects 0 rows.
+#[test]
+fn test_delete_empty_table() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val INT)",
+    );
+
+    let affected = exec_affected(&mut pager, &mut catalog, "DELETE FROM t");
+    assert_eq!(affected, 0);
+}
+
+/// UPDATE on empty table affects 0 rows.
+#[test]
+fn test_update_empty_table() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val INT)",
+    );
+
+    let affected = exec_affected(&mut pager, &mut catalog, "UPDATE t SET val = 99");
+    assert_eq!(affected, 0);
+}
+
+/// JOIN with empty table produces empty result.
+#[test]
+fn test_join_with_empty_table() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE a (id BIGINT PRIMARY KEY, val INT)",
+    );
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE b (id BIGINT PRIMARY KEY, val INT)",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO a VALUES (1, 10)");
+
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT a.id FROM a INNER JOIN b ON a.id = b.id",
+    );
+    assert_eq!(rows.len(), 0);
+}
+
+/// DROP TABLE and re-create with different schema.
+#[test]
+fn test_drop_and_recreate_different_schema() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)",
+    );
+    exec(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (1, 'hello')",
+    );
+    exec(&mut pager, &mut catalog, "DROP TABLE t");
+
+    // Re-create with different schema
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, value INT, flag TINYINT)",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, 42, 1)");
+
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT value, flag FROM t WHERE id = 1",
+    );
+    assert_eq!(rows[0].get("value"), Some(&Value::Integer(42)));
+    assert_eq!(rows[0].get("flag"), Some(&Value::Integer(1)));
+}
+
+/// Empty transaction (BEGIN; COMMIT with no operations) via Database API.
+#[test]
+fn test_empty_transaction() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let mut db = murodb::Database::create(&db_path, &test_key()).unwrap();
+    db.execute("CREATE TABLE t (id BIGINT PRIMARY KEY, val INT)")
+        .unwrap();
+    db.execute("BEGIN").unwrap();
+    db.execute("COMMIT").unwrap();
+
+    // Table should still be accessible
+    let rows = db.query("SELECT COUNT(*) AS cnt FROM t").unwrap();
+    assert_eq!(rows[0].get("cnt"), Some(&Value::Integer(0)));
+}
+
+/// DELETE all rows → table behaves like empty.
+#[test]
+fn test_delete_all_then_empty_behavior() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val INT)",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, 10)");
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (2, 20)");
+    exec(&mut pager, &mut catalog, "DELETE FROM t");
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT COUNT(*) AS cnt FROM t");
+    assert_eq!(rows[0].get("cnt"), Some(&Value::Integer(0)));
+
+    // Can insert again
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (3, 30)");
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 3");
+    assert_eq!(rows[0].get("val"), Some(&Value::Integer(30)));
+}

--- a/tests/fts_limit_tests.rs
+++ b/tests/fts_limit_tests.rs
@@ -1,0 +1,215 @@
+use murodb::crypto::aead::MasterKey;
+use murodb::schema::catalog::SystemCatalog;
+use murodb::sql::executor::{execute, ExecResult};
+use murodb::storage::pager::Pager;
+use murodb::types::Value;
+use tempfile::TempDir;
+
+fn test_key() -> MasterKey {
+    MasterKey::new([0x42u8; 32])
+}
+
+fn setup() -> (Pager, SystemCatalog, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let mut pager = Pager::create(&db_path, &test_key()).unwrap();
+    let catalog = SystemCatalog::create(&mut pager).unwrap();
+    (pager, catalog, dir)
+}
+
+fn exec(pager: &mut Pager, catalog: &mut SystemCatalog, sql: &str) {
+    execute(sql, pager, catalog).unwrap();
+}
+
+fn exec_err(pager: &mut Pager, catalog: &mut SystemCatalog, sql: &str) -> String {
+    execute(sql, pager, catalog).unwrap_err().to_string()
+}
+
+fn query_rows(
+    pager: &mut Pager,
+    catalog: &mut SystemCatalog,
+    sql: &str,
+) -> Vec<murodb::sql::executor::Row> {
+    match execute(sql, pager, catalog).unwrap() {
+        ExecResult::Rows(rows) => rows,
+        other => panic!("Expected rows, got {:?}", other),
+    }
+}
+
+/// Empty string in FTS-indexed column should not crash.
+#[test]
+fn test_fts_empty_string() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, body TEXT)",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, '')");
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE FULLTEXT INDEX ft ON t(body) WITH PARSER ngram",
+    );
+
+    // Query should return no matches (empty string has no tokens)
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT id FROM t WHERE MATCH(body) AGAINST('test' IN NATURAL LANGUAGE MODE) > 0",
+    );
+    assert_eq!(rows.len(), 0);
+}
+
+/// Large text (3500 bytes) in FTS-indexed column.
+#[test]
+fn test_fts_large_text() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, body TEXT)",
+    );
+
+    let text = "東京タワー".repeat(200); // 5 chars * 3 bytes * 200 = 3000 bytes
+    let sql = format!("INSERT INTO t VALUES (1, '{}')", text);
+    exec(&mut pager, &mut catalog, &sql);
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE FULLTEXT INDEX ft ON t(body) WITH PARSER ngram",
+    );
+
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT id FROM t WHERE MATCH(body) AGAINST('東京' IN NATURAL LANGUAGE MODE) > 0",
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get("id"), Some(&Value::Integer(1)));
+}
+
+/// FTS query on table without FTS index → error.
+#[test]
+fn test_fts_no_index_error() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, body TEXT)",
+    );
+    exec(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (1, 'hello world')",
+    );
+
+    let err = exec_err(
+        &mut pager,
+        &mut catalog,
+        "SELECT id FROM t WHERE MATCH(body) AGAINST('hello' IN NATURAL LANGUAGE MODE) > 0",
+    );
+    assert!(
+        err.to_lowercase().contains("fulltext")
+            || err.to_lowercase().contains("fts")
+            || err.to_lowercase().contains("index"),
+        "Expected FTS index error, got: {}",
+        err
+    );
+}
+
+/// Punctuation-only document: tokenization should not crash.
+#[test]
+fn test_fts_punctuation_only() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, body TEXT)",
+    );
+    exec(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (1, '!!!...???---')",
+    );
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE FULLTEXT INDEX ft ON t(body) WITH PARSER ngram",
+    );
+
+    // Should not crash; may or may not match
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT id FROM t WHERE MATCH(body) AGAINST('!!!' IN NATURAL LANGUAGE MODE) > 0",
+    );
+    // We just verify it doesn't panic; result count is implementation-dependent
+    let _ = rows;
+}
+
+/// FTS with increasing document counts: verify query works with various table sizes.
+#[test]
+fn test_fts_two_docs_query() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, body TEXT)",
+    );
+
+    exec(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (1, '東京タワーの夜景がきれい')",
+    );
+    exec(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (2, '京都の金閣寺は素晴らしい')",
+    );
+
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE FULLTEXT INDEX ft ON t(body) WITH PARSER ngram OPTIONS (n=2, normalize='nfkc')",
+    );
+
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT id FROM t WHERE MATCH(body) AGAINST('東京タワー' IN NATURAL LANGUAGE MODE) > 0",
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get("id"), Some(&Value::Integer(1)));
+}
+
+/// FTS with NULL body: should not crash.
+#[test]
+fn test_fts_null_body() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, body TEXT)",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, NULL)");
+    exec(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (2, '検索可能テキスト')",
+    );
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE FULLTEXT INDEX ft ON t(body) WITH PARSER ngram",
+    );
+
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT id FROM t WHERE MATCH(body) AGAINST('検索' IN NATURAL LANGUAGE MODE) > 0",
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get("id"), Some(&Value::Integer(2)));
+}

--- a/tests/identifier_limit_tests.rs
+++ b/tests/identifier_limit_tests.rs
@@ -1,0 +1,185 @@
+use murodb::crypto::aead::MasterKey;
+use murodb::schema::catalog::SystemCatalog;
+use murodb::sql::executor::{execute, ExecResult};
+use murodb::storage::pager::Pager;
+use murodb::types::Value;
+use tempfile::TempDir;
+
+fn test_key() -> MasterKey {
+    MasterKey::new([0x42u8; 32])
+}
+
+fn setup() -> (Pager, SystemCatalog, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let mut pager = Pager::create(&db_path, &test_key()).unwrap();
+    let catalog = SystemCatalog::create(&mut pager).unwrap();
+    (pager, catalog, dir)
+}
+
+fn exec(pager: &mut Pager, catalog: &mut SystemCatalog, sql: &str) {
+    execute(sql, pager, catalog).unwrap();
+}
+
+fn exec_err(pager: &mut Pager, catalog: &mut SystemCatalog, sql: &str) -> String {
+    execute(sql, pager, catalog).unwrap_err().to_string()
+}
+
+fn query_rows(
+    pager: &mut Pager,
+    catalog: &mut SystemCatalog,
+    sql: &str,
+) -> Vec<murodb::sql::executor::Row> {
+    match execute(sql, pager, catalog).unwrap() {
+        ExecResult::Rows(rows) => rows,
+        other => panic!("Expected rows, got {:?}", other),
+    }
+}
+
+/// Table name with 255 characters.
+#[test]
+fn test_table_name_255_chars() {
+    let (mut pager, mut catalog, _dir) = setup();
+    let name = "t".repeat(255);
+    let sql = format!("CREATE TABLE {} (id BIGINT PRIMARY KEY, val INT)", name);
+    exec(&mut pager, &mut catalog, &sql);
+
+    let insert_sql = format!("INSERT INTO {} VALUES (1, 42)", name);
+    exec(&mut pager, &mut catalog, &insert_sql);
+
+    let select_sql = format!("SELECT val FROM {} WHERE id = 1", name);
+    let rows = query_rows(&mut pager, &mut catalog, &select_sql);
+    assert_eq!(rows[0].get("val"), Some(&Value::Integer(42)));
+}
+
+/// Column name with 255 characters.
+#[test]
+fn test_column_name_255_chars() {
+    let (mut pager, mut catalog, _dir) = setup();
+    let col_name = "c".repeat(255);
+    let sql = format!("CREATE TABLE t (id BIGINT PRIMARY KEY, {} INT)", col_name);
+    exec(&mut pager, &mut catalog, &sql);
+
+    let insert_sql = format!("INSERT INTO t (id, {}) VALUES (1, 99)", col_name);
+    exec(&mut pager, &mut catalog, &insert_sql);
+
+    let select_sql = format!("SELECT {} FROM t WHERE id = 1", col_name);
+    let rows = query_rows(&mut pager, &mut catalog, &select_sql);
+    assert_eq!(rows[0].get(&col_name), Some(&Value::Integer(99)));
+}
+
+/// Long SQL with many VALUES (batch insert).
+#[test]
+fn test_long_sql_many_values() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val INT)",
+    );
+
+    let values: Vec<String> = (1..=500).map(|i| format!("({}, {})", i, i * 2)).collect();
+    let sql = format!("INSERT INTO t VALUES {}", values.join(", "));
+    exec(&mut pager, &mut catalog, &sql);
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT COUNT(*) AS cnt FROM t");
+    assert_eq!(rows[0].get("cnt"), Some(&Value::Integer(500)));
+
+    // Verify first and last
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
+    assert_eq!(rows[0].get("val"), Some(&Value::Integer(2)));
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 500");
+    assert_eq!(rows[0].get("val"), Some(&Value::Integer(1000)));
+}
+
+/// Empty identifier should fail at parse time.
+#[test]
+fn test_empty_table_name() {
+    let (mut pager, mut catalog, _dir) = setup();
+    let err = exec_err(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE  (id BIGINT PRIMARY KEY)",
+    );
+    assert!(
+        err.contains("parse")
+            || err.contains("Parse")
+            || err.contains("syntax")
+            || err.contains("expected"),
+        "Expected parse error, got: {}",
+        err
+    );
+}
+
+/// Index name with 255 characters.
+#[test]
+fn test_index_name_255_chars() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val INT)",
+    );
+    let idx_name = "i".repeat(255);
+    let sql = format!("CREATE INDEX {} ON t(val)", idx_name);
+    exec(&mut pager, &mut catalog, &sql);
+
+    // Verify table still works
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, 42)");
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE val = 42");
+    assert_eq!(rows.len(), 1);
+}
+
+/// SQL reserved words as column names (should be rejected or handled).
+#[test]
+fn test_reserved_word_as_column_name() {
+    let (mut pager, mut catalog, _dir) = setup();
+    // "select" is a reserved word — this might fail or succeed depending on parser
+    let result = execute(
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, `select` INT)",
+        &mut pager,
+        &mut catalog,
+    );
+    match result {
+        Ok(_) => {
+            // If backtick-quoting works, verify it
+            exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, 42)");
+        }
+        Err(_) => {
+            // It's acceptable for the parser to reject this
+        }
+    }
+}
+
+/// Multiple tables can be created and queried independently.
+#[test]
+fn test_multiple_tables_independent() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE alpha (id BIGINT PRIMARY KEY, val INT)",
+    );
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE beta (id BIGINT PRIMARY KEY, val INT)",
+    );
+
+    exec(&mut pager, &mut catalog, "INSERT INTO alpha VALUES (1, 10)");
+    exec(&mut pager, &mut catalog, "INSERT INTO beta VALUES (1, 20)");
+
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT val FROM alpha WHERE id = 1",
+    );
+    assert_eq!(rows[0].get("val"), Some(&Value::Integer(10)));
+
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT val FROM beta WHERE id = 1",
+    );
+    assert_eq!(rows[0].get("val"), Some(&Value::Integer(20)));
+}

--- a/tests/integer_boundary_tests.rs
+++ b/tests/integer_boundary_tests.rs
@@ -1,0 +1,343 @@
+use murodb::crypto::aead::MasterKey;
+use murodb::schema::catalog::SystemCatalog;
+use murodb::sql::executor::{execute, ExecResult};
+use murodb::storage::pager::Pager;
+use murodb::types::Value;
+use tempfile::TempDir;
+
+fn test_key() -> MasterKey {
+    MasterKey::new([0x42u8; 32])
+}
+
+fn setup() -> (Pager, SystemCatalog, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let mut pager = Pager::create(&db_path, &test_key()).unwrap();
+    let catalog = SystemCatalog::create(&mut pager).unwrap();
+    (pager, catalog, dir)
+}
+
+fn exec(pager: &mut Pager, catalog: &mut SystemCatalog, sql: &str) {
+    execute(sql, pager, catalog).unwrap();
+}
+
+fn exec_err(pager: &mut Pager, catalog: &mut SystemCatalog, sql: &str) -> String {
+    execute(sql, pager, catalog).unwrap_err().to_string()
+}
+
+fn query_rows(
+    pager: &mut Pager,
+    catalog: &mut SystemCatalog,
+    sql: &str,
+) -> Vec<murodb::sql::executor::Row> {
+    match execute(sql, pager, catalog).unwrap() {
+        ExecResult::Rows(rows) => rows,
+        other => panic!("Expected rows, got {:?}", other),
+    }
+}
+
+// --- TINYINT ---
+
+#[test]
+fn test_tinyint_min_max() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val TINYINT)",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, -128)");
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (2, 127)");
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
+    assert_eq!(rows[0].get("val"), Some(&Value::Integer(-128)));
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 2");
+    assert_eq!(rows[0].get("val"), Some(&Value::Integer(127)));
+}
+
+#[test]
+fn test_tinyint_underflow() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val TINYINT)",
+    );
+    let err = exec_err(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, -129)");
+    assert!(
+        err.contains("out of range") || err.contains("TINYINT"),
+        "Expected range error, got: {}",
+        err
+    );
+}
+
+#[test]
+fn test_tinyint_overflow() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val TINYINT)",
+    );
+    let err = exec_err(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, 128)");
+    assert!(
+        err.contains("out of range") || err.contains("TINYINT"),
+        "Expected range error, got: {}",
+        err
+    );
+}
+
+// --- SMALLINT ---
+
+#[test]
+fn test_smallint_min_max() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val SMALLINT)",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, -32768)");
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (2, 32767)");
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
+    assert_eq!(rows[0].get("val"), Some(&Value::Integer(-32768)));
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 2");
+    assert_eq!(rows[0].get("val"), Some(&Value::Integer(32767)));
+}
+
+#[test]
+fn test_smallint_underflow() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val SMALLINT)",
+    );
+    let err = exec_err(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, -32769)");
+    assert!(
+        err.contains("out of range") || err.contains("SMALLINT"),
+        "Expected range error, got: {}",
+        err
+    );
+}
+
+#[test]
+fn test_smallint_overflow() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val SMALLINT)",
+    );
+    let err = exec_err(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, 32768)");
+    assert!(
+        err.contains("out of range") || err.contains("SMALLINT"),
+        "Expected range error, got: {}",
+        err
+    );
+}
+
+// --- INT ---
+
+#[test]
+fn test_int_min_max() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val INT)",
+    );
+    exec(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (1, -2147483648)",
+    );
+    exec(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (2, 2147483647)",
+    );
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
+    assert_eq!(rows[0].get("val"), Some(&Value::Integer(-2147483648)));
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 2");
+    assert_eq!(rows[0].get("val"), Some(&Value::Integer(2147483647)));
+}
+
+#[test]
+fn test_int_underflow() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val INT)",
+    );
+    let err = exec_err(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (1, -2147483649)",
+    );
+    assert!(
+        err.contains("out of range") || err.contains("INT"),
+        "Expected range error, got: {}",
+        err
+    );
+}
+
+#[test]
+fn test_int_overflow() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val INT)",
+    );
+    let err = exec_err(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (1, 2147483648)",
+    );
+    assert!(
+        err.contains("out of range") || err.contains("INT"),
+        "Expected range error, got: {}",
+        err
+    );
+}
+
+// --- BIGINT ---
+
+#[test]
+fn test_bigint_min_max() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val BIGINT)",
+    );
+    // i64::MIN (-9223372036854775808) cannot be represented as a literal because
+    // the parser handles it as -(9223372036854775808) which overflows i64.
+    // Use i64::MIN + 1 instead.
+    exec(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (1, -9223372036854775807)",
+    );
+    exec(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (2, 9223372036854775807)",
+    );
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
+    assert_eq!(rows[0].get("val"), Some(&Value::Integer(i64::MIN + 1)));
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 2");
+    assert_eq!(rows[0].get("val"), Some(&Value::Integer(i64::MAX)));
+}
+
+// --- FLOAT/DOUBLE ---
+
+#[test]
+fn test_float_nan_rejected() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val FLOAT)",
+    );
+    // NaN can't be represented as a SQL literal easily, but we can test via expression
+    let err = exec_err(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (1, 0.0 / 0.0)",
+    );
+    // This may produce a different error depending on how division is handled
+    assert!(
+        err.contains("finite")
+            || err.contains("NaN")
+            || err.contains("division")
+            || err.contains("zero"),
+        "Expected non-finite or division error, got: {}",
+        err
+    );
+}
+
+#[test]
+fn test_double_nan_rejected() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val DOUBLE)",
+    );
+    let err = exec_err(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (1, 0.0 / 0.0)",
+    );
+    assert!(
+        err.contains("finite")
+            || err.contains("NaN")
+            || err.contains("division")
+            || err.contains("zero"),
+        "Expected non-finite or division error, got: {}",
+        err
+    );
+}
+
+// --- Arithmetic overflow ---
+
+#[test]
+fn test_bigint_addition_overflow() {
+    let (mut pager, mut catalog, _dir) = setup();
+    // SELECT expression that would overflow i64
+    let result = execute(
+        "SELECT 9223372036854775807 + 1 AS val",
+        &mut pager,
+        &mut catalog,
+    );
+    // Should either error or wrap — we just want to confirm it doesn't crash
+    match result {
+        Ok(ExecResult::Rows(rows)) => {
+            // If it succeeds, it might have wrapped or returned a float
+            let _val = rows[0].get("val");
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            assert!(
+                msg.contains("overflow") || msg.contains("out of range"),
+                "Expected overflow error, got: {}",
+                msg
+            );
+        }
+        _ => panic!("Unexpected result type"),
+    }
+}
+
+#[test]
+fn test_integer_zero_value() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val INT)",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, 0)");
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
+    assert_eq!(rows[0].get("val"), Some(&Value::Integer(0)));
+}
+
+#[test]
+fn test_negative_one() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val INT)",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, -1)");
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
+    assert_eq!(rows[0].get("val"), Some(&Value::Integer(-1)));
+}

--- a/tests/null_edge_tests.rs
+++ b/tests/null_edge_tests.rs
@@ -1,0 +1,305 @@
+use murodb::crypto::aead::MasterKey;
+use murodb::schema::catalog::SystemCatalog;
+use murodb::sql::executor::{execute, ExecResult};
+use murodb::storage::pager::Pager;
+use murodb::types::Value;
+use tempfile::TempDir;
+
+fn test_key() -> MasterKey {
+    MasterKey::new([0x42u8; 32])
+}
+
+fn setup() -> (Pager, SystemCatalog, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let mut pager = Pager::create(&db_path, &test_key()).unwrap();
+    let catalog = SystemCatalog::create(&mut pager).unwrap();
+    (pager, catalog, dir)
+}
+
+fn exec(pager: &mut Pager, catalog: &mut SystemCatalog, sql: &str) {
+    execute(sql, pager, catalog).unwrap();
+}
+
+fn exec_err(pager: &mut Pager, catalog: &mut SystemCatalog, sql: &str) -> String {
+    execute(sql, pager, catalog).unwrap_err().to_string()
+}
+
+fn query_rows(
+    pager: &mut Pager,
+    catalog: &mut SystemCatalog,
+    sql: &str,
+) -> Vec<murodb::sql::executor::Row> {
+    match execute(sql, pager, catalog).unwrap() {
+        ExecResult::Rows(rows) => rows,
+        other => panic!("Expected rows, got {:?}", other),
+    }
+}
+
+/// All nullable columns set to NULL.
+#[test]
+fn test_all_columns_null() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, a VARCHAR, b INT, c DOUBLE)",
+    );
+    exec(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (1, NULL, NULL, NULL)",
+    );
+
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT a, b, c FROM t WHERE id = 1",
+    );
+    assert_eq!(rows[0].get("a"), Some(&Value::Null));
+    assert_eq!(rows[0].get("b"), Some(&Value::Null));
+    assert_eq!(rows[0].get("c"), Some(&Value::Null));
+}
+
+/// PK column cannot be NULL.
+#[test]
+fn test_pk_null_rejected() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val VARCHAR)",
+    );
+    let err = exec_err(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (NULL, 'test')",
+    );
+    assert!(
+        err.to_lowercase().contains("null")
+            || err.to_lowercase().contains("not null")
+            || err.to_lowercase().contains("primary key"),
+        "Expected NOT NULL error, got: {}",
+        err
+    );
+}
+
+/// COUNT(*) counts all rows; COUNT(nullable_col) excludes NULLs.
+#[test]
+fn test_count_star_vs_count_column() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val INT)",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, 10)");
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (2, NULL)");
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (3, 30)");
+
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT COUNT(*) AS cnt_all, COUNT(val) AS cnt_val FROM t",
+    );
+    assert_eq!(rows[0].get("cnt_all"), Some(&Value::Integer(3)));
+    assert_eq!(rows[0].get("cnt_val"), Some(&Value::Integer(2)));
+}
+
+/// SUM/AVG/MIN/MAX skip NULLs.
+#[test]
+fn test_aggregates_skip_null() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val INT)",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, 10)");
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (2, NULL)");
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (3, 30)");
+
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT SUM(val) AS s, MIN(val) AS mi, MAX(val) AS ma FROM t",
+    );
+    assert_eq!(rows[0].get("s"), Some(&Value::Integer(40)));
+    assert_eq!(rows[0].get("mi"), Some(&Value::Integer(10)));
+    assert_eq!(rows[0].get("ma"), Some(&Value::Integer(30)));
+}
+
+/// IS NULL vs = NULL.
+#[test]
+fn test_is_null_vs_equals_null() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val INT)",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, NULL)");
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (2, 42)");
+
+    // IS NULL should find the NULL row
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT id FROM t WHERE val IS NULL",
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get("id"), Some(&Value::Integer(1)));
+
+    // = NULL should find nothing (SQL standard: NULL = NULL is UNKNOWN)
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT id FROM t WHERE val = NULL",
+    );
+    assert_eq!(rows.len(), 0);
+}
+
+/// NULL in ORDER BY — consistent ordering.
+#[test]
+fn test_null_order_by() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val INT)",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, NULL)");
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (2, 10)");
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (3, NULL)");
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (4, 5)");
+
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT id, val FROM t ORDER BY val ASC",
+    );
+    // NULLs should all be grouped together (either first or last)
+    assert_eq!(rows.len(), 4);
+    let null_positions: Vec<usize> = rows
+        .iter()
+        .enumerate()
+        .filter(|(_, r)| r.get("val") == Some(&Value::Null))
+        .map(|(i, _)| i)
+        .collect();
+    // All NULLs should be adjacent
+    assert_eq!(null_positions.len(), 2);
+    assert_eq!(
+        null_positions[1] - null_positions[0],
+        1,
+        "NULLs should be adjacent in ORDER BY"
+    );
+}
+
+/// NULL in UNIQUE index: multiple NULLs allowed (SQL standard).
+#[test]
+fn test_null_in_unique_index() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val INT UNIQUE)",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, NULL)");
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (2, NULL)");
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT COUNT(*) AS cnt FROM t");
+    assert_eq!(rows[0].get("cnt"), Some(&Value::Integer(2)));
+}
+
+/// NULL in JOIN condition: NULL does not match NULL.
+#[test]
+fn test_null_join_no_match() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE a (id BIGINT PRIMARY KEY, val INT)",
+    );
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE b (id BIGINT PRIMARY KEY, val INT)",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO a VALUES (1, NULL)");
+    exec(&mut pager, &mut catalog, "INSERT INTO b VALUES (1, NULL)");
+
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT a.id FROM a INNER JOIN b ON a.val = b.val",
+    );
+    assert_eq!(rows.len(), 0, "NULL = NULL should not match in JOIN");
+}
+
+/// NULL in IN list: three-valued logic.
+#[test]
+fn test_null_in_list() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val INT)",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, NULL)");
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (2, 10)");
+
+    // val IN (10, NULL) should find id=2 (val=10 matches), but not id=1 (NULL IN (...) is UNKNOWN)
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT id FROM t WHERE val IN (10, NULL) ORDER BY id",
+    );
+    // At minimum, id=2 should be found
+    assert!(
+        rows.iter().any(|r| r.get("id") == Some(&Value::Integer(2))),
+        "val=10 should match IN (10, NULL)"
+    );
+}
+
+/// NULL in BETWEEN: returns NULL (not matched).
+#[test]
+fn test_null_between() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val INT)",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, NULL)");
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (2, 5)");
+
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT id FROM t WHERE val BETWEEN 1 AND 10",
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get("id"), Some(&Value::Integer(2)));
+}
+
+/// IS NOT NULL filter.
+#[test]
+fn test_is_not_null() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val INT)",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, NULL)");
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (2, 42)");
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (3, NULL)");
+
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT id FROM t WHERE val IS NOT NULL",
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get("id"), Some(&Value::Integer(2)));
+}

--- a/tests/page_boundary_tests.rs
+++ b/tests/page_boundary_tests.rs
@@ -1,0 +1,174 @@
+use murodb::crypto::aead::MasterKey;
+use murodb::schema::catalog::SystemCatalog;
+use murodb::sql::executor::{execute, ExecResult};
+use murodb::storage::pager::Pager;
+use murodb::types::Value;
+use tempfile::TempDir;
+
+fn test_key() -> MasterKey {
+    MasterKey::new([0x42u8; 32])
+}
+
+fn setup() -> (Pager, SystemCatalog, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let mut pager = Pager::create(&db_path, &test_key()).unwrap();
+    let catalog = SystemCatalog::create(&mut pager).unwrap();
+    (pager, catalog, dir)
+}
+
+fn exec(pager: &mut Pager, catalog: &mut SystemCatalog, sql: &str) {
+    execute(sql, pager, catalog).unwrap();
+}
+
+fn exec_err(pager: &mut Pager, catalog: &mut SystemCatalog, sql: &str) -> String {
+    execute(sql, pager, catalog).unwrap_err().to_string()
+}
+
+fn query_rows(
+    pager: &mut Pager,
+    catalog: &mut SystemCatalog,
+    sql: &str,
+) -> Vec<murodb::sql::executor::Row> {
+    match execute(sql, pager, catalog).unwrap() {
+        ExecResult::Rows(rows) => rows,
+        other => panic!("Expected rows, got {:?}", other),
+    }
+}
+
+/// VARCHAR 4000 bytes fits within a single page.
+#[test]
+fn test_varchar_4000_bytes_fits_in_page() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, data VARCHAR)",
+    );
+
+    let data = "a".repeat(4000);
+    let sql = format!("INSERT INTO t VALUES (1, '{}')", data);
+    exec(&mut pager, &mut catalog, &sql);
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT data FROM t WHERE id = 1");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get("data"), Some(&Value::Varchar(data)));
+}
+
+/// VARCHAR 5000 bytes exceeds page capacity → PageOverflow.
+#[test]
+fn test_varchar_5000_bytes_page_overflow() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, data VARCHAR)",
+    );
+
+    let data = "a".repeat(5000);
+    let sql = format!("INSERT INTO t VALUES (1, '{}')", data);
+    let err = exec_err(&mut pager, &mut catalog, &sql);
+    assert!(
+        err.contains("overflow") || err.contains("Overflow") || err.contains("capacity"),
+        "Expected page overflow error, got: {}",
+        err
+    );
+}
+
+/// Two medium-sized rows that together exceed page capacity trigger B-tree split.
+#[test]
+fn test_two_rows_cause_btree_split() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, data VARCHAR)",
+    );
+
+    let data = "b".repeat(2500);
+    let sql1 = format!("INSERT INTO t VALUES (1, '{}')", data);
+    let sql2 = format!("INSERT INTO t VALUES (2, '{}')", data);
+    exec(&mut pager, &mut catalog, &sql1);
+    exec(&mut pager, &mut catalog, &sql2);
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT id FROM t ORDER BY id");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].get("id"), Some(&Value::Integer(1)));
+    assert_eq!(rows[1].get("id"), Some(&Value::Integer(2)));
+}
+
+/// Multiple medium-sized rows fill pages with splits; all rows remain accessible.
+#[test]
+fn test_multiple_medium_rows_all_accessible() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, data VARCHAR)",
+    );
+
+    let data = "c".repeat(500);
+    for i in 1..=20 {
+        let sql = format!("INSERT INTO t VALUES ({}, '{}')", i, data);
+        exec(&mut pager, &mut catalog, &sql);
+    }
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT COUNT(*) AS cnt FROM t");
+    assert_eq!(rows[0].get("cnt"), Some(&Value::Integer(20)));
+}
+
+/// Many small rows that span multiple pages via B-tree splits.
+#[test]
+fn test_many_small_rows_spanning_pages() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)",
+    );
+
+    for i in 1..=200 {
+        let sql = format!("INSERT INTO t VALUES ({}, 'row_{}')", i, i);
+        exec(&mut pager, &mut catalog, &sql);
+    }
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT COUNT(*) AS cnt FROM t");
+    assert_eq!(rows[0].get("cnt"), Some(&Value::Integer(200)));
+
+    // Verify first and last row
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT name FROM t WHERE id = 1");
+    assert_eq!(rows[0].get("name"), Some(&Value::Varchar("row_1".into())));
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT name FROM t WHERE id = 200",
+    );
+    assert_eq!(rows[0].get("name"), Some(&Value::Varchar("row_200".into())));
+}
+
+/// Rows near the page boundary: insert rows of increasing size until overflow.
+#[test]
+fn test_gradual_size_increase_until_overflow() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, data VARCHAR)",
+    );
+
+    // Start at 3900 bytes and increase. At some point the row won't fit in a single page.
+    // The B-tree should handle splits for rows that fit and error for rows that are too large.
+    let mut max_success = 0;
+    for size in (3900..=4200).step_by(50) {
+        let data = "x".repeat(size);
+        let sql = format!("INSERT INTO t VALUES ({}, '{}')", size, data);
+        match execute(&sql, &mut pager, &mut catalog) {
+            Ok(_) => max_success = size,
+            Err(_) => break,
+        }
+    }
+    // We should have succeeded for at least 3900 bytes
+    assert!(max_success >= 3900, "Expected at least 3900 bytes to fit");
+    // And it should have failed before 4200 bytes
+    assert!(max_success < 4200, "Expected overflow before 4200 bytes");
+}

--- a/tests/utf8_edge_tests.rs
+++ b/tests/utf8_edge_tests.rs
@@ -1,0 +1,187 @@
+use murodb::crypto::aead::MasterKey;
+use murodb::schema::catalog::SystemCatalog;
+use murodb::sql::executor::{execute, ExecResult};
+use murodb::storage::pager::Pager;
+use murodb::types::Value;
+use tempfile::TempDir;
+
+fn test_key() -> MasterKey {
+    MasterKey::new([0x42u8; 32])
+}
+
+fn setup() -> (Pager, SystemCatalog, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let mut pager = Pager::create(&db_path, &test_key()).unwrap();
+    let catalog = SystemCatalog::create(&mut pager).unwrap();
+    (pager, catalog, dir)
+}
+
+fn exec(pager: &mut Pager, catalog: &mut SystemCatalog, sql: &str) {
+    execute(sql, pager, catalog).unwrap();
+}
+
+fn query_rows(
+    pager: &mut Pager,
+    catalog: &mut SystemCatalog,
+    sql: &str,
+) -> Vec<murodb::sql::executor::Row> {
+    match execute(sql, pager, catalog).unwrap() {
+        ExecResult::Rows(rows) => rows,
+        other => panic!("Expected rows, got {:?}", other),
+    }
+}
+
+/// Japanese text round-trip.
+#[test]
+fn test_japanese_roundtrip() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val VARCHAR)",
+    );
+    exec(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (1, '東京タワーの夜景がきれい')",
+    );
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
+    assert_eq!(
+        rows[0].get("val"),
+        Some(&Value::Varchar("東京タワーの夜景がきれい".into()))
+    );
+}
+
+/// Emoji round-trip (4-byte UTF-8).
+#[test]
+fn test_emoji_roundtrip() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val VARCHAR)",
+    );
+    exec(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (1, '🎉🚀💯')",
+    );
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
+    assert_eq!(rows[0].get("val"), Some(&Value::Varchar("🎉🚀💯".into())));
+}
+
+/// Empty string round-trip.
+#[test]
+fn test_empty_string_roundtrip() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val VARCHAR)",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, '')");
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
+    assert_eq!(rows[0].get("val"), Some(&Value::Varchar(String::new())));
+}
+
+/// Long UTF-8 string (within page limit).
+#[test]
+fn test_long_utf8_string() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val VARCHAR)",
+    );
+    // Each Japanese char is 3 bytes; 1000 chars = 3000 bytes (fits in page)
+    let data: String = "あ".repeat(1000);
+    let sql = format!("INSERT INTO t VALUES (1, '{}')", data);
+    exec(&mut pager, &mut catalog, &sql);
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
+    assert_eq!(rows[0].get("val"), Some(&Value::Varchar(data)));
+}
+
+/// Zero-width characters round-trip.
+#[test]
+fn test_zero_width_chars() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val VARCHAR)",
+    );
+    // Zero-width space (U+200B) and zero-width joiner (U+200D)
+    let text = "a\u{200B}b\u{200D}c";
+    let sql = format!("INSERT INTO t VALUES (1, '{}')", text);
+    exec(&mut pager, &mut catalog, &sql);
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
+    assert_eq!(rows[0].get("val"), Some(&Value::Varchar(text.into())));
+}
+
+/// Combining characters round-trip (e.g., é as e + combining acute).
+#[test]
+fn test_combining_chars() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val VARCHAR)",
+    );
+    // e followed by combining acute accent (U+0301)
+    let text = "e\u{0301}";
+    let sql = format!("INSERT INTO t VALUES (1, '{}')", text);
+    exec(&mut pager, &mut catalog, &sql);
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
+    assert_eq!(rows[0].get("val"), Some(&Value::Varchar(text.into())));
+}
+
+/// SQL single-quote escape: two single-quotes represent one.
+#[test]
+fn test_single_quote_escape() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val VARCHAR)",
+    );
+    exec(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (1, 'it''s a test')",
+    );
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
+    assert_eq!(
+        rows[0].get("val"),
+        Some(&Value::Varchar("it's a test".into()))
+    );
+}
+
+/// Mixed ASCII and multibyte text.
+#[test]
+fn test_mixed_ascii_multibyte() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val VARCHAR)",
+    );
+    exec(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (1, 'Hello世界🌍test')",
+    );
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
+    assert_eq!(
+        rows[0].get("val"),
+        Some(&Value::Varchar("Hello世界🌍test".into()))
+    );
+}

--- a/tests/varchar_limit_tests.rs
+++ b/tests/varchar_limit_tests.rs
@@ -1,0 +1,197 @@
+use murodb::crypto::aead::MasterKey;
+use murodb::schema::catalog::SystemCatalog;
+use murodb::sql::executor::{execute, ExecResult};
+use murodb::storage::pager::Pager;
+use murodb::types::Value;
+use tempfile::TempDir;
+
+fn test_key() -> MasterKey {
+    MasterKey::new([0x42u8; 32])
+}
+
+fn setup() -> (Pager, SystemCatalog, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let mut pager = Pager::create(&db_path, &test_key()).unwrap();
+    let catalog = SystemCatalog::create(&mut pager).unwrap();
+    (pager, catalog, dir)
+}
+
+fn exec(pager: &mut Pager, catalog: &mut SystemCatalog, sql: &str) {
+    execute(sql, pager, catalog).unwrap();
+}
+
+fn exec_err(pager: &mut Pager, catalog: &mut SystemCatalog, sql: &str) -> String {
+    execute(sql, pager, catalog).unwrap_err().to_string()
+}
+
+fn query_rows(
+    pager: &mut Pager,
+    catalog: &mut SystemCatalog,
+    sql: &str,
+) -> Vec<murodb::sql::executor::Row> {
+    match execute(sql, pager, catalog).unwrap() {
+        ExecResult::Rows(rows) => rows,
+        other => panic!("Expected rows, got {:?}", other),
+    }
+}
+
+/// VARCHAR(100) with exactly 100 bytes succeeds.
+#[test]
+fn test_varchar_100_exact_fit() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val VARCHAR(100))",
+    );
+    let data = "a".repeat(100);
+    let sql = format!("INSERT INTO t VALUES (1, '{}')", data);
+    exec(&mut pager, &mut catalog, &sql);
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
+    assert_eq!(rows[0].get("val"), Some(&Value::Varchar(data)));
+}
+
+/// VARCHAR(100) with 101 bytes fails.
+#[test]
+fn test_varchar_100_one_over() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val VARCHAR(100))",
+    );
+    let data = "a".repeat(101);
+    let sql = format!("INSERT INTO t VALUES (1, '{}')", data);
+    let err = exec_err(&mut pager, &mut catalog, &sql);
+    assert!(
+        err.contains("exceeds") || err.contains("VARCHAR"),
+        "Expected VARCHAR length error, got: {}",
+        err
+    );
+}
+
+/// Empty string inserts and reads back correctly.
+#[test]
+fn test_empty_string() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val VARCHAR)",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, '')");
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
+    assert_eq!(rows[0].get("val"), Some(&Value::Varchar(String::new())));
+}
+
+/// VARBINARY column can store NULL values.
+#[test]
+fn test_varbinary_null() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val VARBINARY(256))",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, NULL)");
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
+    assert_eq!(rows[0].get("val"), Some(&Value::Null));
+}
+
+/// Multibyte UTF-8 (Japanese 3-byte chars) — VARCHAR(n) checks byte length.
+#[test]
+fn test_varchar_multibyte_byte_count() {
+    let (mut pager, mut catalog, _dir) = setup();
+    // VARCHAR(9) should fit 3 Japanese chars (3 bytes each = 9 bytes)
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val VARCHAR(9))",
+    );
+    exec(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (1, 'あいう')",
+    );
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
+    assert_eq!(rows[0].get("val"), Some(&Value::Varchar("あいう".into())));
+}
+
+/// VARCHAR(8) cannot fit 3 Japanese chars (9 bytes).
+#[test]
+fn test_varchar_multibyte_overflow() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val VARCHAR(8))",
+    );
+    let err = exec_err(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (1, 'あいう')",
+    );
+    assert!(
+        err.contains("exceeds") || err.contains("VARCHAR"),
+        "Expected VARCHAR length error, got: {}",
+        err
+    );
+}
+
+/// TEXT type with large value (within page limit).
+#[test]
+fn test_text_large_value() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val TEXT)",
+    );
+    let data = "t".repeat(3000);
+    let sql = format!("INSERT INTO t VALUES (1, '{}')", data);
+    exec(&mut pager, &mut catalog, &sql);
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
+    assert_eq!(rows[0].get("val"), Some(&Value::Varchar(data)));
+}
+
+/// TEXT type with page-exceeding value → PageOverflow.
+#[test]
+fn test_text_page_overflow() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val TEXT)",
+    );
+    let data = "t".repeat(5000);
+    let sql = format!("INSERT INTO t VALUES (1, '{}')", data);
+    let err = exec_err(&mut pager, &mut catalog, &sql);
+    assert!(
+        err.contains("overflow") || err.contains("Overflow") || err.contains("capacity"),
+        "Expected page overflow error, got: {}",
+        err
+    );
+}
+
+/// VARCHAR with unlimited length (no size specified) and large value.
+#[test]
+fn test_varchar_unlimited_large() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val VARCHAR)",
+    );
+    let data = "u".repeat(3500);
+    let sql = format!("INSERT INTO t VALUES (1, '{}')", data);
+    exec(&mut pager, &mut catalog, &sql);
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
+    assert_eq!(rows[0].get("val"), Some(&Value::Varchar(data)));
+}


### PR DESCRIPTION
## Summary

- Add 9 integration test files with 76 new tests covering boundary values, edge cases, and error conditions
- Create limits reference documentation (`docs-site/src/user-guide/limits.md`)
- Add Limitations section to README

## Test Files

| File | Tests | Coverage |
|---|---|---|
| `page_boundary_tests.rs` | 6 | VARCHAR 4000/5000 bytes, B-tree splits, gradual overflow detection |
| `integer_boundary_tests.rs` | 15 | TINYINT/SMALLINT/INT/BIGINT min/max, overflow/underflow, NaN rejection |
| `varchar_limit_tests.rs` | 9 | VARCHAR(n) exact/overflow, empty string, multibyte byte-count, TEXT limits |
| `utf8_edge_tests.rs` | 8 | Japanese, emoji, zero-width chars, combining chars, quote escape |
| `null_edge_tests.rs` | 11 | NULL in PK, aggregates, IS NULL vs =NULL, ORDER BY, UNIQUE, JOIN, IN, BETWEEN |
| `column_count_tests.rs` | 7 | 1/100 columns, NULL bitmap at 8/9/16/17 column boundaries |
| `identifier_limit_tests.rs` | 7 | 255-char names, 500-value batch INSERT, empty identifier, reserved words |
| `empty_table_edge_tests.rs` | 9 | Empty SELECT/COUNT/DELETE/UPDATE, aggregate NULLs, JOIN, DROP+recreate |
| `fts_limit_tests.rs` | 6 | Empty/NULL/large text, no-index error, punctuation-only |

## Bugs Found

テスト中に発見した問題を issue として登録済み:

- #157 — `i64::MIN` リテラルをパーサーが処理できない
- #158 — `ORDER BY` on BIGINT PK が正しい順序を返さない場合がある
- #159 — FTS クエリが複数ドキュメントマッチ時に 0 件を返す
- #160 — `VARCHAR(n)` がバイト数ベース (MySQL は文字数ベース)
- #161 — `X'...'` hex リテラル未対応

## Test plan

- [x] `cargo test` — 全テスト pass (既存テストへの退行なし)
- [x] `cargo clippy` — 新規 warning なし
- [x] Pre-commit DB/SQL expert review 実施済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)