### PR TITLE
Security review follow-ups: docs risk register and CLI password warning

### DIFF
--- a/docs-site/src/SUMMARY.md
+++ b/docs-site/src/SUMMARY.md
@@ -21,6 +21,7 @@
 - [Alerting & Monitoring](user-guide/alerting.md)
 - [Incident Response Runbook](user-guide/runbook.md)
 - [Limits Reference](user-guide/limits.md)
+- [Security Considerations](user-guide/security-considerations.md)
 
 # Internals
 

--- a/docs-site/src/internals/cryptography.md
+++ b/docs-site/src/internals/cryptography.md
@@ -13,7 +13,7 @@ User's passphrase
     ├──→ Page encryption  (AES-256-GCM-SIV, AAD = page_id || epoch)
     └──→ WAL encryption   (AES-256-GCM-SIV, AAD = lsn || 0)
 
-FTS term blinding (HMAC-SHA256, compile-time constant key)
+FTS term blinding (HMAC-SHA256, DB-scoped term key)
 ```
 
 The encryption system has four layers:
@@ -21,7 +21,7 @@ The encryption system has four layers:
 1. **Key derivation (KDF)** — Derive a cryptographic key from the user's passphrase
 2. **Page encryption** — Encrypt and authenticate each data page
 3. **WAL encryption** — Encrypt write-ahead log records
-4. **FTS term blinding** — Hide full-text search tokens on disk (separate from passphrase-based encryption; see below)
+4. **FTS term blinding** — Hide full-text search tokens on disk (separate from page/WAL encryption; see below)
 
 ## Encryption Suites
 
@@ -142,7 +142,11 @@ term_id = HMAC-SHA256(term_key, "tokyo")  →  32-byte hash
 
 Only hash values are stored on disk — no plaintext search terms ever reach the storage layer.
 
-**Important caveat**: The current `term_key` is a compile-time constant (`[0x55u8; 32]`) embedded in the binary, **not** derived from the user's passphrase or `MasterKey`. This means an attacker with access to MuroDB's source code (or binary) can compute term IDs for candidate tokens. The blinding prevents casual inspection of on-disk data but does not provide resistance against a determined attacker who knows the key. Deriving `term_key` from `MasterKey` is a potential future improvement.
+**Important caveats:**
+
+- In encrypted mode, `term_key` is derived from `MasterKey` + DB salt, so term IDs are database-scoped and secret-dependent.
+- In plaintext mode, `term_key` is derived from a public label + DB salt. This still hides raw tokens in casual inspection, but does not provide strong secrecy against offline dictionary guessing.
+- Legacy databases may still contain historical FTS key metadata. Open-time migration/backfill logic keeps them readable.
 
 ## Key Rotation (Epoch)
 

--- a/docs-site/src/user-guide/cli.md
+++ b/docs-site/src/user-guide/cli.md
@@ -114,3 +114,8 @@ murodb-wal-inspect mydb.db --wal mydb.wal --recovery-mode permissive
 ```
 
 See [WAL Inspection](wal-inspect.md) for exit codes and JSON schema.
+
+## Security Notes
+
+- Prefer interactive password prompt over `--password` to reduce secret exposure in process lists/history.
+- For `ALTER DATABASE REKEY`, avoid one-shot `-e` with inline password literals in production environments. This limitation is tracked in [#183](https://github.com/tokuhirom/murodb/issues/183).

--- a/docs-site/src/user-guide/security-considerations.md
+++ b/docs-site/src/user-guide/security-considerations.md
@@ -1,0 +1,25 @@
+# Security Considerations
+
+This page summarizes the current security model, known risks, and operational guidance.
+
+## Threat Model (Current)
+
+- MuroDB is an embedded database library/CLI, not a network server.
+- Encrypted mode (`aes256-gcm-siv`) targets at-rest confidentiality and tamper detection for DB/WAL pages.
+- Plaintext mode (`--encryption off`) is explicit opt-in and provides no cryptographic protection.
+
+## Known Risks
+
+| Risk | Impact | Status |
+|---|---|---|
+| Malformed page/cell metadata can currently trigger panic paths instead of clean corruption errors | Process abort (availability) when opening/querying corrupted files, especially relevant in plaintext mode | Tracked: [#182](https://github.com/tokuhirom/murodb/issues/182) |
+| `ALTER DATABASE REKEY WITH PASSWORD '...'` requires literal secrets in SQL text | Password can leak via shell history, process args (`-e`), logs, and audit trails | Tracked: [#183](https://github.com/tokuhirom/murodb/issues/183) |
+| Plaintext mode has no confidentiality/integrity guarantees | Data can be read/modified offline without cryptographic checks | By design |
+| No built-in user authentication/authorization layer | Access control depends on host process + filesystem permissions | By design |
+
+## Operational Guidance
+
+- Prefer encrypted mode for production data.
+- Avoid passing secrets via CLI args (`--password`) when possible; use interactive prompt.
+- Treat database files as trusted inputs only until #182 is addressed.
+- Apply OS-level controls: file permissions, disk encryption, process isolation, and secrets management.

--- a/docs-site/src/user-guide/sql-reference.md
+++ b/docs-site/src/user-guide/sql-reference.md
@@ -974,6 +974,10 @@ ALTER DATABASE REKEY WITH PASSWORD 'new_password';
 - If a crash occurs mid-rekey, the next `open_with_password` detects the marker and completes or rolls back the operation automatically.
 - After successful rekey, only the new password can open the database.
 
+**Security note:**
+- `REKEY` currently takes a SQL string literal password, which may leak through shell history/process arguments when used with CLI `-e`.
+- For safer operations, prefer interactive flows and avoid embedding secrets in command lines. Improvement is tracked in [#183](https://github.com/tokuhirom/murodb/issues/183).
+
 ## Transactions
 
 ```sql

--- a/src/bin/murodb.rs
+++ b/src/bin/murodb.rs
@@ -91,6 +91,9 @@ struct Cli {
 
 fn get_password(cli_password: &Option<String>) -> String {
     if let Some(pw) = cli_password {
+        eprintln!(
+            "WARNING: Passing passwords via --password can expose secrets in shell history and process lists. Prefer interactive prompt when possible."
+        );
         return pw.clone();
     }
     rpassword::read_password_from_tty(Some("Password: ")).unwrap_or_else(|e| {


### PR DESCRIPTION
## Summary
This PR applies the security-review follow-up work discussed in this branch:

- Add a dedicated security documentation page with threat model, known risks, and operational guidance.
- Fix stale cryptography docs that still described FTS term-key handling as compile-time constant.
- Add CLI/runtime warning when `--password` is passed on command line.
- Add explicit security notes for REKEY/CLI usage in user docs.

## Changes
- Added `docs-site/src/user-guide/security-considerations.md`
  - Includes known risks and links to tracking issues.
- Updated `docs-site/src/SUMMARY.md`
  - Adds Security Considerations page to mdBook nav.
- Updated `docs-site/src/internals/cryptography.md`
  - Corrects FTS term key explanation (encrypted mode derives from master key + salt, plaintext mode caveat).
- Updated `docs-site/src/user-guide/cli.md`
  - Adds warning guidance for `--password` and REKEY usage.
- Updated `docs-site/src/user-guide/sql-reference.md`
  - Adds REKEY security note about inline password literals.
- Updated `src/bin/murodb.rs`
  - Emits warning on `--password` usage:
    - `WARNING: Passing passwords via --password can expose secrets in shell history and process lists. Prefer interactive prompt when possible.`

## Validation
- `mdbook build docs-site`
- `cargo test --bin murodb format_rows_json_empty`

## Related Issues
- #182
- #183
