### PR TITLE
Add open_reader API and document query mutability

### DIFF
--- a/docs-site/src/internals/architecture.md
+++ b/docs-site/src/internals/architecture.md
@@ -61,7 +61,7 @@ If your goal is "reconstruct internals after a long break", read in this order:
   - CLI routes read-only statements to `query` unless an explicit transaction is active.
 - **Handle model**:
   - `Database::query` takes `&mut self` because read execution may refresh pager/catalog state from disk before running.
-  - For concurrent reads in one process, open additional handles (`Database::open_reader`) and run `query` on each handle.
+  - For concurrent reads in one process, open additional read-only handles (`Database::open_reader`) and run `query` on each handle.
 
 For on-disk file contracts (main DB file / `.wal` / `.lock`), see [Files, WAL, and Locking](files-and-locking.md).
 For catalog key/value binary layouts, see [Catalog Format](catalog-format.md).

--- a/docs-site/src/internals/files-and-locking.md
+++ b/docs-site/src/internals/files-and-locking.md
@@ -80,7 +80,7 @@ API behavior:
 - `Database::query(...)` acquires shared read lock.
 - `Database::execute(...)` acquires exclusive write lock.
 - `Database::query(...)` is a `&mut self` API because read execution may refresh pager/catalog metadata from disk before running.
-- For multiple concurrent readers within one process, use separate handles (for example `Database::open_reader()`).
+- For multiple concurrent readers within one process, use separate read-only handles (for example `Database::open_reader()`).
 
 Important granularity note:
 

--- a/docs-site/src/internals/wal.md
+++ b/docs-site/src/internals/wal.md
@@ -54,7 +54,7 @@ Record tags on wire:
 3. Execute directly on pager/catalog (no implicit WAL transaction)
 
 `query` is a `&mut self` API because the session may refresh pager/catalog state from disk before read execution.
-For concurrent readers in one process, open additional handles (`Database::open_reader`) and query from each handle.
+For concurrent readers in one process, open additional read-only handles (`Database::open_reader`) and query from each handle.
 
 If an explicit transaction is active, read statements are executed in the transaction context (`execute_in_tx`) so uncommitted writes remain visible to that session.
 

--- a/docs-site/src/user-guide/sql-reference.md
+++ b/docs-site/src/user-guide/sql-reference.md
@@ -979,7 +979,7 @@ ROLLBACK;
 Rust API note:
 - `Database::query()` accepts read-only SQL only.
 - `Database::query()` takes `&mut self` because read execution may refresh pager/catalog state from disk before running.
-- For concurrent reads in one process, use multiple handles (for example `Database::open_reader()`).
+- For concurrent reads in one process, use multiple read-only handles (for example `Database::open_reader()`).
 - Inside an explicit transaction (`BEGIN` ... `COMMIT`/`ROLLBACK`), run statements through `Database::execute()`, including `SELECT`.
 
 ## Hidden _rowid

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,6 @@ use crate::sql::prepared::PreparedStatement;
 use crate::sql::session::Session;
 use crate::storage::pager::{read_rekey_marker, rekey_marker_path, unwrap_rekey_old_key, Pager};
 use crate::types::Value;
-use crate::wal::reader::WalReader;
-use crate::wal::record::Lsn;
 use crate::wal::recovery::{RecoveryMode, RecoveryResult};
 use crate::wal::writer::WalWriter;
 
