### PR TITLE
fix: FTS query returns 0 results when multiple documents match

### DIFF
--- a/src/sql/executor/ddl.rs
+++ b/src/sql/executor/ddl.rs
@@ -371,9 +371,9 @@ pub(super) fn exec_create_fulltext_index(
     }
 
     let mut fts_index = FtsIndex::create(pager, SQL_FTS_TERM_KEY)?;
-    let fts_root = fts_index.root_page_id();
+    let initial_fts_root = fts_index.root_page_id();
 
-    let build_res: Result<()> = (|| {
+    let build_res: Result<PageId> = (|| {
         let data_btree = BTree::open(table_def.data_btree_root);
         let mut pending = Vec::new();
         let mut mappings = Vec::new();
@@ -396,17 +396,22 @@ pub(super) fn exec_create_fulltext_index(
 
         fts_index.apply_pending(pager, &pending)?;
 
-        let mut meta_btree = BTree::open(fts_root);
+        // Use the updated root after apply_pending (root may have changed due to B-tree splits)
+        let mut meta_btree = BTree::open(fts_index.root_page_id());
         for (pk_key, doc_id) in &mappings {
             fts_put_doc_mapping(&mut meta_btree, pager, pk_key, *doc_id)?;
         }
         fts_set_next_doc_id(&mut meta_btree, pager, next_doc_id)?;
-        Ok(())
+        // Return the final root after all B-tree modifications
+        Ok(meta_btree.root_page_id())
     })();
-    if let Err(e) = build_res {
-        free_btree_pages(pager, fts_root);
-        return Err(e);
-    }
+    let final_fts_root = match build_res {
+        Ok(root) => root,
+        Err(e) => {
+            free_btree_pages(pager, initial_fts_root);
+            return Err(e);
+        }
+    };
 
     let idx_def = IndexDef {
         name: fi.index_name.clone(),
@@ -414,7 +419,7 @@ pub(super) fn exec_create_fulltext_index(
         column_names: vec![fi.column_name.clone()],
         index_type: IndexType::Fulltext,
         is_unique: false,
-        btree_root: fts_root,
+        btree_root: final_fts_root,
         stats_distinct_keys: 0,
         stats_num_min: 0,
         stats_num_max: 0,

--- a/tests/fts_limit_tests.rs
+++ b/tests/fts_limit_tests.rs
@@ -184,6 +184,65 @@ fn test_fts_two_docs_query() {
     assert_eq!(rows[0].get("id"), Some(&Value::Integer(1)));
 }
 
+/// FTS query with multiple matching documents (regression test for #159).
+#[test]
+fn test_fts_multi_match() {
+    let (mut pager, mut catalog, _dir) = setup();
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE TABLE t (id BIGINT PRIMARY KEY, body TEXT)",
+    );
+    exec(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (1, '東京タワーの夜景がきれい')",
+    );
+    exec(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (2, '東京タワーは観光名所です')",
+    );
+    exec(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (3, '東京タワーに行きました')",
+    );
+    exec(
+        &mut pager,
+        &mut catalog,
+        "INSERT INTO t VALUES (4, '京都の金閣寺は素晴らしい')",
+    );
+
+    exec(
+        &mut pager,
+        &mut catalog,
+        "CREATE FULLTEXT INDEX ft ON t(body) WITH PARSER ngram OPTIONS (n=2, normalize='nfkc')",
+    );
+
+    let rows = query_rows(
+        &mut pager,
+        &mut catalog,
+        "SELECT id FROM t WHERE MATCH(body) AGAINST('東京タワー' IN NATURAL LANGUAGE MODE) > 0",
+    );
+    assert_eq!(
+        rows.len(),
+        3,
+        "Expected 3 matching rows, got {}",
+        rows.len()
+    );
+
+    let mut ids: Vec<i64> = rows
+        .iter()
+        .filter_map(|r| match r.get("id") {
+            Some(Value::Integer(n)) => Some(*n),
+            _ => None,
+        })
+        .collect();
+    ids.sort();
+    assert_eq!(ids, vec![1, 2, 3]);
+}
+
 /// FTS with NULL body: should not crash.
 #[test]
 fn test_fts_null_body() {


### PR DESCRIPTION
## Summary
- Fixed FTS queries returning 0 results (or erroring with "missing segmented posting payload") when multiple documents match
- Root cause: `CREATE FULLTEXT INDEX` captured the B-tree root page ID **before** `apply_pending()`, which may cause root splits. The stale root was then used for pk2doc mappings and stored in the catalog
- Fix: re-read `root_page_id()` after `apply_pending()` and after `fts_put_doc_mapping()`, storing the final root in the catalog

## Test plan
- [x] Added `test_fts_multi_match` — 4 documents, 3 matching, verifies all 3 are returned
- [x] All existing FTS tests pass (7/7)
- [x] Full test suite passes with no regressions
- [x] `cargo clippy` clean

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)