### PR TITLE
fix: handle i64::MIN literal in SQL parser

### DIFF
--- a/src/sql/parser/expr_and_select.rs
+++ b/src/sql/parser/expr_and_select.rs
@@ -611,6 +611,17 @@ impl Parser {
     pub(super) fn parse_unary(&mut self) -> Result<Expr, String> {
         if self.peek() == Some(&Token::Minus) {
             self.advance();
+            // Handle i64::MIN: the lexer cannot parse 9223372036854775808 as i64,
+            // so it becomes an Ident. We detect this case and parse "-{digits}" as i64.
+            if let Some(Token::Ident(s)) = self.peek() {
+                if s.chars().all(|c| c.is_ascii_digit()) {
+                    let neg_str = format!("-{}", s);
+                    if let Ok(n) = neg_str.parse::<i64>() {
+                        self.advance();
+                        return Ok(Expr::IntLiteral(n));
+                    }
+                }
+            }
             let operand = self.parse_primary()?;
             // Optimize: if it's an integer literal, negate it directly
             match operand {

--- a/src/sql/parser/tests.rs
+++ b/src/sql/parser/tests.rs
@@ -334,6 +334,23 @@ fn test_parse_unary_minus() {
 }
 
 #[test]
+fn test_parse_i64_min_literal() {
+    // i64::MIN = -9223372036854775808
+    // The lexer cannot parse 9223372036854775808 as i64 (overflow), so the parser
+    // must handle the combined "-9223372036854775808" as a special case.
+    let stmt = parse_sql("SELECT * FROM t WHERE id = -9223372036854775808").unwrap();
+    if let Statement::Select(sel) = stmt {
+        if let Some(Expr::BinaryOp { right, .. }) = sel.where_clause {
+            assert!(matches!(*right, Expr::IntLiteral(n) if n == i64::MIN));
+        } else {
+            panic!("Expected BinaryOp");
+        }
+    } else {
+        panic!("Expected Select");
+    }
+}
+
+#[test]
 fn test_parse_default_value() {
     let stmt = parse_sql("CREATE TABLE t (id BIGINT PRIMARY KEY, status INT DEFAULT 0)").unwrap();
     if let Statement::CreateTable(ct) = stmt {

--- a/tests/integer_boundary_tests.rs
+++ b/tests/integer_boundary_tests.rs
@@ -215,13 +215,10 @@ fn test_bigint_min_max() {
         &mut catalog,
         "CREATE TABLE t (id BIGINT PRIMARY KEY, val BIGINT)",
     );
-    // i64::MIN (-9223372036854775808) cannot be represented as a literal because
-    // the parser handles it as -(9223372036854775808) which overflows i64.
-    // Use i64::MIN + 1 instead.
     exec(
         &mut pager,
         &mut catalog,
-        "INSERT INTO t VALUES (1, -9223372036854775807)",
+        "INSERT INTO t VALUES (1, -9223372036854775808)",
     );
     exec(
         &mut pager,
@@ -230,7 +227,7 @@ fn test_bigint_min_max() {
     );
 
     let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
-    assert_eq!(rows[0].get("val"), Some(&Value::Integer(i64::MIN + 1)));
+    assert_eq!(rows[0].get("val"), Some(&Value::Integer(i64::MIN)));
     let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 2");
     assert_eq!(rows[0].get("val"), Some(&Value::Integer(i64::MAX)));
 }


### PR DESCRIPTION
## Summary

- Fix parser to handle `-9223372036854775808` (i64::MIN) as a valid integer literal
- The lexer cannot parse `9223372036854775808` as i64 (overflow), so it becomes an Ident token
- `parse_unary` now detects `-` followed by an all-digit Ident and tries parsing the combined string as i64

## Changes

- `src/sql/parser/expr_and_select.rs` — Add fallback in `parse_unary` for overflowed digit Idents
- `src/sql/parser/tests.rs` — Add unit test `test_parse_i64_min_literal`
- `tests/integer_boundary_tests.rs` — Update `test_bigint_min_max` to use actual i64::MIN

Closes #157

## Test plan

- [x] `cargo test` — all tests pass
- [x] `cargo clippy` — no warnings
- [x] Pre-commit DB/SQL expert review

🤖 Generated with [Claude Code](https://claude.com/claude-code)