### PR TITLE
feat: add hex literal (X'...') support for VARBINARY

### DIFF
--- a/docs-site/src/roadmap.md
+++ b/docs-site/src/roadmap.md
@@ -8,6 +8,7 @@
 - [x] CREATE FULLTEXT INDEX (bigram, BM25, NATURAL/BOOLEAN mode, snippet)
 - [x] MySQL-compatible integer types (TINYINT, SMALLINT, INT, BIGINT)
 - [x] VARCHAR(n), VARBINARY(n), TEXT with size validation
+- [x] Hex literal (`X'...'`) for VARBINARY data
 - [x] WHERE with comparison operators (=, !=, <, >, <=, >=)
 - [x] AND, OR logical operators
 - [x] ORDER BY (ASC/DESC, multi-column), LIMIT

--- a/docs-site/src/user-guide/sql-reference.md
+++ b/docs-site/src/user-guide/sql-reference.md
@@ -311,6 +311,29 @@ SELECT * FROM t LIMIT 10;
 SELECT * FROM t LIMIT 10 OFFSET 5;
 ```
 
+## Literals
+
+### Hex Literal (Binary)
+
+Binary data can be specified using the `X'...'` syntax (SQL standard / MySQL compatible):
+
+```sql
+-- Insert binary data
+INSERT INTO t (id, data) VALUES (1, X'DEADBEEF');
+
+-- Empty binary literal
+INSERT INTO t (id, data) VALUES (2, X'');
+
+-- Case-insensitive (both X and x are accepted)
+INSERT INTO t (id, data) VALUES (3, x'cafebabe');
+
+-- Use in WHERE clause
+SELECT * FROM t WHERE data = X'DEADBEEF';
+```
+
+The hex string must contain an even number of hex digits (`0-9`, `A-F`, `a-f`).
+Odd-length hex strings and invalid characters produce a parse error.
+
 ## Expressions
 
 ### Arithmetic operators

--- a/src/sql/lexer.rs
+++ b/src/sql/lexer.rs
@@ -120,6 +120,7 @@ pub enum Token {
     Integer(i64),
     Float(f64),
     StringLit(String),
+    HexLiteral(Vec<u8>),
 
     // Identifiers
     Ident(String),
@@ -165,6 +166,17 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, String> {
                 tokens.push(token);
                 remaining = rest;
             }
+            Err(nom::Err::Failure(e)) => {
+                if e.code == nom::error::ErrorKind::HexDigit {
+                    // Determine if it's odd digits or invalid character
+                    let snippet = &remaining[..remaining.len().min(30)];
+                    return Err(format!("Invalid hex literal: {}", snippet));
+                }
+                return Err(format!(
+                    "Unexpected character at: '{}'",
+                    &remaining[..remaining.len().min(20)]
+                ));
+            }
             Err(_) => {
                 return Err(format!(
                     "Unexpected character at: '{}'",
@@ -178,12 +190,56 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, String> {
 }
 
 fn lex_token(input: &str) -> IResult<&str, Token> {
+    // Check for hex literal X'...' or x'...' before keyword/ident
+    if (input.starts_with("X'") || input.starts_with("x'")) && input.len() >= 2 {
+        return lex_hex_literal(input);
+    }
     alt((
         lex_symbol,
         lex_string_literal,
         lex_number,
         lex_keyword_or_ident,
     ))(input)
+}
+
+fn lex_hex_literal(input: &str) -> IResult<&str, Token> {
+    // input starts with X' or x'
+    let rest = &input[2..]; // skip X'
+    let mut hex_end = 0usize;
+    for c in rest.chars() {
+        if c == '\'' {
+            break;
+        }
+        if !c.is_ascii_hexdigit() {
+            return Err(nom::Err::Failure(nom::error::Error::new(
+                input,
+                nom::error::ErrorKind::HexDigit,
+            )));
+        }
+        hex_end += c.len_utf8();
+    }
+    let hex_str = &rest[..hex_end];
+    // Check closing quote
+    if rest.len() <= hex_end || rest.as_bytes()[hex_end] != b'\'' {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Char,
+        )));
+    }
+    // Odd number of hex digits is an error
+    if !hex_str.len().is_multiple_of(2) {
+        return Err(nom::Err::Failure(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::HexDigit,
+        )));
+    }
+    let bytes: Vec<u8> = (0..hex_str.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&hex_str[i..i + 2], 16).unwrap())
+        .collect();
+    // skip past closing quote
+    let remaining = &rest[hex_end + 1..];
+    Ok((remaining, Token::HexLiteral(bytes)))
 }
 
 fn lex_symbol(input: &str) -> IResult<&str, Token> {

--- a/src/sql/parser/expr_and_select.rs
+++ b/src/sql/parser/expr_and_select.rs
@@ -651,6 +651,10 @@ impl Parser {
                 self.advance();
                 Ok(Expr::StringLiteral(s))
             }
+            Some(Token::HexLiteral(bytes)) => {
+                self.advance();
+                Ok(Expr::BlobLiteral(bytes))
+            }
             Some(Token::Null) => {
                 self.advance();
                 Ok(Expr::Null)

--- a/tests/hex_literal_tests.rs
+++ b/tests/hex_literal_tests.rs
@@ -1,0 +1,180 @@
+use murodb::crypto::aead::MasterKey;
+use murodb::schema::catalog::SystemCatalog;
+use murodb::sql::executor::{execute, ExecResult};
+use murodb::sql::lexer::{tokenize, Token};
+use murodb::storage::pager::Pager;
+use murodb::types::Value;
+use tempfile::TempDir;
+
+fn test_key() -> MasterKey {
+    MasterKey::new([0x42u8; 32])
+}
+
+fn setup() -> (Pager, SystemCatalog, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let mut pager = Pager::create(&db_path, &test_key()).unwrap();
+    let catalog = SystemCatalog::create(&mut pager).unwrap();
+    (pager, catalog, dir)
+}
+
+#[test]
+fn test_hex_literal_tokenize() {
+    let tokens = tokenize("X'DEADBEEF'").unwrap();
+    assert_eq!(
+        tokens,
+        vec![Token::HexLiteral(vec![0xDE, 0xAD, 0xBE, 0xEF])]
+    );
+}
+
+#[test]
+fn test_hex_literal_lowercase() {
+    let tokens = tokenize("x'deadbeef'").unwrap();
+    assert_eq!(
+        tokens,
+        vec![Token::HexLiteral(vec![0xDE, 0xAD, 0xBE, 0xEF])]
+    );
+}
+
+#[test]
+fn test_hex_literal_empty() {
+    let tokens = tokenize("X''").unwrap();
+    assert_eq!(tokens, vec![Token::HexLiteral(vec![])]);
+}
+
+#[test]
+fn test_hex_literal_odd_digits_error() {
+    let result = tokenize("X'DEA'");
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_hex_literal_invalid_chars_error() {
+    let result = tokenize("X'GGGG'");
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_hex_literal_insert_and_select() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE bin_data (id BIGINT PRIMARY KEY, val VARBINARY(256))",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    execute(
+        "INSERT INTO bin_data VALUES (1, X'DEADBEEF')",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    let result = execute(
+        "SELECT val FROM bin_data WHERE id = 1",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    if let ExecResult::Rows(rows) = result {
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].get("val"),
+            Some(&Value::Varbinary(vec![0xDE, 0xAD, 0xBE, 0xEF]))
+        );
+    } else {
+        panic!("Expected Rows result");
+    }
+}
+
+#[test]
+fn test_hex_literal_empty_insert() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE bin_data (id BIGINT PRIMARY KEY, val VARBINARY(256))",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    execute(
+        "INSERT INTO bin_data VALUES (1, X'')",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    let result = execute(
+        "SELECT val FROM bin_data WHERE id = 1",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    if let ExecResult::Rows(rows) = result {
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].get("val"), Some(&Value::Varbinary(vec![])));
+    } else {
+        panic!("Expected Rows result");
+    }
+}
+
+#[test]
+fn test_hex_literal_length_exceeded() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE bin_data (id BIGINT PRIMARY KEY, val VARBINARY(4))",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    let result = execute(
+        "INSERT INTO bin_data VALUES (1, X'DEADBEEFCAFE')",
+        &mut pager,
+        &mut catalog,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_hex_literal_where_clause() {
+    let (mut pager, mut catalog, _dir) = setup();
+
+    execute(
+        "CREATE TABLE bin_data (id BIGINT PRIMARY KEY, val VARBINARY(256))",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    execute(
+        "INSERT INTO bin_data VALUES (1, X'DEADBEEF')",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    execute(
+        "INSERT INTO bin_data VALUES (2, X'CAFEBABE')",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+
+    let result = execute(
+        "SELECT id FROM bin_data WHERE val = X'DEADBEEF'",
+        &mut pager,
+        &mut catalog,
+    )
+    .unwrap();
+    if let ExecResult::Rows(rows) = result {
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].get("id"), Some(&Value::Integer(1)));
+    } else {
+        panic!("Expected Rows result");
+    }
+}


### PR DESCRIPTION
## Summary

- Add `X'...'` / `x'...'` hex literal syntax to the lexer and parser (SQL standard / MySQL compatible)
- Maps to existing `Expr::BlobLiteral` → `Value::Varbinary` pipeline, no storage layer changes needed
- Validates even number of hex digits and valid hex characters with clear error messages

## Test plan

- [x] `cargo test hex_literal` — 9 new tests (tokenizer, insert/select, WHERE, empty, length overflow, error cases)
- [x] `cargo test` — full regression suite passes
- [x] `cargo clippy` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)