### PR TITLE
fix: ORDER BY with columns not in SELECT list

### DIFF
--- a/src/sql/executor/select_query.rs
+++ b/src/sql/executor/select_query.rs
@@ -448,6 +448,10 @@ pub(super) fn exec_select(
         // Non-aggregation path (original)
         let mut rows: Vec<Row> = Vec::new();
 
+        // Collect ORDER BY columns not present in SELECT list.
+        // These must be included in each Row for sorting, then stripped afterward.
+        let extra_order_cols = collect_extra_order_by_columns(&sel.columns, &sel.order_by);
+
         match plan {
             Plan::PkSeek { key_exprs, .. } => {
                 let pk_key = eval_pk_seek_key(&table_def, &key_exprs)?;
@@ -473,8 +477,13 @@ pub(super) fn exec_select(
                         &values,
                         Some(&fts_ctx),
                     )? {
-                        let row =
-                            build_row_with_fts(&table_def, &values, &sel.columns, Some(&fts_ctx))?;
+                        let row = build_row_with_fts_and_extras(
+                            &table_def,
+                            &values,
+                            &sel.columns,
+                            Some(&fts_ctx),
+                            &extra_order_cols,
+                        )?;
                         rows.push(row);
                     }
                 }
@@ -516,11 +525,12 @@ pub(super) fn exec_select(
                             &values,
                             Some(&fts_ctx),
                         )? {
-                            let row = build_row_with_fts(
+                            let row = build_row_with_fts_and_extras(
                                 &table_def,
                                 &values,
                                 &sel.columns,
                                 Some(&fts_ctx),
+                                &extra_order_cols,
                             )?;
                             rows.push(row);
                         }
@@ -585,11 +595,12 @@ pub(super) fn exec_select(
                             &values,
                             Some(&fts_ctx),
                         )? {
-                            let row = build_row_with_fts(
+                            let row = build_row_with_fts_and_extras(
                                 &table_def,
                                 &values,
                                 &sel.columns,
                                 Some(&fts_ctx),
+                                &extra_order_cols,
                             )?;
                             rows.push(row);
                         }
@@ -623,11 +634,12 @@ pub(super) fn exec_select(
                             &values,
                             Some(&fts_ctx),
                         )? {
-                            let row = build_row_with_fts(
+                            let row = build_row_with_fts_and_extras(
                                 &table_def,
                                 &values,
                                 &sel.columns,
                                 Some(&fts_ctx),
+                                &extra_order_cols,
                             )?;
                             rows.push(row);
                         }
@@ -645,11 +657,12 @@ pub(super) fn exec_select(
                             &values,
                             Some(&fts_ctx),
                         )? {
-                            let row = build_row_with_fts(
+                            let row = build_row_with_fts_and_extras(
                                 &table_def,
                                 &values,
                                 &sel.columns,
                                 Some(&fts_ctx),
+                                &extra_order_cols,
                             )?;
                             rows.push(row);
                         }
@@ -682,8 +695,13 @@ pub(super) fn exec_select(
                         &values,
                         Some(&fts_ctx),
                     )? {
-                        let row =
-                            build_row_with_fts(&table_def, &values, &sel.columns, Some(&fts_ctx))?;
+                        let row = build_row_with_fts_and_extras(
+                            &table_def,
+                            &values,
+                            &sel.columns,
+                            Some(&fts_ctx),
+                            &extra_order_cols,
+                        )?;
                         rows.push(row);
                     }
                 }
@@ -706,6 +724,14 @@ pub(super) fn exec_select(
         // ORDER BY
         if let Some(order_items) = &sel.order_by {
             sort_rows(&mut rows, order_items);
+        }
+
+        // Strip extra ORDER BY columns that were injected for sorting
+        if !extra_order_cols.is_empty() {
+            for row in &mut rows {
+                row.values
+                    .retain(|(name, _)| !extra_order_cols.contains(name));
+            }
         }
 
         // OFFSET
@@ -850,11 +876,12 @@ pub(super) fn matches_where_with_fts(
     }
 }
 
-pub(super) fn build_row_with_fts(
+pub(super) fn build_row_with_fts_and_extras(
     table_def: &TableDef,
     values: &[Value],
     select_columns: &[SelectColumn],
     fts_ctx: Option<&FtsEvalContext>,
+    extra_columns: &[String],
 ) -> Result<Row> {
     let mut row_values = Vec::with_capacity(select_columns.len().max(table_def.columns.len()));
 
@@ -885,5 +912,52 @@ pub(super) fn build_row_with_fts(
         }
     }
 
+    // Append extra columns needed for ORDER BY that are not in the SELECT list
+    for col_name in extra_columns {
+        if let Some(i) = table_def.column_index(col_name) {
+            let val = values.get(i).cloned().unwrap_or(Value::Null);
+            row_values.push((col_name.clone(), val));
+        }
+    }
+
     Ok(Row { values: row_values })
+}
+
+/// Collect ORDER BY column names that are not present in the SELECT list.
+/// These columns must be temporarily included in rows for sorting.
+fn collect_extra_order_by_columns(
+    select_columns: &[SelectColumn],
+    order_by: &Option<Vec<OrderByItem>>,
+) -> Vec<String> {
+    let order_items = match order_by {
+        Some(items) => items,
+        None => return Vec::new(),
+    };
+
+    // Collect names already in SELECT
+    let mut selected_names: HashSet<String> = HashSet::new();
+    for col in select_columns {
+        match col {
+            SelectColumn::Star => return Vec::new(), // SELECT * includes everything
+            SelectColumn::Expr(Expr::ColumnRef(name), alias) => {
+                selected_names.insert(alias.clone().unwrap_or_else(|| name.clone()));
+                selected_names.insert(name.clone());
+            }
+            SelectColumn::Expr(_, Some(alias)) => {
+                selected_names.insert(alias.clone());
+            }
+            _ => {}
+        }
+    }
+
+    // Find ORDER BY columns not in SELECT
+    let mut extra = Vec::new();
+    for item in order_items {
+        if let Expr::ColumnRef(name) = &item.expr {
+            if !selected_names.contains(name) {
+                extra.push(name.clone());
+            }
+        }
+    }
+    extra
 }

--- a/tests/integer_boundary_tests.rs
+++ b/tests/integer_boundary_tests.rs
@@ -338,3 +338,62 @@ fn test_negative_one() {
     let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
     assert_eq!(rows[0].get("val"), Some(&Value::Integer(-1)));
 }
+
+// --- ORDER BY with column not in SELECT list ---
+
+#[test]
+fn test_order_by_column_not_in_select() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val TINYINT)",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (2, 20)");
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, 10)");
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (3, 30)");
+
+    // ORDER BY id ASC — id is not in the SELECT list
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t ORDER BY id");
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0].get("val"), Some(&Value::Integer(10)));
+    assert_eq!(rows[1].get("val"), Some(&Value::Integer(20)));
+    assert_eq!(rows[2].get("val"), Some(&Value::Integer(30)));
+    // Ensure "id" is NOT in the output rows (it was only used for sorting)
+    assert_eq!(rows[0].get("id"), None);
+
+    // ORDER BY id DESC
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT val FROM t ORDER BY id DESC",
+    );
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0].get("val"), Some(&Value::Integer(30)));
+    assert_eq!(rows[1].get("val"), Some(&Value::Integer(20)));
+    assert_eq!(rows[2].get("val"), Some(&Value::Integer(10)));
+}
+
+#[test]
+fn test_order_by_column_in_select() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val TINYINT)",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (2, 20)");
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, 10)");
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (3, 30)");
+
+    // ORDER BY id ASC — id IS in the SELECT list
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT id, val FROM t ORDER BY id",
+    );
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0].get("id"), Some(&Value::Integer(1)));
+    assert_eq!(rows[1].get("id"), Some(&Value::Integer(2)));
+    assert_eq!(rows[2].get("id"), Some(&Value::Integer(3)));
+}


### PR DESCRIPTION
## Summary
- Fixed incorrect sort order when ORDER BY references columns not in the SELECT list (e.g., `SELECT val FROM t ORDER BY id`)
- Root cause: `sort_rows()` was called after row projection, so `row.get("col")` returned `None` for ORDER BY columns not in SELECT, causing `cmp_values(None, None)` to produce undefined sort behavior
- Fix: temporarily inject extra ORDER BY columns into each Row before sorting, then strip them afterward

## Test plan
- [x] Added `test_order_by_column_not_in_select` — verifies ASC and DESC with column not in SELECT
- [x] Added `test_order_by_column_in_select` — verifies no regression when ORDER BY column is in SELECT
- [x] Full test suite passes with no regressions
- [x] `cargo clippy` clean

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)