### PR TITLE
fix: VARCHAR(n) character-based length check (MySQL-compatible)

### DIFF
--- a/docs-site/src/user-guide/limits.md
+++ b/docs-site/src/user-guide/limits.md
@@ -41,12 +41,11 @@ MuroDB does not currently support row overflow pages; a single row must fit with
 | VARCHAR(n) max n | 4,294,967,295 (u32) | Practical max is ~4,048 bytes due to page capacity |
 | VARBINARY(n) max n | 4,294,967,295 (u32) | Practical max is ~4,048 bytes due to page capacity |
 | TEXT max size | ~4,048 bytes | Same as VARCHAR; limited by page capacity |
-| VARCHAR(n) length check | Byte-based | `VARCHAR(100)` allows up to 100 *bytes*, not characters |
+| VARCHAR(n) length check | Character-based | `VARCHAR(100)` allows up to 100 *characters* (MySQL-compatible) |
 
-> **Note:** MuroDB checks `VARCHAR(n)` against *byte length*, not character count.
-> This differs from MySQL, where `VARCHAR(n)` limits the number of *characters*.
+> **Note:** MuroDB checks `VARCHAR(n)` against *character count*, consistent with MySQL.
 > Multi-byte UTF-8 characters (e.g., Japanese characters at 3 bytes each, emoji at 4 bytes)
-> consume multiple bytes of the VARCHAR(n) budget.
+> each count as one character. `VARBINARY(n)` still uses byte-based length checking.
 
 ## Internal Limits
 

--- a/src/sql/executor/fts.rs
+++ b/src/sql/executor/fts.rs
@@ -543,10 +543,10 @@ pub(super) fn validate_value(value: &Value, data_type: &DataType) -> Result<()> 
         (Value::Float(n), DataType::Float) if *n < f32::MIN as f64 || *n > f32::MAX as f64 => Err(
             MuroError::Execution(format!("Value {} out of range for FLOAT", n)),
         ),
-        (Value::Varchar(s), DataType::Varchar(Some(max))) if s.len() as u32 > *max => {
+        (Value::Varchar(s), DataType::Varchar(Some(max))) if s.chars().count() as u32 > *max => {
             Err(MuroError::Execution(format!(
                 "String length {} exceeds VARCHAR({})",
-                s.len(),
+                s.chars().count(),
                 max
             )))
         }

--- a/tests/varchar_limit_tests.rs
+++ b/tests/varchar_limit_tests.rs
@@ -102,15 +102,15 @@ fn test_varbinary_null() {
     assert_eq!(rows[0].get("val"), Some(&Value::Null));
 }
 
-/// Multibyte UTF-8 (Japanese 3-byte chars) — VARCHAR(n) checks byte length.
+/// Multibyte UTF-8 (Japanese 3-byte chars) — VARCHAR(n) checks character count (MySQL-compatible).
 #[test]
-fn test_varchar_multibyte_byte_count() {
+fn test_varchar_multibyte_char_count() {
     let (mut pager, mut catalog, _dir) = setup();
-    // VARCHAR(9) should fit 3 Japanese chars (3 bytes each = 9 bytes)
+    // VARCHAR(3) should fit 3 Japanese chars (3 characters, even though 9 bytes)
     exec(
         &mut pager,
         &mut catalog,
-        "CREATE TABLE t (id BIGINT PRIMARY KEY, val VARCHAR(9))",
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val VARCHAR(3))",
     );
     exec(
         &mut pager,
@@ -122,14 +122,14 @@ fn test_varchar_multibyte_byte_count() {
     assert_eq!(rows[0].get("val"), Some(&Value::Varchar("あいう".into())));
 }
 
-/// VARCHAR(8) cannot fit 3 Japanese chars (9 bytes).
+/// VARCHAR(2) cannot fit 3 Japanese chars (3 characters).
 #[test]
 fn test_varchar_multibyte_overflow() {
     let (mut pager, mut catalog, _dir) = setup();
     exec(
         &mut pager,
         &mut catalog,
-        "CREATE TABLE t (id BIGINT PRIMARY KEY, val VARCHAR(8))",
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val VARCHAR(2))",
     );
     let err = exec_err(
         &mut pager,
@@ -141,6 +141,22 @@ fn test_varchar_multibyte_overflow() {
         "Expected VARCHAR length error, got: {}",
         err
     );
+}
+
+/// Emoji (4-byte UTF-8) counted as characters, not bytes.
+#[test]
+fn test_varchar_emoji_char_count() {
+    let (mut pager, mut catalog, _dir) = setup();
+    // VARCHAR(2) should fit 2 emoji (2 characters, 8 bytes)
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, val VARCHAR(2))",
+    );
+    exec(&mut pager, &mut catalog, "INSERT INTO t VALUES (1, '😀🎉')");
+
+    let rows = query_rows(&mut pager, &mut catalog, "SELECT val FROM t WHERE id = 1");
+    assert_eq!(rows[0].get("val"), Some(&Value::Varchar("😀🎉".into())));
 }
 
 /// TEXT type with large value (within page limit).


### PR DESCRIPTION
## Summary
- Changed `VARCHAR(n)` length validation from byte-based to character-based, matching MySQL behavior
- `VARCHAR(3)` now correctly accepts `'あいう'` (3 characters, 9 bytes)
- `VARBINARY(n)` remains byte-based (unchanged)
- Updated limits documentation to reflect the change

## Test plan
- [x] `test_varchar_multibyte_char_count` — Japanese 3-char string in `VARCHAR(3)` succeeds
- [x] `test_varchar_multibyte_overflow` — Japanese 3-char string in `VARCHAR(2)` fails
- [x] `test_varchar_emoji_char_count` — 2 emoji (8 bytes) in `VARCHAR(2)` succeeds
- [x] Full test suite passes with no regressions
- [x] `cargo clippy` clean

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)