### PR TITLE
feat: add JSONB type and JSONPath function support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,6 +576,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonpath_lib"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,6 +656,7 @@ dependencies = [
  "clap",
  "fs4",
  "hmac",
+ "jsonpath_lib",
  "lru",
  "nom",
  "parking_lot",
@@ -653,6 +665,7 @@ dependencies = [
  "rpassword",
  "rust_decimal",
  "rustyline",
+ "serde_json",
  "sha2",
  "tempfile",
  "thiserror",
@@ -1064,6 +1077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1092,6 +1106,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ rand = "0.8"
 uuid = { version = "1", features = ["v4", "v7"] }
 regex = "1"
 rust_decimal = "1"
+serde_json = "1"
+jsonpath_lib = "0.3"
 base64 = "0.22"
 zeroize = { version = "1", features = ["derive"] }
 thiserror = "2"

--- a/docs-site/src/user-guide/sql-reference.md
+++ b/docs-site/src/user-guide/sql-reference.md
@@ -14,6 +14,7 @@
 | TIMESTAMP | 8 bytes | `YYYY-MM-DD HH:MM:SS` (timezone-aware input, normalized to UTC) |
 | VARCHAR(n) | variable | max n bytes (optional) |
 | TEXT | variable | unbounded text |
+| JSONB | variable | Canonical JSON text (validated on write) |
 | VARBINARY(n) | variable | max n bytes (optional) |
 | FLOAT | 4 bytes | Single-precision IEEE 754 |
 | DOUBLE | 8 bytes | Double-precision IEEE 754 |
@@ -682,7 +683,63 @@ SELECT CAST(42 AS VARCHAR);    -- '42'
 SELECT CAST(val AS BIGINT) FROM t;
 ```
 
-Supported target types: TINYINT, SMALLINT, INT, BIGINT, FLOAT, DOUBLE, DECIMAL(p,s), DATE, DATETIME, TIMESTAMP, VARCHAR, TEXT, VARBINARY.
+Supported target types: TINYINT, SMALLINT, INT, BIGINT, FLOAT, DOUBLE, DECIMAL(p,s), DATE, DATETIME, TIMESTAMP, VARCHAR, TEXT, JSONB, VARBINARY.
+
+### JSON Functions
+
+`JSONB` accepts valid JSON only. Values are canonicalized when stored.
+
+```sql
+CREATE TABLE docs (id BIGINT PRIMARY KEY, doc JSONB);
+INSERT INTO docs VALUES (1, '{"a":{"b":[1,2,3]}}');
+```
+
+#### JSON_EXTRACT(json, path)
+
+Evaluates `path` using `jsonpath_lib` JSONPath semantics and returns matched JSON (canonical text). If multiple values match, returns a JSON array.
+
+```sql
+SELECT JSON_EXTRACT('{"a":{"b":1}}', '$.a.b'); -- "1"
+```
+
+#### JSON_SET(json, path, value)
+
+Sets `value` at `path` and returns updated JSON. Supported update-path syntax is root-based dot/index form (`$.key`, `$.arr[0]`, chained combinations).
+
+```sql
+SELECT JSON_SET('{"a":1}', '$.b', 2); -- {"a":1,"b":2}
+```
+
+#### JSON_REMOVE(json, path)
+
+Removes value at `path` and returns updated JSON. Missing path is a no-op.
+
+```sql
+SELECT JSON_REMOVE('{"a":1,"b":2}', '$.a'); -- {"b":2}
+```
+
+#### JSON_TYPE(json)
+
+Returns one of: `NULL`, `BOOLEAN`, `INTEGER`, `DOUBLE`, `STRING`, `ARRAY`, `OBJECT`.
+
+```sql
+SELECT JSON_TYPE('[1,2,3]'); -- ARRAY
+```
+
+#### JSON_CONTAINS(json, value_or_path)
+
+- If second argument starts with `$`, it is evaluated as JSONPath (via `jsonpath_lib`); returns `1` when any match exists.
+- Otherwise it is treated as a JSON candidate value and checked for containment.
+
+```sql
+SELECT JSON_CONTAINS('{"a":{"b":1}}', '$.a.b'); -- 1
+SELECT JSON_CONTAINS('{"a":1,"b":2}', '{"b":2}'); -- 1
+```
+
+JSON function behavior:
+- If any argument is `NULL`, returns `NULL`.
+- Invalid JSON input returns an error.
+- Invalid/unsupported update-path syntax in `JSON_SET`/`JSON_REMOVE` returns an error.
 
 ## Aggregation & GROUP BY
 

--- a/src/schema/column.rs
+++ b/src/schema/column.rs
@@ -101,6 +101,7 @@ impl ColumnDef {
             DataType::Timestamp => 12,
             DataType::Uuid => 13,
             DataType::Decimal(_, _) => 14,
+            DataType::Jsonb => 15,
         });
         // flags
         let mut flags: u8 = 0;
@@ -229,6 +230,7 @@ impl ColumnDef {
                 consumed += 4;
                 DataType::Decimal(p, s)
             }
+            15 => DataType::Jsonb,
             _ => return None,
         };
 
@@ -352,6 +354,7 @@ mod tests {
             DataType::Varbinary(None),
             DataType::Varbinary(Some(512)),
             DataType::Text,
+            DataType::Jsonb,
             DataType::Uuid,
             DataType::Decimal(10, 0),
             DataType::Decimal(18, 2),

--- a/src/sql/eval.rs
+++ b/src/sql/eval.rs
@@ -408,6 +408,82 @@ mod tests {
     }
 
     #[test]
+    fn test_eval_json_functions() {
+        let lookup = |_: &str| -> Option<Value> { None };
+
+        let extract_expr = Expr::FunctionCall {
+            name: "JSON_EXTRACT".into(),
+            args: vec![
+                Expr::StringLiteral("{\"a\":{\"b\":1}}".into()),
+                Expr::StringLiteral("$.a.b".into()),
+            ],
+        };
+        assert_eq!(
+            eval_expr(&extract_expr, &lookup).unwrap(),
+            Value::Varchar("1".into())
+        );
+
+        let set_expr = Expr::FunctionCall {
+            name: "JSON_SET".into(),
+            args: vec![
+                Expr::StringLiteral("{\"a\":1}".into()),
+                Expr::StringLiteral("$.b".into()),
+                Expr::IntLiteral(2),
+            ],
+        };
+        assert_eq!(
+            eval_expr(&set_expr, &lookup).unwrap(),
+            Value::Varchar("{\"a\":1,\"b\":2}".into())
+        );
+
+        let remove_expr = Expr::FunctionCall {
+            name: "JSON_REMOVE".into(),
+            args: vec![
+                Expr::StringLiteral("{\"a\":1,\"b\":2}".into()),
+                Expr::StringLiteral("$.a".into()),
+            ],
+        };
+        assert_eq!(
+            eval_expr(&remove_expr, &lookup).unwrap(),
+            Value::Varchar("{\"b\":2}".into())
+        );
+
+        let type_expr = Expr::FunctionCall {
+            name: "JSON_TYPE".into(),
+            args: vec![Expr::StringLiteral("[1,2,3]".into())],
+        };
+        assert_eq!(
+            eval_expr(&type_expr, &lookup).unwrap(),
+            Value::Varchar("ARRAY".into())
+        );
+
+        let contains_expr = Expr::FunctionCall {
+            name: "JSON_CONTAINS".into(),
+            args: vec![
+                Expr::StringLiteral("{\"a\":1,\"b\":2}".into()),
+                Expr::StringLiteral("{\"b\":2}".into()),
+            ],
+        };
+        assert_eq!(
+            eval_expr(&contains_expr, &lookup).unwrap(),
+            Value::Integer(1)
+        );
+    }
+
+    #[test]
+    fn test_json_extract_invalid_path_is_error() {
+        let lookup = |_: &str| -> Option<Value> { None };
+        let expr = Expr::FunctionCall {
+            name: "JSON_EXTRACT".into(),
+            args: vec![
+                Expr::StringLiteral("{\"a\":1}".into()),
+                Expr::StringLiteral("a".into()),
+            ],
+        };
+        assert!(eval_expr(&expr, &lookup).is_err());
+    }
+
+    #[test]
     fn test_like_patterns() {
         assert!(like_match("hello", "hello"));
         assert!(like_match("hello", "%"));

--- a/src/sql/eval/cast.rs
+++ b/src/sql/eval/cast.rs
@@ -4,6 +4,7 @@ use crate::types::{
     parse_timestamp_string, parse_uuid_string, DataType, Value,
 };
 use rust_decimal::prelude::ToPrimitive;
+use serde_json::Value as JsonValue;
 
 pub(super) fn eval_cast(val: &Value, target_type: &DataType) -> Result<Value> {
     const I64_MIN_F64: f64 = -9_223_372_036_854_775_808.0; // -2^63
@@ -174,6 +175,19 @@ pub(super) fn eval_cast(val: &Value, target_type: &DataType) -> Result<Value> {
             };
             Ok(Value::Varchar(s))
         }
+        DataType::Jsonb => match val {
+            Value::Varchar(s) => Ok(Value::Varchar(canonicalize_json_text(s)?)),
+            Value::Varbinary(b) => {
+                let s = std::str::from_utf8(b).map_err(|_| {
+                    MuroError::Execution("Cannot cast non-UTF8 VARBINARY to JSONB".into())
+                })?;
+                Ok(Value::Varchar(canonicalize_json_text(s)?))
+            }
+            Value::Date(_) | Value::DateTime(_) | Value::Timestamp(_) | Value::Uuid(_) => {
+                Ok(Value::Varchar(json_string_literal(&val.to_string())?))
+            }
+            _ => Ok(Value::Varchar(canonicalize_json_text(&val.to_string())?)),
+        },
         DataType::Varbinary(_) => match val {
             Value::Varbinary(b) => Ok(Value::Varbinary(b.clone())),
             Value::Varchar(s) => Ok(Value::Varbinary(s.as_bytes().to_vec())),
@@ -207,4 +221,16 @@ pub(super) fn eval_cast(val: &Value, target_type: &DataType) -> Result<Value> {
             ))),
         },
     }
+}
+
+fn canonicalize_json_text(s: &str) -> Result<String> {
+    let parsed: JsonValue = serde_json::from_str(s)
+        .map_err(|e| MuroError::Execution(format!("Invalid JSON: {}", e)))?;
+    serde_json::to_string(&parsed)
+        .map_err(|e| MuroError::Execution(format!("Failed to canonicalize JSON: {}", e)))
+}
+
+fn json_string_literal(s: &str) -> Result<String> {
+    serde_json::to_string(s)
+        .map_err(|e| MuroError::Execution(format!("Failed to encode JSON string: {}", e)))
 }

--- a/src/sql/eval/functions.rs
+++ b/src/sql/eval/functions.rs
@@ -1,6 +1,7 @@
 use crate::error::{MuroError, Result};
 use crate::sql::ast::Expr;
 use crate::types::{parse_date_string, parse_timestamp_string, Value};
+use serde_json::Value as JsonValue;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::compare::{is_truthy, value_cmp};
@@ -538,6 +539,94 @@ pub(super) fn eval_function_call(
                 )),
             }
         }
+        "JSON_EXTRACT" => {
+            check_args(name, args, 2)?;
+            let vals = eval_args_null_check(args, columns)?;
+            let vals = match vals {
+                Some(v) => v,
+                None => return Ok(Value::Null),
+            };
+            let doc = parse_json_doc(&vals[0])?;
+            let path = vals[1].to_string();
+            let hits = jsonpath_lib::select(&doc, &path).map_err(|e| {
+                MuroError::Execution(format!("JSON_EXTRACT invalid path '{}': {}", path, e))
+            })?;
+            if hits.is_empty() {
+                return Ok(Value::Null);
+            }
+            if hits.len() == 1 {
+                return Ok(Value::Varchar(canonical_json(hits[0])?));
+            }
+            let arr = JsonValue::Array(hits.into_iter().cloned().collect());
+            Ok(Value::Varchar(canonical_json(&arr)?))
+        }
+        "JSON_SET" => {
+            check_args(name, args, 3)?;
+            let vals = eval_args_null_check(args, columns)?;
+            let vals = match vals {
+                Some(v) => v,
+                None => return Ok(Value::Null),
+            };
+            let mut doc = parse_json_doc(&vals[0])?;
+            let path = vals[1].to_string();
+            let parsed_path = parse_json_path(&path)?;
+            let json_value = sql_value_to_json_value(&vals[2]);
+            set_json_path(&mut doc, &parsed_path, json_value);
+            Ok(Value::Varchar(canonical_json(&doc)?))
+        }
+        "JSON_REMOVE" => {
+            check_args(name, args, 2)?;
+            let vals = eval_args_null_check(args, columns)?;
+            let vals = match vals {
+                Some(v) => v,
+                None => return Ok(Value::Null),
+            };
+            let mut doc = parse_json_doc(&vals[0])?;
+            let path = vals[1].to_string();
+            let parsed_path = parse_json_path(&path)?;
+            remove_json_path(&mut doc, &parsed_path);
+            Ok(Value::Varchar(canonical_json(&doc)?))
+        }
+        "JSON_TYPE" => {
+            check_args(name, args, 1)?;
+            let val = eval_expr(&args[0], columns)?;
+            if val.is_null() {
+                return Ok(Value::Null);
+            }
+            let doc = parse_json_doc(&val)?;
+            let type_name = match doc {
+                JsonValue::Null => "NULL",
+                JsonValue::Bool(_) => "BOOLEAN",
+                JsonValue::Number(ref n) if n.is_i64() || n.is_u64() => "INTEGER",
+                JsonValue::Number(_) => "DOUBLE",
+                JsonValue::String(_) => "STRING",
+                JsonValue::Array(_) => "ARRAY",
+                JsonValue::Object(_) => "OBJECT",
+            };
+            Ok(Value::Varchar(type_name.to_string()))
+        }
+        "JSON_CONTAINS" => {
+            check_args(name, args, 2)?;
+            let vals = eval_args_null_check(args, columns)?;
+            let vals = match vals {
+                Some(v) => v,
+                None => return Ok(Value::Null),
+            };
+            let doc = parse_json_doc(&vals[0])?;
+            let contains = if let Value::Varchar(s) = &vals[1] {
+                if s.starts_with('$') {
+                    let hits = jsonpath_lib::select(&doc, s).map_err(|e| {
+                        MuroError::Execution(format!("JSON_CONTAINS invalid path '{}': {}", s, e))
+                    })?;
+                    !hits.is_empty()
+                } else {
+                    deep_json_contains(&doc, &sql_value_to_json_value(&vals[1]))
+                }
+            } else {
+                deep_json_contains(&doc, &sql_value_to_json_value(&vals[1]))
+            };
+            Ok(Value::Integer(if contains { 1 } else { 0 }))
+        }
 
         // UUID functions
         "UUID_V4" => {
@@ -739,6 +828,212 @@ fn civil_from_days(z: i64) -> (i32, i32, i32) {
     let m = mp + if mp < 10 { 3 } else { -9 };
     let y = y + if m <= 2 { 1 } else { 0 };
     (y as i32, m as i32, d as i32)
+}
+
+#[derive(Debug)]
+enum JsonPathSegment {
+    Key(String),
+    Index(usize),
+}
+
+fn canonical_json(v: &JsonValue) -> Result<String> {
+    serde_json::to_string(v)
+        .map_err(|e| MuroError::Execution(format!("JSON serialization error: {}", e)))
+}
+
+fn parse_json_doc(val: &Value) -> Result<JsonValue> {
+    match val {
+        Value::Varchar(s) => serde_json::from_str(s)
+            .map_err(|e| MuroError::Execution(format!("Invalid JSON document: {}", e))),
+        Value::Varbinary(b) => {
+            let s = std::str::from_utf8(b)
+                .map_err(|_| MuroError::Execution("JSON document must be valid UTF-8".into()))?;
+            serde_json::from_str(s)
+                .map_err(|e| MuroError::Execution(format!("Invalid JSON document: {}", e)))
+        }
+        _ => serde_json::from_str(&val.to_string())
+            .map_err(|e| MuroError::Execution(format!("Invalid JSON document: {}", e))),
+    }
+}
+
+fn sql_value_to_json_value(val: &Value) -> JsonValue {
+    match val {
+        Value::Null => JsonValue::Null,
+        Value::Integer(n) => JsonValue::from(*n),
+        Value::Float(n) => serde_json::Number::from_f64(*n)
+            .map(JsonValue::Number)
+            .unwrap_or(JsonValue::Null),
+        Value::Decimal(d) => {
+            let s = d.to_string();
+            serde_json::from_str(&s).unwrap_or_else(|_| JsonValue::String(s))
+        }
+        Value::Date(_) | Value::DateTime(_) | Value::Timestamp(_) => {
+            JsonValue::String(val.to_string())
+        }
+        Value::Varchar(s) => {
+            serde_json::from_str(s).unwrap_or_else(|_| JsonValue::String(s.clone()))
+        }
+        Value::Varbinary(b) => JsonValue::String(String::from_utf8_lossy(b).to_string()),
+        Value::Uuid(b) => JsonValue::String(crate::types::format_uuid(b)),
+    }
+}
+
+fn parse_json_path(path: &str) -> Result<Vec<JsonPathSegment>> {
+    if !path.starts_with('$') {
+        return Err(MuroError::Execution(format!(
+            "JSON path must start with '$': {}",
+            path
+        )));
+    }
+    let chars: Vec<char> = path.chars().collect();
+    let mut i = 1usize;
+    let mut segs = Vec::new();
+    while i < chars.len() {
+        match chars[i] {
+            '.' => {
+                i += 1;
+                let start = i;
+                while i < chars.len() && (chars[i].is_ascii_alphanumeric() || chars[i] == '_') {
+                    i += 1;
+                }
+                if i == start {
+                    return Err(MuroError::Execution(format!(
+                        "Invalid JSON path near '{}'",
+                        path
+                    )));
+                }
+                segs.push(JsonPathSegment::Key(path[start..i].to_string()));
+            }
+            '[' => {
+                i += 1;
+                let start = i;
+                while i < chars.len() && chars[i].is_ascii_digit() {
+                    i += 1;
+                }
+                if i == start || i >= chars.len() || chars[i] != ']' {
+                    return Err(MuroError::Execution(format!(
+                        "Invalid JSON path near '{}'",
+                        path
+                    )));
+                }
+                let idx = path[start..i].parse::<usize>().map_err(|_| {
+                    MuroError::Execution(format!("Invalid JSON path index in '{}'", path))
+                })?;
+                i += 1;
+                segs.push(JsonPathSegment::Index(idx));
+            }
+            _ => {
+                return Err(MuroError::Execution(format!(
+                    "Unsupported JSON path syntax in '{}'",
+                    path
+                )))
+            }
+        }
+    }
+    Ok(segs)
+}
+
+fn set_json_path(root: &mut JsonValue, path: &[JsonPathSegment], value: JsonValue) {
+    if path.is_empty() {
+        *root = value;
+        return;
+    }
+    let mut cur = root;
+    for (idx, seg) in path.iter().enumerate() {
+        let is_last = idx + 1 == path.len();
+        match seg {
+            JsonPathSegment::Key(key) => {
+                if !cur.is_object() {
+                    *cur = JsonValue::Object(serde_json::Map::new());
+                }
+                let obj = cur.as_object_mut().expect("object just created");
+                if is_last {
+                    obj.insert(key.clone(), value);
+                    return;
+                }
+                let next = match path[idx + 1] {
+                    JsonPathSegment::Index(_) => JsonValue::Array(Vec::new()),
+                    JsonPathSegment::Key(_) => JsonValue::Object(serde_json::Map::new()),
+                };
+                cur = obj.entry(key.clone()).or_insert(next);
+            }
+            JsonPathSegment::Index(i) => {
+                if !cur.is_array() {
+                    *cur = JsonValue::Array(Vec::new());
+                }
+                let arr = cur.as_array_mut().expect("array just created");
+                while arr.len() <= *i {
+                    arr.push(JsonValue::Null);
+                }
+                if is_last {
+                    arr[*i] = value;
+                    return;
+                }
+                cur = &mut arr[*i];
+            }
+        }
+    }
+}
+
+fn remove_json_path(root: &mut JsonValue, path: &[JsonPathSegment]) {
+    if path.is_empty() {
+        *root = JsonValue::Null;
+        return;
+    }
+    let mut cur = root;
+    for seg in &path[..path.len().saturating_sub(1)] {
+        match seg {
+            JsonPathSegment::Key(key) => {
+                let Some(next) = cur.as_object_mut().and_then(|o| o.get_mut(key)) else {
+                    return;
+                };
+                cur = next;
+            }
+            JsonPathSegment::Index(i) => {
+                let Some(next) = cur.as_array_mut().and_then(|a| a.get_mut(*i)) else {
+                    return;
+                };
+                cur = next;
+            }
+        }
+    }
+    match path.last().expect("non-empty path") {
+        JsonPathSegment::Key(key) => {
+            if let Some(obj) = cur.as_object_mut() {
+                obj.remove(key);
+            }
+        }
+        JsonPathSegment::Index(i) => {
+            if let Some(arr) = cur.as_array_mut() {
+                if *i < arr.len() {
+                    arr.remove(*i);
+                }
+            }
+        }
+    }
+}
+
+fn deep_json_contains(haystack: &JsonValue, needle: &JsonValue) -> bool {
+    if json_contains_at_node(haystack, needle) {
+        return true;
+    }
+    match haystack {
+        JsonValue::Array(items) => items.iter().any(|v| deep_json_contains(v, needle)),
+        JsonValue::Object(map) => map.values().any(|v| deep_json_contains(v, needle)),
+        _ => false,
+    }
+}
+
+fn json_contains_at_node(haystack: &JsonValue, needle: &JsonValue) -> bool {
+    match (haystack, needle) {
+        (JsonValue::Object(h), JsonValue::Object(n)) => n
+            .iter()
+            .all(|(k, nv)| h.get(k).is_some_and(|hv| json_contains_at_node(hv, nv))),
+        (JsonValue::Array(h), JsonValue::Array(n)) => n
+            .iter()
+            .all(|nv| h.iter().any(|hv| json_contains_at_node(hv, nv))),
+        _ => haystack == needle,
+    }
 }
 
 fn check_args(name: &str, args: &[Expr], expected: usize) -> Result<()> {

--- a/src/sql/executor/alter.rs
+++ b/src/sql/executor/alter.rs
@@ -1,4 +1,5 @@
 use super::*;
+use serde_json::Value as JsonValue;
 
 pub(super) fn exec_alter_table(
     at: &AlterTable,
@@ -538,6 +539,7 @@ pub(super) fn coerce_value(value: &Value, target_type: DataType) -> Result<Value
                 "Cannot coerce integer to date/time type".into(),
             )),
             DataType::Varchar(_) | DataType::Text => Ok(Value::Varchar(n.to_string())),
+            DataType::Jsonb => Ok(Value::Varchar(canonicalize_json_text(&n.to_string())?)),
             DataType::Varbinary(_) => Err(MuroError::Execution(
                 "Cannot coerce integer to VARBINARY".into(),
             )),
@@ -563,6 +565,7 @@ pub(super) fn coerce_value(value: &Value, target_type: DataType) -> Result<Value
                 "Cannot coerce float to date/time type".into(),
             )),
             DataType::Varchar(_) | DataType::Text => Ok(Value::Varchar(n.to_string())),
+            DataType::Jsonb => Ok(Value::Varchar(canonicalize_json_text(&n.to_string())?)),
             DataType::Varbinary(_) => Err(MuroError::Execution(
                 "Cannot coerce floating-point value to VARBINARY".into(),
             )),
@@ -588,6 +591,7 @@ pub(super) fn coerce_value(value: &Value, target_type: DataType) -> Result<Value
                 Ok(Value::Float(n))
             }
             DataType::Varchar(_) | DataType::Text => Ok(Value::Varchar(d.to_string())),
+            DataType::Jsonb => Ok(Value::Varchar(canonicalize_json_text(&d.to_string())?)),
             _ => Err(MuroError::Execution(
                 "Cannot coerce DECIMAL to target type".into(),
             )),
@@ -631,6 +635,7 @@ pub(super) fn coerce_value(value: &Value, target_type: DataType) -> Result<Value
                 Ok(Value::Timestamp(ts))
             }
             DataType::Varchar(_) | DataType::Text => Ok(Value::Varchar(s.clone())),
+            DataType::Jsonb => Ok(Value::Varchar(canonicalize_json_text(s)?)),
             DataType::Varbinary(_) => Ok(Value::Varbinary(s.as_bytes().to_vec())),
             DataType::Uuid => {
                 let bytes = crate::types::parse_uuid_string(s).ok_or_else(|| {
@@ -644,6 +649,7 @@ pub(super) fn coerce_value(value: &Value, target_type: DataType) -> Result<Value
             DataType::DateTime => Ok(Value::DateTime((*d as i64) * 1_000_000)),
             DataType::Timestamp => Ok(Value::Timestamp((*d as i64) * 1_000_000)),
             DataType::Varchar(_) | DataType::Text => Ok(Value::Varchar(format_date(*d))),
+            DataType::Jsonb => Ok(Value::Varchar(json_string_literal(&format_date(*d))?)),
             _ => Err(MuroError::Execution(
                 "Cannot coerce DATE to target type".into(),
             )),
@@ -653,6 +659,7 @@ pub(super) fn coerce_value(value: &Value, target_type: DataType) -> Result<Value
             DataType::Timestamp => Ok(Value::Timestamp(*dt)),
             DataType::Date => Ok(Value::Date((*dt / 1_000_000) as i32)),
             DataType::Varchar(_) | DataType::Text => Ok(Value::Varchar(format_datetime(*dt))),
+            DataType::Jsonb => Ok(Value::Varchar(json_string_literal(&format_datetime(*dt))?)),
             _ => Err(MuroError::Execution(
                 "Cannot coerce DATETIME to target type".into(),
             )),
@@ -662,6 +669,7 @@ pub(super) fn coerce_value(value: &Value, target_type: DataType) -> Result<Value
             DataType::DateTime => Ok(Value::DateTime(*ts)),
             DataType::Date => Ok(Value::Date((*ts / 1_000_000) as i32)),
             DataType::Varchar(_) | DataType::Text => Ok(Value::Varchar(format_datetime(*ts))),
+            DataType::Jsonb => Ok(Value::Varchar(json_string_literal(&format_datetime(*ts))?)),
             _ => Err(MuroError::Execution(
                 "Cannot coerce TIMESTAMP to target type".into(),
             )),
@@ -674,6 +682,12 @@ pub(super) fn coerce_value(value: &Value, target_type: DataType) -> Result<Value
                 Ok(Value::Varchar(s))
             }
             DataType::Varbinary(_) => Ok(Value::Varbinary(b.clone())),
+            DataType::Jsonb => {
+                let s = std::str::from_utf8(b).map_err(|_| {
+                    MuroError::Execution("Cannot convert non-UTF8 VARBINARY to JSONB".into())
+                })?;
+                Ok(Value::Varchar(canonicalize_json_text(s)?))
+            }
             DataType::Uuid => {
                 if b.len() != 16 {
                     return Err(MuroError::Execution(format!(
@@ -694,10 +708,25 @@ pub(super) fn coerce_value(value: &Value, target_type: DataType) -> Result<Value
             DataType::Varchar(_) | DataType::Text => {
                 Ok(Value::Varchar(crate::types::format_uuid(b)))
             }
+            DataType::Jsonb => Ok(Value::Varchar(json_string_literal(
+                &crate::types::format_uuid(b),
+            )?)),
             DataType::Varbinary(_) => Ok(Value::Varbinary(b.to_vec())),
             _ => Err(MuroError::Execution(
                 "Cannot coerce UUID to target type".into(),
             )),
         },
     }
+}
+
+fn canonicalize_json_text(s: &str) -> Result<String> {
+    let parsed: JsonValue = serde_json::from_str(s)
+        .map_err(|e| MuroError::Execution(format!("Invalid JSON: {}", e)))?;
+    serde_json::to_string(&parsed)
+        .map_err(|e| MuroError::Execution(format!("Failed to canonicalize JSON: {}", e)))
+}
+
+fn json_string_literal(s: &str) -> Result<String> {
+    serde_json::to_string(s)
+        .map_err(|e| MuroError::Execution(format!("Failed to encode JSON string: {}", e)))
 }

--- a/src/sql/executor/codec.rs
+++ b/src/sql/executor/codec.rs
@@ -66,7 +66,7 @@ pub fn serialize_row(values: &[Value], columns: &[ColumnDef]) -> Vec<u8> {
                 }
                 DataType::Date => buf.extend_from_slice(&(*n as i32).to_le_bytes()),
                 DataType::DateTime | DataType::Timestamp => buf.extend_from_slice(&n.to_le_bytes()),
-                DataType::Varchar(_) | DataType::Text => {
+                DataType::Varchar(_) | DataType::Text | DataType::Jsonb => {
                     let bytes = n.to_string().as_bytes().to_vec();
                     buf.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
                     buf.extend_from_slice(&bytes);
@@ -94,7 +94,7 @@ pub fn serialize_row(values: &[Value], columns: &[ColumnDef]) -> Vec<u8> {
                 DataType::Date | DataType::DateTime | DataType::Timestamp => {
                     panic!("float value reached date/time serializer")
                 }
-                DataType::Varchar(_) | DataType::Text => {
+                DataType::Varchar(_) | DataType::Text | DataType::Jsonb => {
                     let bytes = n.to_string().as_bytes().to_vec();
                     buf.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
                     buf.extend_from_slice(&bytes);
@@ -112,7 +112,7 @@ pub fn serialize_row(values: &[Value], columns: &[ColumnDef]) -> Vec<u8> {
                     let v = (*d as i64) * 1_000_000;
                     buf.extend_from_slice(&v.to_le_bytes());
                 }
-                DataType::Varchar(_) | DataType::Text => {
+                DataType::Varchar(_) | DataType::Text | DataType::Jsonb => {
                     let s = format_date(*d);
                     let bytes = s.as_bytes();
                     buf.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
@@ -128,7 +128,7 @@ pub fn serialize_row(values: &[Value], columns: &[ColumnDef]) -> Vec<u8> {
                 DataType::DateTime | DataType::Timestamp => {
                     buf.extend_from_slice(&dt.to_le_bytes());
                 }
-                DataType::Varchar(_) | DataType::Text => {
+                DataType::Varchar(_) | DataType::Text | DataType::Jsonb => {
                     let s = format_datetime(*dt);
                     let bytes = s.as_bytes();
                     buf.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
@@ -144,7 +144,7 @@ pub fn serialize_row(values: &[Value], columns: &[ColumnDef]) -> Vec<u8> {
                 DataType::DateTime | DataType::Timestamp => {
                     buf.extend_from_slice(&ts.to_le_bytes());
                 }
-                DataType::Varchar(_) | DataType::Text => {
+                DataType::Varchar(_) | DataType::Text | DataType::Jsonb => {
                     let s = format_datetime(*ts);
                     let bytes = s.as_bytes();
                     buf.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
@@ -293,7 +293,7 @@ pub fn deserialize_row_versioned(
                 values.push(Value::Timestamp(n));
                 offset += 8;
             }
-            DataType::Varchar(_) | DataType::Text => {
+            DataType::Varchar(_) | DataType::Text | DataType::Jsonb => {
                 if offset + 4 > data.len() {
                     return Err(MuroError::InvalidPage);
                 }
@@ -463,6 +463,7 @@ pub fn encode_value(value: &Value, data_type: &DataType) -> Vec<u8> {
             // Parse UUID string for UUID column key encoding
             parse_uuid_string(s).map_or_else(|| s.as_bytes().to_vec(), |b| b.to_vec())
         }
+        (Value::Varchar(s), DataType::Jsonb) => s.as_bytes().to_vec(),
         (Value::Varchar(s), _) => s.as_bytes().to_vec(),
         (Value::Varbinary(b), _) => b.clone(),
         (Value::Uuid(b), _) => b.to_vec(),

--- a/src/sql/executor/fts.rs
+++ b/src/sql/executor/fts.rs
@@ -576,6 +576,11 @@ pub(super) fn validate_value(value: &Value, data_type: &DataType) -> Result<()> 
                 Ok(())
             }
         }
+        (Value::Varchar(s), DataType::Jsonb) => {
+            serde_json::from_str::<serde_json::Value>(s)
+                .map_err(|e| MuroError::Execution(format!("Invalid JSON: {}", e)))?;
+            Ok(())
+        }
         _ => Ok(()),
     }
 }

--- a/src/sql/lexer.rs
+++ b/src/sql/lexer.rs
@@ -114,6 +114,7 @@ pub enum Token {
     VarcharType,   // "VARCHAR"
     VarbinaryType, // "VARBINARY"
     TextType,      // "TEXT"
+    JsonbType,     // "JSONB"
     BooleanType,   // "BOOLEAN" / "BOOL"
     UuidType,      // "UUID"
     DecimalType,   // "DECIMAL" / "NUMERIC"
@@ -470,6 +471,7 @@ fn lex_keyword_or_ident(input: &str) -> IResult<&str, Token> {
         "VARCHAR" => Token::VarcharType,
         "VARBINARY" => Token::VarbinaryType,
         "TEXT" => Token::TextType,
+        "JSONB" => Token::JsonbType,
         "UUID" => Token::UuidType,
         "DECIMAL" | "NUMERIC" => Token::DecimalType,
         "FTS_SNIPPET" => Token::FtsSnippet,
@@ -533,6 +535,12 @@ mod tests {
         assert_eq!(tokens[2], Token::If);
         assert_eq!(tokens[3], Token::Exists);
         assert_eq!(tokens[4], Token::Ident("t".to_string()));
+    }
+
+    #[test]
+    fn test_tokenize_jsonb_type() {
+        let tokens = tokenize("CREATE TABLE t (doc JSONB)").unwrap();
+        assert!(tokens.contains(&Token::JsonbType));
     }
 
     #[test]

--- a/src/sql/parser/mod.rs
+++ b/src/sql/parser/mod.rs
@@ -488,6 +488,7 @@ impl Parser {
                     Ok(DataType::Varbinary(size))
                 }
                 Some(Token::TextType) => Ok(DataType::Text),
+                Some(Token::JsonbType) => Ok(DataType::Jsonb),
                 Some(Token::UuidType) => Ok(DataType::Uuid),
                 Some(Token::DecimalType) => {
                     // Parse optional (precision, scale) with defaults (10, 0)

--- a/src/sql/parser/tests.rs
+++ b/src/sql/parser/tests.rs
@@ -394,6 +394,16 @@ fn test_parse_boolean_type() {
 }
 
 #[test]
+fn test_parse_jsonb_type() {
+    let stmt = parse_sql("CREATE TABLE t (id BIGINT PRIMARY KEY, doc JSONB)").unwrap();
+    if let Statement::CreateTable(ct) = stmt {
+        assert_eq!(ct.columns[1].data_type, DataType::Jsonb);
+    } else {
+        panic!("Expected CreateTable");
+    }
+}
+
+#[test]
 fn test_parse_not_operator() {
     let stmt = parse_sql("SELECT * FROM t WHERE NOT id = 1").unwrap();
     if let Statement::Select(sel) = stmt {

--- a/src/types.rs
+++ b/src/types.rs
@@ -335,6 +335,7 @@ pub enum DataType {
     Varchar(Option<u32>),
     Varbinary(Option<u32>),
     Text,
+    Jsonb,
     Uuid,
 }
 
@@ -356,6 +357,7 @@ impl fmt::Display for DataType {
             DataType::Varbinary(None) => write!(f, "VARBINARY"),
             DataType::Varbinary(Some(n)) => write!(f, "VARBINARY({})", n),
             DataType::Text => write!(f, "TEXT"),
+            DataType::Jsonb => write!(f, "JSONB"),
             DataType::Uuid => write!(f, "UUID"),
         }
     }


### PR DESCRIPTION
## Summary
Implements issue #169 by adding native `JSONB` support and initial JSON/JSONPath functions.

### What changed
- Added `JSONB` data type to lexer/parser/type system/catalog serialization.
- Added JSON validation/canonicalization on write paths (`INSERT`/`UPDATE`/`ALTER` coercion).
- Added JSON functions:
  - `JSON_EXTRACT(json, path)`
  - `JSON_SET(json, path, value)`
  - `JSON_REMOVE(json, path)`
  - `JSON_TYPE(json)`
  - `JSON_CONTAINS(json, value_or_path)`
- Integrated JSONPath evaluation via `jsonpath_lib` for read/query semantics.
- Added docs for JSONB + JSON function behavior (dialect, NULL/error behavior).
- Added parser/eval tests for JSONB and JSON functions.

## Notes on semantics
- `JSON_EXTRACT` and `JSON_CONTAINS(..., '$...')` use `jsonpath_lib` semantics.
- `JSON_SET` / `JSON_REMOVE` currently support root-based dot/index update paths (documented).
- Invalid JSON is rejected for `JSONB` values.
- Missing paths in `JSON_EXTRACT` return `NULL`; missing paths in `JSON_REMOVE` are no-op.

## Validation
- `cargo test -q` passed.

## Related
- Closes #169