@@ -54,6 +52,12 @@ pub struct Database {
     db_path: PathBuf,
     #[allow(dead_code)]
     encryption_suite: EncryptionSuite,
+}
+
+/// Read-only database handle for concurrent query workloads.
+pub struct DatabaseReader {
+    session: Session,
+    lock_manager: LockManager,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -161,19 +165,6 @@ fn quarantine_wal_durably(wal_path: &Path) -> Result<PathBuf> {
     sync_dir(wal_path);
 
     Ok(dest)
-}
-
-fn wal_next_lsn(
-    path: &Path,
-    suite: EncryptionSuite,
-    master_key: Option<&MasterKey>,
-) -> Result<Lsn> {
-    if !path.exists() {
-        return Ok(0);
-    }
-    let mut reader = WalReader::open_with_suite(path, suite, master_key)?;
-    let records = reader.read_all()?;
-    Ok(records.len() as Lsn)
 }
 
 fn fts_value_to_text(value: &Value) -> Option<&str> {
@@ -727,7 +718,9 @@ impl Database {
     ///
     /// This is useful when you want concurrent readers without manually
     /// re-opening the same path and re-supplying key material.
-    pub fn open_reader(&self) -> Result<Self> {
+    ///
+    /// The returned handle is read-only and does not expose write APIs.
+    pub fn open_reader(&self) -> Result<DatabaseReader> {
         let path = self.db_path.as_path();
         let wp = wal_path(path);
         match self.encryption_suite {
@@ -746,16 +739,13 @@ impl Database {
                     LEGACY_SQL_FTS_TERM_KEY,
                     false,
                 )?;
-                let next_lsn = wal_next_lsn(&wp, EncryptionSuite::Plaintext, None)?;
-                let wal = WalWriter::open_plaintext(&wp, next_lsn)?;
+                // Reader handles never write WAL; fixed LSN is acceptable.
+                let wal = WalWriter::open_plaintext(&wp, 0)?;
                 let lock_manager = LockManager::new(path)?;
                 let session = Session::new(pager, catalog, wal);
-                Ok(Database {
+                Ok(DatabaseReader {
                     session,
                     lock_manager,
-                    master_key: None,
-                    db_path: path.to_path_buf(),
-                    encryption_suite: EncryptionSuite::Plaintext,
                 })
             }
             EncryptionSuite::Aes256GcmSiv => {
@@ -776,16 +766,13 @@ impl Database {
                     LEGACY_SQL_FTS_TERM_KEY,
                     false,
                 )?;
-                let next_lsn = wal_next_lsn(&wp, EncryptionSuite::Aes256GcmSiv, Some(master_key))?;
-                let wal = WalWriter::open(&wp, master_key, next_lsn)?;
+                // Reader handles never write WAL; fixed LSN is acceptable.
+                let wal = WalWriter::open(&wp, master_key, 0)?;
                 let lock_manager = LockManager::new(path)?;
                 let session = Session::new(pager, catalog, wal);
-                Ok(Database {
+                Ok(DatabaseReader {
                     session,
                     lock_manager,
-                    master_key: Some(master_key.clone()),
-                    db_path: path.to_path_buf(),
-                    encryption_suite: EncryptionSuite::Aes256GcmSiv,
                 })
             }
         }
@@ -840,6 +827,36 @@ impl Database {
     /// pager, catalog, and WAL writer, and manages explicit transaction state.
     pub fn into_session(self) -> Session {
         self.session
+    }
+}
+
+impl DatabaseReader {
+    /// Parse SQL into a reusable prepared statement template.
+    pub fn prepare(&self, sql: &str) -> Result<PreparedStatement> {
+        self.session.prepare(sql)
+    }
+
+    /// Execute a read-only SQL query and return rows.
+    pub fn query(&mut self, sql: &str) -> Result<Vec<Row>> {
+        let _guard = self.lock_manager.read_lock()?;
+        self.session.execute_read_only_query(sql)
+    }
+
+    /// Execute a prepared read-only query and return rows.
+    pub fn query_prepared(
+        &mut self,
+        prepared: &PreparedStatement,
+        params: &[Value],
+    ) -> Result<Vec<Row>> {
+        let _guard = self.lock_manager.read_lock()?;
+        self.session
+            .execute_read_only_prepared_query(prepared, params)
+    }
+
+    /// Convenience API: prepare+query in one call using bound values.
+    pub fn query_params(&mut self, sql: &str, params: &[Value]) -> Result<Vec<Row>> {
+        let prepared = self.prepare(sql)?;
+        self.query_prepared(&prepared, params)
     }
 }
 


### PR DESCRIPTION
## Summary
- add `Database::open_reader()` to open an additional handle for read-oriented concurrent access
- document why `Database::query()` currently requires `&mut self`
- update docs to explain the handle model for concurrent readers
- ensure `rekey_with_password()` refreshes in-memory key/suite metadata so `open_reader()` works after rekey
- add unit tests for plaintext and post-rekey reader open

## Changes
- API
  - `src/lib.rs`
    - add `Database::open_reader(&self) -> Result<Self>`
    - expand `Database::query` docs with `&mut self` rationale
    - update `rekey_with_password` to refresh `master_key`/`encryption_suite`
    - add tests:
      - `open_reader_plaintext_can_query_same_db`
      - `open_reader_works_after_rekey_with_password`
- Docs
  - `docs-site/src/internals/architecture.md`
  - `docs-site/src/internals/files-and-locking.md`
  - `docs-site/src/internals/wal.md`
  - `docs-site/src/user-guide/sql-reference.md`

## Verification
- `cargo fmt --all`
- `cargo test --lib open_reader -- --nocapture`

Closes #201
