### PR TITLE
fix: use appended sidecar suffixes for WAL/lock paths

### DIFF
--- a/docs-site/src/internals/files-and-locking.md
+++ b/docs-site/src/internals/files-and-locking.md
@@ -28,7 +28,7 @@ If you open database path `<db_path>`, MuroDB uses:
 Example:
 
 - if `<db_path> = mydata`, files are `mydata`, `mydata.wal`, `mydata.lock`
-- if `<db_path> = mydb.db`, files are `mydb.db`, `mydb.wal`, `mydb.lock`
+- if `<db_path> = mydb.db`, files are `mydb.db`, `mydb.db.wal`, `mydb.db.lock`
 
 ## Main DB File Layout
 

--- a/src/bin/murodb_bench.rs
+++ b/src/bin/murodb_bench.rs
@@ -411,6 +411,8 @@ fn main() {
         println!("kept_db_path={}", db_path.display());
     } else {
         let _ = std::fs::remove_file(&db_path);
-        let _ = std::fs::remove_file(db_path.with_extension("wal"));
+        let mut wal_os = db_path.as_os_str().to_os_string();
+        wal_os.push(".wal");
+        let _ = std::fs::remove_file(PathBuf::from(wal_os));
     }
 }

--- a/src/concurrency/mod.rs
+++ b/src/concurrency/mod.rs
@@ -23,7 +23,9 @@ pub struct LockManager {
 
 impl LockManager {
     pub fn new(db_path: &Path) -> Result<Self> {
-        let lock_path = db_path.with_extension("lock");
+        let mut lock_os = db_path.as_os_str().to_os_string();
+        lock_os.push(".lock");
+        let lock_path = PathBuf::from(lock_os);
         let lock_file = OpenOptions::new()
             .create(true)
             .truncate(false)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,30 @@ pub enum DatabaseEncryption {
 }
 
 fn wal_path(db_path: &Path) -> PathBuf {
-    db_path.with_extension("wal")
+    let mut s = db_path.as_os_str().to_os_string();
+    s.push(".wal");
+    PathBuf::from(s)
+}
+
+/// Migrate legacy sidecar files that used `with_extension()` (which replaces
+/// the extension) to the new append-suffix naming.
+/// e.g. `mydb.wal` → `mydb.db.wal` when db_path is `mydb.db`.
+fn migrate_legacy_sidecar_paths(db_path: &Path) {
+    for suffix in &["wal", "lock"] {
+        let legacy = db_path.with_extension(suffix);
+        let new = {
+            let mut s = db_path.as_os_str().to_os_string();
+            s.push(".");
+            s.push(suffix);
+            PathBuf::from(s)
+        };
+        // Only migrate when the paths actually differ (i.e. db_path had an extension)
+        // and the legacy file exists but the new one does not.
+        if legacy != new && legacy.exists() && !new.exists() {
+            let _ = std::fs::rename(&legacy, &new);
+            sync_dir(&new);
+        }
+    }
 }
 
 /// Best-effort directory fsync to persist metadata (new file, rename, truncate).
@@ -206,6 +229,7 @@ impl Database {
         master_key: &MasterKey,
         recovery_mode: RecoveryMode,
     ) -> Result<(Self, Option<RecoveryResult>)> {
+        migrate_legacy_sidecar_paths(path);
         let wp = wal_path(path);
         let mut recovery_report = None;
 
@@ -251,6 +275,7 @@ impl Database {
         path: &Path,
         recovery_mode: RecoveryMode,
     ) -> Result<(Self, Option<RecoveryResult>)> {
+        migrate_legacy_sidecar_paths(path);
         let wp = wal_path(path);
         let mut recovery_report = None;
 

--- a/tests/crash_matrix.rs
+++ b/tests/crash_matrix.rs
@@ -49,7 +49,7 @@ enum PriorTx {
 fn setup_db(prior: PriorTx) -> (TempDir, std::path::PathBuf, std::path::PathBuf, u64, u64) {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
 
     let mut pager = Pager::create(&db_path, &test_key()).unwrap();
 
@@ -459,7 +459,7 @@ fn test_crash_recovery_freelist_content_consistent() {
     // After recovery, the freelist content should match the last committed freelist
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
 
     // Create DB and commit a transaction that frees a page
     {
@@ -501,7 +501,7 @@ fn test_crash_page_count_monotonic() {
     // page_count should never decrease across transactions
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
 
     {
         let mut pager = Pager::create(&db_path, &test_key()).unwrap();

--- a/tests/crash_stress.rs
+++ b/tests/crash_stress.rs
@@ -309,7 +309,9 @@ fn save_failure_artifacts(
     let _ = fs::create_dir_all(artifact_dir);
     let _ = fs::copy(db_path, artifact_dir.join("stress.db"));
     // Also copy the WAL file if present
-    let wal_path = db_path.with_extension("wal");
+    let mut wal_os = db_path.as_os_str().to_os_string();
+    wal_os.push(".wal");
+    let wal_path = PathBuf::from(wal_os);
     if wal_path.exists() {
         let _ = fs::copy(&wal_path, artifact_dir.join("stress.wal"));
     }

--- a/tests/fts_overflow_recovery.rs
+++ b/tests/fts_overflow_recovery.rs
@@ -38,7 +38,7 @@ fn assert_overflow_doc_searchable(db_path: &std::path::Path, fts_root: u64) {
 fn setup_committed_overflow_wal() -> (TempDir, std::path::PathBuf, std::path::PathBuf, u64) {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
     let mut pager = Pager::create(&db_path, &test_key()).unwrap();
     let mut wal = WalWriter::create(&wal_path, &test_key()).unwrap();
 
@@ -101,7 +101,7 @@ fn test_fts_overflow_recovery_with_torn_wal_tail() {
 fn test_fts_overflow_recovery_after_post_wal_sync_partial_write() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
     let mut pager = Pager::create(&db_path, &test_key()).unwrap();
     let mut wal = WalWriter::create(&wal_path, &test_key()).unwrap();
 

--- a/tests/post_wal_sync_failpoints.rs
+++ b/tests/post_wal_sync_failpoints.rs
@@ -30,7 +30,7 @@ fn setup_with_post_sync_failure(
 ) -> (TempDir, std::path::PathBuf, std::path::PathBuf) {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
 
     let mut pager = Pager::create(&db_path, &test_key()).unwrap();
     let mut wal = WalWriter::create(&wal_path, &test_key()).unwrap();
@@ -183,7 +183,7 @@ fn test_flush_meta_failure_recovery_metadata_correct() {
 fn test_write_page_failure_with_freed_pages_recovery() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
 
     let mut pager = Pager::create(&db_path, &test_key()).unwrap();
     let mut wal = WalWriter::create(&wal_path, &test_key()).unwrap();
@@ -228,7 +228,7 @@ fn test_write_page_failure_with_freed_pages_recovery() {
 fn test_flush_meta_failure_with_freed_pages_recovery() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
 
     let mut pager = Pager::create(&db_path, &test_key()).unwrap();
     let mut wal = WalWriter::create(&wal_path, &test_key()).unwrap();

--- a/tests/transaction_tests.rs
+++ b/tests/transaction_tests.rs
@@ -13,7 +13,7 @@ fn test_key() -> MasterKey {
 fn setup_session() -> (Session, TempDir) {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
     let mut pager = Pager::create(&db_path, &test_key()).unwrap();
     let catalog = SystemCatalog::create(&mut pager).unwrap();
     pager.set_catalog_root(catalog.root_page_id());

--- a/tests/wal_idempotent_recovery.rs
+++ b/tests/wal_idempotent_recovery.rs
@@ -44,7 +44,7 @@ fn read_logical_state(db_path: &std::path::Path) -> (Vec<Vec<u8>>, u64, u64, u64
 fn test_idempotent_recovery_single_tx() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
     let wal_backup = dir.path().join("test.wal.bak");
 
     // Create DB and commit one transaction to WAL (no checkpoint)
@@ -87,7 +87,7 @@ fn test_idempotent_recovery_single_tx() {
 fn test_idempotent_recovery_multiple_tx() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
     let wal_backup = dir.path().join("test.wal.bak");
 
     {
@@ -147,7 +147,7 @@ fn test_idempotent_recovery_multiple_tx() {
 fn test_idempotent_recovery_with_torn_tail() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
     let wal_backup = dir.path().join("test.wal.bak");
 
     {

--- a/tests/wal_recovery.rs
+++ b/tests/wal_recovery.rs
@@ -16,7 +16,7 @@ fn test_key() -> MasterKey {
 #[test]
 fn test_wal_write_and_read() {
     let dir = TempDir::new().unwrap();
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
 
     {
         let mut writer = WalWriter::create(&wal_path, &test_key()).unwrap();
@@ -64,7 +64,7 @@ fn test_wal_write_and_read() {
 fn test_recovery_replays_committed_only() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
 
     // Create database
     {
@@ -177,7 +177,7 @@ fn test_recovery_restores_metadata_prevents_page_reuse() {
 fn test_permissive_open_quarantines_malformed_wal() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
 
     {
         let _pager = Pager::create(&db_path, &test_key()).unwrap();
@@ -217,7 +217,7 @@ fn test_permissive_open_quarantines_malformed_wal() {
 fn test_truncated_wal_tail_recovery() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
 
     // Create database with one page
     {
@@ -284,7 +284,7 @@ fn test_truncated_wal_tail_recovery() {
 fn test_corrupt_tail_frame_recovery() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
 
     {
         let mut pager = Pager::create(&db_path, &test_key()).unwrap();
@@ -393,7 +393,7 @@ fn test_catalog_root_durable_after_commit() {
 fn test_wal_is_checkpointed_after_successful_commit() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
 
     let mut db = murodb::Database::create(&db_path, &test_key()).unwrap();
     db.execute("CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)")
@@ -415,7 +415,7 @@ fn test_wal_is_checkpointed_after_successful_commit() {
 fn test_wal_is_checkpointed_after_explicit_rollback() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
 
     let mut db = murodb::Database::create(&db_path, &test_key()).unwrap();
     db.execute("CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)")
@@ -499,7 +499,7 @@ fn test_freelist_persisted_across_reopen() {
 fn test_freelist_wal_recovery() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
 
     // Create DB, insert and delete to create freelist entries
     {
@@ -579,7 +579,7 @@ fn test_rollback_discards_freed_pages() {
 fn test_interleaved_txs_with_tail_corruption() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
 
     {
         let mut pager = Pager::create(&db_path, &test_key()).unwrap();
@@ -656,7 +656,7 @@ fn test_interleaved_txs_with_tail_corruption() {
 fn test_corruption_at_transaction_boundary() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
 
     {
         let mut pager = Pager::create(&db_path, &test_key()).unwrap();
@@ -717,7 +717,7 @@ fn test_corruption_at_transaction_boundary() {
 fn test_committed_tx_then_aborted_tx_then_crash() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
 
     {
         let mut pager = Pager::create(&db_path, &test_key()).unwrap();
@@ -793,7 +793,7 @@ fn test_committed_tx_then_aborted_tx_then_crash() {
 fn test_multi_tx_committed_then_crash_mid_commit() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
 
     // Create DB and insert 3 committed transactions
     {
@@ -915,7 +915,7 @@ fn test_recovery_catalog_page_count_data_consistency() {
 fn test_recovery_truncates_wal_durably() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
 
     // Create DB with some data
     {

--- a/tests/wal_torn_tail.rs
+++ b/tests/wal_torn_tail.rs
@@ -23,7 +23,7 @@ fn test_key() -> MasterKey {
 fn setup_committed_with_pending_wal() -> (TempDir, std::path::PathBuf, std::path::PathBuf, u64) {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
-    let wal_path = dir.path().join("test.wal");
+    let wal_path = dir.path().join("test.db.wal");
 
     let mut pager = Pager::create(&db_path, &test_key()).unwrap();
     let mut wal = WalWriter::create(&wal_path, &test_key()).unwrap();


### PR DESCRIPTION
## Summary
- Change WAL and lock file path generation from `Path::with_extension()` (which **replaces** the extension) to appending `.wal`/`.lock` suffixes, so `mydb.db` produces `mydb.db.wal` instead of `mydb.wal`
- Add backward-compatible migration logic that auto-renames legacy sidecar files on database open
- Update all integration tests and documentation to reflect the new naming

Closes #153

## Test plan
- [x] `cargo build` compiles
- [x] `cargo test` — all tests pass
- [x] `cargo clippy` — no warnings
- [ ] Verify that opening a database created with the old naming scheme auto-migrates WAL/lock files

🤖 Generated with [Claude Code](https://claude.com/claude-code)