### PR TITLE
Implement foreign key constraints and enforcement

### DIFF
--- a/docs-site/src/user-guide/sql-reference.md
+++ b/docs-site/src/user-guide/sql-reference.md
@@ -68,6 +68,22 @@ CREATE TABLE t (
   b INT,
   UNIQUE (a, b)
 );
+
+-- FOREIGN KEY (default: RESTRICT)
+CREATE TABLE children (
+  id BIGINT PRIMARY KEY,
+  parent_id BIGINT,
+  FOREIGN KEY (parent_id) REFERENCES parents(id)
+);
+
+-- FOREIGN KEY with actions
+CREATE TABLE child_actions (
+  id BIGINT PRIMARY KEY,
+  parent_id BIGINT,
+  FOREIGN KEY (parent_id) REFERENCES parents(id)
+    ON DELETE CASCADE
+    ON UPDATE SET NULL
+);
 ```
 
 ### CREATE INDEX
@@ -120,6 +136,10 @@ ALTER TABLE t MODIFY name TEXT;
 
 -- Rename and optionally change a column (CHANGE COLUMN)
 ALTER TABLE t CHANGE COLUMN name username VARCHAR;
+
+-- Add / drop FOREIGN KEY
+ALTER TABLE child ADD FOREIGN KEY (parent_id) REFERENCES parent(id);
+ALTER TABLE child DROP FOREIGN KEY (parent_id);
 ```
 
 **Performance notes:**
@@ -135,11 +155,15 @@ ALTER TABLE t CHANGE COLUMN name username VARCHAR;
 - `MODIFY COLUMN` / `CHANGE COLUMN` with a type change rewrites all rows and coerces values; conversion failures abort the statement.
 - `CHANGE COLUMN` updates index metadata to the new column name when indexes reference the old name.
 - `MODIFY COLUMN` / `CHANGE COLUMN` reconcile single-column `UNIQUE`: adding `UNIQUE` may create an index; removing `UNIQUE` drops the corresponding auto unique index.
+- `ADD FOREIGN KEY` validates existing rows; if orphan rows exist, it fails.
+- FK actions support `RESTRICT`, `CASCADE`, and `SET NULL` for both `ON DELETE` and `ON UPDATE`.
 
 **Limitations:**
 - Cannot add a PRIMARY KEY column via ALTER TABLE.
 - Cannot drop a PRIMARY KEY column.
 - Cannot drop a column that has an index on it (drop the index first).
+- Cannot drop a table that is referenced by a foreign key.
+- `DROP FOREIGN KEY` is specified by child column list: `DROP FOREIGN KEY (col1, col2)`.
 
 ### RENAME TABLE
 

--- a/src/schema/catalog.rs
+++ b/src/schema/catalog.rs
@@ -12,6 +12,40 @@ use crate::schema::index::IndexDef;
 use crate::storage::page::PageId;
 use crate::storage::page_store::PageStore;
 const META_FTS_TERM_KEY: &[u8] = b"meta:fts_term_key";
+const FK_LAYOUT_V2_TAG: u8 = 0xF1;
+
+fn serialize_fk_action(action: &ForeignKeyAction) -> u8 {
+    match action {
+        ForeignKeyAction::Restrict => 0,
+        ForeignKeyAction::Cascade => 1,
+        ForeignKeyAction::SetNull => 2,
+    }
+}
+
+fn deserialize_fk_action(v: u8) -> Option<ForeignKeyAction> {
+    match v {
+        0 => Some(ForeignKeyAction::Restrict),
+        1 => Some(ForeignKeyAction::Cascade),
+        2 => Some(ForeignKeyAction::SetNull),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ForeignKeyAction {
+    Restrict,
+    Cascade,
+    SetNull,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForeignKeyDef {
+    pub columns: Vec<String>,
+    pub ref_table: String,
+    pub ref_columns: Vec<String>,
+    pub on_delete: ForeignKeyAction,
+    pub on_update: ForeignKeyAction,
+}
 
 /// Table definition.
 #[derive(Debug, Clone)]
@@ -26,6 +60,7 @@ pub struct TableDef {
     pub row_format_version: u8,
     /// Last analyzed approximate row count (0 means unknown / not analyzed).
     pub stats_row_count: u64,
+    pub foreign_keys: Vec<ForeignKeyDef>,
 }
 
 impl TableDef {
@@ -71,6 +106,28 @@ impl TableDef {
         buf.push(self.row_format_version);
         // stats_row_count
         buf.extend_from_slice(&self.stats_row_count.to_le_bytes());
+        // foreign_keys (optional tail, backward compatible)
+        buf.push(FK_LAYOUT_V2_TAG);
+        buf.extend_from_slice(&(self.foreign_keys.len() as u16).to_le_bytes());
+        for fk in &self.foreign_keys {
+            buf.extend_from_slice(&(fk.columns.len() as u16).to_le_bytes());
+            for col in &fk.columns {
+                let b = col.as_bytes();
+                buf.extend_from_slice(&(b.len() as u16).to_le_bytes());
+                buf.extend_from_slice(b);
+            }
+            let t = fk.ref_table.as_bytes();
+            buf.extend_from_slice(&(t.len() as u16).to_le_bytes());
+            buf.extend_from_slice(t);
+            buf.extend_from_slice(&(fk.ref_columns.len() as u16).to_le_bytes());
+            for col in &fk.ref_columns {
+                let b = col.as_bytes();
+                buf.extend_from_slice(&(b.len() as u16).to_le_bytes());
+                buf.extend_from_slice(b);
+            }
+            buf.push(serialize_fk_action(&fk.on_delete));
+            buf.push(serialize_fk_action(&fk.on_update));
+        }
         buf
     }
 
@@ -175,9 +232,123 @@ impl TableDef {
 
         // stats_row_count (optional, defaults to 0 for old tables)
         let stats_row_count = if data.len() >= offset + 8 {
-            u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap())
+            let v = u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
+            offset += 8;
+            v
         } else {
             0
+        };
+
+        // foreign_keys (optional tail)
+        let foreign_keys = if data.len() > offset {
+            let (fk_count, has_actions) = if data[offset] == FK_LAYOUT_V2_TAG {
+                offset += 1;
+                if data.len() < offset + 2 {
+                    return None;
+                }
+                (
+                    u16::from_le_bytes(data[offset..offset + 2].try_into().unwrap()) as usize,
+                    true,
+                )
+            } else {
+                if data.len() < offset + 2 {
+                    return None;
+                }
+                (
+                    u16::from_le_bytes(data[offset..offset + 2].try_into().unwrap()) as usize,
+                    false,
+                )
+            };
+            offset += 2;
+            let mut fks = Vec::with_capacity(fk_count);
+            for _ in 0..fk_count {
+                if data.len() < offset + 2 {
+                    return None;
+                }
+                let child_count =
+                    u16::from_le_bytes(data[offset..offset + 2].try_into().unwrap()) as usize;
+                offset += 2;
+                let mut columns = Vec::with_capacity(child_count);
+                for _ in 0..child_count {
+                    if data.len() < offset + 2 {
+                        return None;
+                    }
+                    let len =
+                        u16::from_le_bytes(data[offset..offset + 2].try_into().unwrap()) as usize;
+                    offset += 2;
+                    if data.len() < offset + len {
+                        return None;
+                    }
+                    let col = String::from_utf8(data[offset..offset + len].to_vec()).ok()?;
+                    offset += len;
+                    columns.push(col);
+                }
+
+                if data.len() < offset + 2 {
+                    return None;
+                }
+                let table_len =
+                    u16::from_le_bytes(data[offset..offset + 2].try_into().unwrap()) as usize;
+                offset += 2;
+                if data.len() < offset + table_len {
+                    return None;
+                }
+                let ref_table =
+                    String::from_utf8(data[offset..offset + table_len].to_vec()).ok()?;
+                offset += table_len;
+
+                if data.len() < offset + 2 {
+                    return None;
+                }
+                let parent_count =
+                    u16::from_le_bytes(data[offset..offset + 2].try_into().unwrap()) as usize;
+                offset += 2;
+                let mut ref_columns = Vec::with_capacity(parent_count);
+                for _ in 0..parent_count {
+                    if data.len() < offset + 2 {
+                        return None;
+                    }
+                    let len =
+                        u16::from_le_bytes(data[offset..offset + 2].try_into().unwrap()) as usize;
+                    offset += 2;
+                    if data.len() < offset + len {
+                        return None;
+                    }
+                    let col = String::from_utf8(data[offset..offset + len].to_vec()).ok()?;
+                    offset += len;
+                    ref_columns.push(col);
+                }
+                let on_delete = if has_actions {
+                    if data.len() < offset + 1 {
+                        return None;
+                    }
+                    let a = deserialize_fk_action(data[offset])?;
+                    offset += 1;
+                    a
+                } else {
+                    ForeignKeyAction::Restrict
+                };
+                let on_update = if has_actions {
+                    if data.len() < offset + 1 {
+                        return None;
+                    }
+                    let a = deserialize_fk_action(data[offset])?;
+                    offset += 1;
+                    a
+                } else {
+                    ForeignKeyAction::Restrict
+                };
+                fks.push(ForeignKeyDef {
+                    columns,
+                    ref_table,
+                    ref_columns,
+                    on_delete,
+                    on_update,
+                });
+            }
+            fks
+        } else {
+            Vec::new()
         };
 
         Some(TableDef {
@@ -188,6 +359,7 @@ impl TableDef {
             next_rowid,
             row_format_version,
             stats_row_count,
+            foreign_keys,
         })
     }
 
@@ -314,6 +486,7 @@ impl SystemCatalog {
             next_rowid: 0,
             row_format_version: 1,
             stats_row_count: 0,
+            foreign_keys: Vec::new(),
         };
 
         // Store in catalog
@@ -528,6 +701,7 @@ mod tests {
             next_rowid: 0,
             row_format_version: 1,
             stats_row_count: 0,
+            foreign_keys: Vec::new(),
         };
 
         let bytes = table.serialize();

--- a/src/sql/ast.rs
+++ b/src/sql/ast.rs
@@ -60,6 +60,8 @@ pub enum AlterTableOp {
     DropColumn(String),
     ModifyColumn(ColumnSpec),
     ChangeColumn(String, ColumnSpec), // (old_name, new_spec)
+    AddForeignKey(ForeignKeySpec),
+    DropForeignKey(Vec<String>), // child column list
 }
 
 #[derive(Debug, Clone)]
@@ -78,6 +80,29 @@ pub struct RenameTable {
 pub enum TableConstraint {
     PrimaryKey(Vec<String>),
     Unique(Option<String>, Vec<String>), // (optional name, columns)
+    ForeignKey {
+        columns: Vec<String>,
+        ref_table: String,
+        ref_columns: Vec<String>,
+        on_delete: ForeignKeyAction,
+        on_update: ForeignKeyAction,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct ForeignKeySpec {
+    pub columns: Vec<String>,
+    pub ref_table: String,
+    pub ref_columns: Vec<String>,
+    pub on_delete: ForeignKeyAction,
+    pub on_update: ForeignKeyAction,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForeignKeyAction {
+    Restrict,
+    Cascade,
+    SetNull,
 }
 
 #[derive(Debug, Clone)]

--- a/src/sql/executor.rs
+++ b/src/sql/executor.rs
@@ -10,7 +10,7 @@ use crate::error::{MuroError, Result};
 use crate::fts::index::{FtsIndex, FtsPendingOp};
 use crate::fts::query::{query_boolean, query_natural_with_config, FtsQueryConfig, FtsResult};
 use crate::fts::snippet::fts_snippet;
-use crate::schema::catalog::{SystemCatalog, TableDef};
+use crate::schema::catalog::{ForeignKeyDef, SystemCatalog, TableDef};
 use crate::schema::column::{ColumnDef, DefaultValue};
 use crate::schema::index::{IndexDef, IndexType};
 use crate::sql::ast::*;
@@ -31,6 +31,7 @@ mod aggregation;
 mod alter;
 mod codec;
 mod ddl;
+mod foreign_key;
 mod fts;
 mod indexing;
 mod insert;
@@ -48,6 +49,10 @@ use aggregation::{cmp_values, execute_aggregation, execute_aggregation_join, has
 use alter::*;
 use codec::default_value_for_column;
 use ddl::*;
+use foreign_key::{
+    enforce_child_foreign_keys, enforce_parent_restrict_on_delete,
+    enforce_parent_restrict_on_update,
+};
 use fts::{
     build_fts_eval_context, execute_fts_scan_rows, free_btree_pages, fts_allocate_doc_id,
     fts_delete_doc_mapping, fts_get_doc_id, fts_put_doc_mapping, fts_set_next_doc_id,
@@ -58,7 +63,7 @@ use indexing::{
     check_unique_index_constraints, check_unique_index_constraints_excluding,
     delete_from_secondary_indexes, encode_index_key_from_row, encode_pk_key, eval_index_seek_key,
     eval_pk_seek_key, find_unique_index_conflict, index_seek_pk_keys, index_seek_pk_keys_range,
-    insert_into_secondary_indexes, persist_indexes, replace_delete_unique_conflicts,
+    insert_into_secondary_indexes, persist_indexes,
 };
 use insert::*;
 use mutation::*;
@@ -833,5 +838,1076 @@ mod tests {
             &mut catalog,
         );
         assert!(invalid_timestamp.is_err());
+    }
+
+    #[test]
+    fn test_foreign_key_insert_and_delete_restrict() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE parents (id BIGINT PRIMARY KEY)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE children (id BIGINT PRIMARY KEY, parent_id BIGINT, FOREIGN KEY (parent_id) REFERENCES parents(id))",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        execute("INSERT INTO parents VALUES (1)", &mut pager, &mut catalog).unwrap();
+        execute(
+            "INSERT INTO children VALUES (10, 1)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        let missing_parent = execute(
+            "INSERT INTO children VALUES (11, 999)",
+            &mut pager,
+            &mut catalog,
+        );
+        assert!(missing_parent.is_err());
+
+        let delete_parent = execute("DELETE FROM parents WHERE id = 1", &mut pager, &mut catalog);
+        assert!(delete_parent.is_err());
+    }
+
+    #[test]
+    fn test_foreign_key_composite_and_nullable() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE parents (a BIGINT, b BIGINT, PRIMARY KEY (a, b))",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE children (id BIGINT PRIMARY KEY, a BIGINT, b BIGINT, FOREIGN KEY (a, b) REFERENCES parents(a, b))",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        execute(
+            "INSERT INTO parents VALUES (1, 2)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "INSERT INTO children VALUES (1, 1, 2)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "INSERT INTO children VALUES (2, NULL, 2)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        let bad = execute(
+            "INSERT INTO children VALUES (3, 1, 9)",
+            &mut pager,
+            &mut catalog,
+        );
+        assert!(bad.is_err());
+    }
+
+    #[test]
+    fn test_show_create_and_describe_include_foreign_key() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE p (id BIGINT PRIMARY KEY)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c (id BIGINT PRIMARY KEY, p_id BIGINT, FOREIGN KEY (p_id) REFERENCES p(id))",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        let show = execute("SHOW CREATE TABLE c", &mut pager, &mut catalog).unwrap();
+        if let ExecResult::Rows(rows) = show {
+            let ddl = match rows[0].get("Create Table") {
+                Some(Value::Varchar(s)) => s,
+                _ => panic!("expected Create Table string"),
+            };
+            assert!(ddl.contains("FOREIGN KEY (p_id) REFERENCES p(id)"));
+        } else {
+            panic!("expected rows");
+        }
+
+        let desc = execute("DESCRIBE c", &mut pager, &mut catalog).unwrap();
+        if let ExecResult::Rows(rows) = desc {
+            assert!(rows
+                .iter()
+                .any(|r| { matches!(r.get("Key"), Some(Value::Varchar(k)) if k == "FK") }));
+        } else {
+            panic!("expected rows");
+        }
+    }
+
+    #[test]
+    fn test_describe_reports_foreign_key_actions() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE p (id BIGINT PRIMARY KEY)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c (id BIGINT PRIMARY KEY, p_id BIGINT, FOREIGN KEY (p_id) REFERENCES p(id) ON DELETE CASCADE ON UPDATE SET NULL)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        let desc = execute("DESCRIBE c", &mut pager, &mut catalog).unwrap();
+        if let ExecResult::Rows(rows) = desc {
+            let fk_row = rows
+                .iter()
+                .find(|r| matches!(r.get("Key"), Some(Value::Varchar(k)) if k == "FK"))
+                .expect("expected FK row");
+            assert_eq!(
+                fk_row.get("Extra"),
+                Some(&Value::Varchar(
+                    "ON DELETE CASCADE ON UPDATE SET NULL".to_string()
+                ))
+            );
+        } else {
+            panic!("expected rows");
+        }
+    }
+
+    #[test]
+    fn test_drop_table_referenced_by_foreign_key_is_rejected() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE p (id BIGINT PRIMARY KEY)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c (id BIGINT PRIMARY KEY, p_id BIGINT, FOREIGN KEY (p_id) REFERENCES p(id))",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        let res = execute("DROP TABLE p", &mut pager, &mut catalog);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_rename_table_updates_foreign_key_references() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE p (id BIGINT PRIMARY KEY)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c (id BIGINT PRIMARY KEY, p_id BIGINT, FOREIGN KEY (p_id) REFERENCES p(id))",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        execute("RENAME TABLE p TO p2", &mut pager, &mut catalog).unwrap();
+
+        let show = execute("SHOW CREATE TABLE c", &mut pager, &mut catalog).unwrap();
+        if let ExecResult::Rows(rows) = show {
+            let ddl = match rows[0].get("Create Table") {
+                Some(Value::Varchar(s)) => s,
+                _ => panic!("expected Create Table string"),
+            };
+            assert!(ddl.contains("REFERENCES p2(id)"));
+        } else {
+            panic!("expected rows");
+        }
+
+        execute("INSERT INTO p2 VALUES (1)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO c VALUES (1, 1)", &mut pager, &mut catalog).unwrap();
+        let err = execute("INSERT INTO c VALUES (2, 999)", &mut pager, &mut catalog);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn test_foreign_key_on_delete_cascade() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE p (id BIGINT PRIMARY KEY)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c (id BIGINT PRIMARY KEY, p_id BIGINT, FOREIGN KEY (p_id) REFERENCES p(id) ON DELETE CASCADE)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute("INSERT INTO p VALUES (1)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO c VALUES (10, 1)", &mut pager, &mut catalog).unwrap();
+
+        execute("DELETE FROM p WHERE id = 1", &mut pager, &mut catalog).unwrap();
+        let result = execute("SELECT * FROM c", &mut pager, &mut catalog).unwrap();
+        if let ExecResult::Rows(rows) = result {
+            assert!(rows.is_empty());
+        } else {
+            panic!("expected rows");
+        }
+    }
+
+    #[test]
+    fn test_foreign_key_on_delete_set_null() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE p (id BIGINT PRIMARY KEY)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c (id BIGINT PRIMARY KEY, p_id BIGINT, FOREIGN KEY (p_id) REFERENCES p(id) ON DELETE SET NULL)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute("INSERT INTO p VALUES (1)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO c VALUES (10, 1)", &mut pager, &mut catalog).unwrap();
+
+        execute("DELETE FROM p WHERE id = 1", &mut pager, &mut catalog).unwrap();
+        let result = execute("SELECT p_id FROM c WHERE id = 10", &mut pager, &mut catalog).unwrap();
+        if let ExecResult::Rows(rows) = result {
+            assert_eq!(rows.len(), 1);
+            assert_eq!(rows[0].get("p_id"), Some(&Value::Null));
+        } else {
+            panic!("expected rows");
+        }
+    }
+
+    #[test]
+    fn test_foreign_key_on_update_cascade_and_set_null() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE p (id BIGINT PRIMARY KEY, uk BIGINT UNIQUE)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c1 (id BIGINT PRIMARY KEY, p_uk BIGINT, FOREIGN KEY (p_uk) REFERENCES p(uk) ON UPDATE CASCADE)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c2 (id BIGINT PRIMARY KEY, p_uk BIGINT, FOREIGN KEY (p_uk) REFERENCES p(uk) ON UPDATE SET NULL)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        execute("INSERT INTO p VALUES (1, 100)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO c1 VALUES (10, 100)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO c2 VALUES (20, 100)", &mut pager, &mut catalog).unwrap();
+
+        execute(
+            "UPDATE p SET uk = 200 WHERE id = 1",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        let c1 = execute(
+            "SELECT p_uk FROM c1 WHERE id = 10",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        if let ExecResult::Rows(rows) = c1 {
+            assert_eq!(rows[0].get("p_uk"), Some(&Value::Integer(200)));
+        } else {
+            panic!("expected rows");
+        }
+
+        let c2 = execute(
+            "SELECT p_uk FROM c2 WHERE id = 20",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        if let ExecResult::Rows(rows) = c2 {
+            assert_eq!(rows[0].get("p_uk"), Some(&Value::Null));
+        } else {
+            panic!("expected rows");
+        }
+    }
+
+    #[test]
+    fn test_alter_table_add_foreign_key_validates_existing_rows() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE p (id BIGINT PRIMARY KEY)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c (id BIGINT PRIMARY KEY, p_id BIGINT)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        execute("INSERT INTO c VALUES (1, 999)", &mut pager, &mut catalog).unwrap();
+        let err = execute(
+            "ALTER TABLE c ADD FOREIGN KEY (p_id) REFERENCES p(id)",
+            &mut pager,
+            &mut catalog,
+        );
+        assert!(err.is_err());
+
+        execute("DELETE FROM c WHERE id = 1", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO p VALUES (10)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO c VALUES (2, 10)", &mut pager, &mut catalog).unwrap();
+        execute(
+            "ALTER TABLE c ADD FOREIGN KEY (p_id) REFERENCES p(id)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_alter_table_drop_foreign_key_removes_constraint() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE p (id BIGINT PRIMARY KEY)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c (id BIGINT PRIMARY KEY, p_id BIGINT, FOREIGN KEY (p_id) REFERENCES p(id))",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        execute(
+            "ALTER TABLE c DROP FOREIGN KEY (p_id)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        execute("INSERT INTO c VALUES (1, 999)", &mut pager, &mut catalog).unwrap();
+    }
+
+    #[test]
+    fn test_cascade_delete_honors_grandchild_restrict() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE p (id BIGINT PRIMARY KEY)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c (id BIGINT PRIMARY KEY, p_id BIGINT, FOREIGN KEY (p_id) REFERENCES p(id) ON DELETE CASCADE)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE g (id BIGINT PRIMARY KEY, c_id BIGINT, FOREIGN KEY (c_id) REFERENCES c(id))",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute("INSERT INTO p VALUES (1)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO c VALUES (10, 1)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO g VALUES (100, 10)", &mut pager, &mut catalog).unwrap();
+
+        let err = execute("DELETE FROM p WHERE id = 1", &mut pager, &mut catalog);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn test_cascade_update_validates_other_outgoing_foreign_keys() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE p1 (id BIGINT PRIMARY KEY)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE p2 (id BIGINT PRIMARY KEY)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c (id BIGINT PRIMARY KEY, a_id BIGINT, FOREIGN KEY (a_id) REFERENCES p1(id) ON UPDATE CASCADE, FOREIGN KEY (a_id) REFERENCES p2(id))",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute("INSERT INTO p1 VALUES (1)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO p2 VALUES (1)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO c VALUES (10, 1)", &mut pager, &mut catalog).unwrap();
+
+        // Updating p1.id to 2 would cascade c.a_id=2, which violates c.a_id -> p2(id).
+        let err = execute(
+            "UPDATE p1 SET id = 2 WHERE id = 1",
+            &mut pager,
+            &mut catalog,
+        );
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn test_drop_column_not_used_by_fk_child_side_is_allowed() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE p (id BIGINT PRIMARY KEY)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c (cid BIGINT PRIMARY KEY, id BIGINT, parent_id BIGINT, FOREIGN KEY (parent_id) REFERENCES p(id))",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        execute("ALTER TABLE c DROP COLUMN id", &mut pager, &mut catalog).unwrap();
+    }
+
+    #[test]
+    fn test_self_referencing_delete_ignores_rows_pending_deletion() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE t (id BIGINT PRIMARY KEY, parent_id BIGINT, FOREIGN KEY (parent_id) REFERENCES t(id))",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute("INSERT INTO t VALUES (1, NULL)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO t VALUES (2, 1)", &mut pager, &mut catalog).unwrap();
+
+        execute("DELETE FROM t", &mut pager, &mut catalog).unwrap();
+        let rows = execute("SELECT * FROM t", &mut pager, &mut catalog).unwrap();
+        if let ExecResult::Rows(rows) = rows {
+            assert!(rows.is_empty());
+        } else {
+            panic!("expected rows");
+        }
+    }
+
+    #[test]
+    fn test_cascade_update_rekeys_child_when_fk_is_part_of_pk() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE p (id BIGINT PRIMARY KEY, u BIGINT UNIQUE)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c (u BIGINT, seq BIGINT, PRIMARY KEY (u, seq), FOREIGN KEY (u) REFERENCES p(u) ON UPDATE CASCADE)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute("INSERT INTO p VALUES (1, 100)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO c VALUES (100, 1)", &mut pager, &mut catalog).unwrap();
+
+        execute(
+            "UPDATE p SET u = 200 WHERE id = 1",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        // If child PK re-keying is correct, old PK can be reused.
+        execute("INSERT INTO p VALUES (2, 100)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO c VALUES (100, 1)", &mut pager, &mut catalog).unwrap();
+        let rows = execute(
+            "SELECT * FROM c WHERE u = 200 AND seq = 1",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        if let ExecResult::Rows(rows) = rows {
+            assert_eq!(rows.len(), 1);
+        } else {
+            panic!("expected rows");
+        }
+    }
+
+    #[test]
+    fn test_parent_unique_failure_does_not_mutate_child_before_cascade() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE p (id BIGINT PRIMARY KEY, u BIGINT UNIQUE, u2 BIGINT UNIQUE)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c (id BIGINT PRIMARY KEY, pu BIGINT, FOREIGN KEY (pu) REFERENCES p(u) ON UPDATE CASCADE)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "INSERT INTO p VALUES (1, 10, 100)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "INSERT INTO p VALUES (2, 20, 200)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute("INSERT INTO c VALUES (1, 10)", &mut pager, &mut catalog).unwrap();
+
+        let err = execute("UPDATE p SET u = 20 WHERE id = 1", &mut pager, &mut catalog);
+        assert!(err.is_err());
+
+        let rows = execute("SELECT pu FROM c WHERE id = 1", &mut pager, &mut catalog).unwrap();
+        if let ExecResult::Rows(rows) = rows {
+            assert_eq!(rows[0].get("pu"), Some(&Value::Integer(10)));
+        } else {
+            panic!("expected rows");
+        }
+    }
+
+    #[test]
+    fn test_delete_cascade_cycle_does_not_recurse_forever() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE a (id BIGINT PRIMARY KEY, b_id BIGINT)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE b (id BIGINT PRIMARY KEY, a_id BIGINT)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "ALTER TABLE a ADD FOREIGN KEY (b_id) REFERENCES b(id) ON DELETE CASCADE",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "ALTER TABLE b ADD FOREIGN KEY (a_id) REFERENCES a(id) ON DELETE CASCADE",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        execute("INSERT INTO a VALUES (1, NULL)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO b VALUES (1, 1)", &mut pager, &mut catalog).unwrap();
+        execute(
+            "UPDATE a SET b_id = 1 WHERE id = 1",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        execute("DELETE FROM a WHERE id = 1", &mut pager, &mut catalog).unwrap();
+        let a_rows = execute("SELECT * FROM a", &mut pager, &mut catalog).unwrap();
+        let b_rows = execute("SELECT * FROM b", &mut pager, &mut catalog).unwrap();
+        if let ExecResult::Rows(rows) = a_rows {
+            assert!(rows.is_empty());
+        } else {
+            panic!("expected rows");
+        }
+        if let ExecResult::Rows(rows) = b_rows {
+            assert!(rows.is_empty());
+        } else {
+            panic!("expected rows");
+        }
+    }
+
+    #[test]
+    fn test_cascade_update_propagates_parent_side_fk_checks() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE p (id BIGINT PRIMARY KEY, u BIGINT UNIQUE)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c (id BIGINT PRIMARY KEY, pu BIGINT UNIQUE, FOREIGN KEY (pu) REFERENCES p(u) ON UPDATE CASCADE)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE g (id BIGINT PRIMARY KEY, cu BIGINT, FOREIGN KEY (cu) REFERENCES c(pu))",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        execute("INSERT INTO p VALUES (1, 10)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO c VALUES (1, 10)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO g VALUES (1, 10)", &mut pager, &mut catalog).unwrap();
+
+        // Updating p.u cascades c.pu. Since g.cu references c(pu) with RESTRICT,
+        // this must fail unless g is also handled.
+        let err = execute("UPDATE p SET u = 20 WHERE id = 1", &mut pager, &mut catalog);
+        assert!(err.is_err());
+
+        let c_rows = execute("SELECT pu FROM c WHERE id = 1", &mut pager, &mut catalog).unwrap();
+        if let ExecResult::Rows(rows) = c_rows {
+            assert_eq!(rows[0].get("pu"), Some(&Value::Integer(10)));
+        } else {
+            panic!("expected rows");
+        }
+    }
+
+    #[test]
+    fn test_parent_update_failing_outgoing_fk_does_not_apply_incoming_cascade() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE gp (id BIGINT PRIMARY KEY)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE p (id BIGINT PRIMARY KEY, g_id BIGINT, u BIGINT UNIQUE, FOREIGN KEY (g_id) REFERENCES gp(id))",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c (id BIGINT PRIMARY KEY, pu BIGINT, FOREIGN KEY (pu) REFERENCES p(u) ON UPDATE CASCADE)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute("INSERT INTO gp VALUES (1)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO p VALUES (1, 1, 10)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO c VALUES (1, 10)", &mut pager, &mut catalog).unwrap();
+
+        let err = execute(
+            "UPDATE p SET u = 20, g_id = 999 WHERE id = 1",
+            &mut pager,
+            &mut catalog,
+        );
+        assert!(err.is_err());
+
+        let rows = execute("SELECT pu FROM c WHERE id = 1", &mut pager, &mut catalog).unwrap();
+        if let ExecResult::Rows(rows) = rows {
+            assert_eq!(rows[0].get("pu"), Some(&Value::Integer(10)));
+        } else {
+            panic!("expected rows");
+        }
+    }
+
+    #[test]
+    fn test_on_duplicate_update_failing_outgoing_fk_does_not_apply_incoming_cascade() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE gp (id BIGINT PRIMARY KEY)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE p (id BIGINT PRIMARY KEY, g_id BIGINT, u BIGINT UNIQUE, FOREIGN KEY (g_id) REFERENCES gp(id))",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c (id BIGINT PRIMARY KEY, pu BIGINT, FOREIGN KEY (pu) REFERENCES p(u) ON UPDATE CASCADE)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute("INSERT INTO gp VALUES (1)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO p VALUES (1, 1, 10)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO c VALUES (1, 10)", &mut pager, &mut catalog).unwrap();
+
+        let err = execute(
+            "INSERT INTO p VALUES (1, 999, 10) ON DUPLICATE KEY UPDATE g_id = 999, u = 20",
+            &mut pager,
+            &mut catalog,
+        );
+        assert!(err.is_err());
+
+        let rows = execute("SELECT pu FROM c WHERE id = 1", &mut pager, &mut catalog).unwrap();
+        if let ExecResult::Rows(rows) = rows {
+            assert_eq!(rows[0].get("pu"), Some(&Value::Integer(10)));
+        } else {
+            panic!("expected rows");
+        }
+    }
+
+    #[test]
+    fn test_replace_checks_foreign_keys_for_all_conflicting_rows() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE p (id BIGINT PRIMARY KEY, email VARCHAR UNIQUE, uname VARCHAR UNIQUE)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c (id BIGINT PRIMARY KEY, uname VARCHAR, FOREIGN KEY (uname) REFERENCES p(uname))",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "INSERT INTO p VALUES (1, 'a@example.com', 'u1')",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "INSERT INTO p VALUES (2, 'b@example.com', 'u2')",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute("INSERT INTO c VALUES (1, 'u2')", &mut pager, &mut catalog).unwrap();
+
+        // Conflicts with id=1 by email and id=2 by uname. id=2 is referenced.
+        let err = execute(
+            "REPLACE INTO p VALUES (3, 'a@example.com', 'u2')",
+            &mut pager,
+            &mut catalog,
+        );
+        assert!(err.is_err());
+
+        let p2 = execute("SELECT * FROM p WHERE id = 2", &mut pager, &mut catalog).unwrap();
+        if let ExecResult::Rows(rows) = p2 {
+            assert_eq!(rows.len(), 1);
+        } else {
+            panic!("expected rows");
+        }
+    }
+
+    #[test]
+    fn test_drop_foreign_key_ambiguous_columns_is_rejected() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE p1 (id BIGINT PRIMARY KEY)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE p2 (id BIGINT PRIMARY KEY)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c (id BIGINT PRIMARY KEY, x BIGINT)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "ALTER TABLE c ADD FOREIGN KEY (x) REFERENCES p1(id)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "ALTER TABLE c ADD FOREIGN KEY (x) REFERENCES p2(id)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        let err = execute(
+            "ALTER TABLE c DROP FOREIGN KEY (x)",
+            &mut pager,
+            &mut catalog,
+        );
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn test_drop_column_referenced_by_self_fk_parent_side_is_rejected() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE t (id BIGINT PRIMARY KEY, u BIGINT UNIQUE, pu BIGINT, FOREIGN KEY (pu) REFERENCES t(u))",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        let err = execute("ALTER TABLE t DROP COLUMN u", &mut pager, &mut catalog);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn test_delete_mixed_actions_has_no_partial_side_effect_on_restrict_failure() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE p (id BIGINT PRIMARY KEY)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c_cas (id BIGINT PRIMARY KEY, p_id BIGINT, FOREIGN KEY (p_id) REFERENCES p(id) ON DELETE CASCADE)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c_res (id BIGINT PRIMARY KEY, p_id BIGINT, FOREIGN KEY (p_id) REFERENCES p(id) ON DELETE RESTRICT)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute("INSERT INTO p VALUES (1)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO c_cas VALUES (1, 1)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO c_res VALUES (1, 1)", &mut pager, &mut catalog).unwrap();
+
+        let err = execute("DELETE FROM p WHERE id = 1", &mut pager, &mut catalog);
+        assert!(err.is_err());
+
+        // CASCADE side table must remain unchanged on failure.
+        let rows = execute("SELECT * FROM c_cas", &mut pager, &mut catalog).unwrap();
+        if let ExecResult::Rows(rows) = rows {
+            assert_eq!(rows.len(), 1);
+        } else {
+            panic!("expected rows");
+        }
+    }
+
+    #[test]
+    fn test_delete_multi_parent_rows_has_no_partial_side_effect_on_restrict_failure() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE p (id BIGINT PRIMARY KEY)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c_cas (id BIGINT PRIMARY KEY, p_id BIGINT, FOREIGN KEY (p_id) REFERENCES p(id) ON DELETE CASCADE)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c_res (id BIGINT PRIMARY KEY, p_id BIGINT, FOREIGN KEY (p_id) REFERENCES p(id) ON DELETE RESTRICT)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute("INSERT INTO p VALUES (1)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO p VALUES (2)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO c_cas VALUES (1, 1)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO c_res VALUES (1, 2)", &mut pager, &mut catalog).unwrap();
+
+        let err = execute(
+            "DELETE FROM p WHERE id = 1 OR id = 2",
+            &mut pager,
+            &mut catalog,
+        );
+        assert!(err.is_err());
+
+        let cas_rows = execute("SELECT * FROM c_cas", &mut pager, &mut catalog).unwrap();
+        if let ExecResult::Rows(rows) = cas_rows {
+            assert_eq!(rows.len(), 1);
+        } else {
+            panic!("expected rows");
+        }
+
+        let p_rows = execute("SELECT * FROM p", &mut pager, &mut catalog).unwrap();
+        if let ExecResult::Rows(rows) = p_rows {
+            assert_eq!(rows.len(), 2);
+        } else {
+            panic!("expected rows");
+        }
+    }
+
+    #[test]
+    fn test_update_mixed_actions_has_no_partial_side_effect_on_restrict_failure() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE p (id BIGINT PRIMARY KEY, u BIGINT UNIQUE)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c_cas (id BIGINT PRIMARY KEY, pu BIGINT, FOREIGN KEY (pu) REFERENCES p(u) ON UPDATE CASCADE)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c_res (id BIGINT PRIMARY KEY, pu BIGINT, FOREIGN KEY (pu) REFERENCES p(u) ON UPDATE RESTRICT)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute("INSERT INTO p VALUES (1, 10)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO c_cas VALUES (1, 10)", &mut pager, &mut catalog).unwrap();
+        execute("INSERT INTO c_res VALUES (1, 10)", &mut pager, &mut catalog).unwrap();
+
+        let err = execute("UPDATE p SET u = 20 WHERE id = 1", &mut pager, &mut catalog);
+        assert!(err.is_err());
+
+        let rows = execute(
+            "SELECT pu FROM c_cas WHERE id = 1",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        if let ExecResult::Rows(rows) = rows {
+            assert_eq!(rows[0].get("pu"), Some(&Value::Integer(10)));
+        } else {
+            panic!("expected rows");
+        }
+    }
+
+    #[test]
+    fn test_modify_column_rejected_when_fk_depends_on_it() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE p (id BIGINT PRIMARY KEY)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c (id BIGINT PRIMARY KEY, p_id BIGINT, FOREIGN KEY (p_id) REFERENCES p(id))",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        let err = execute(
+            "ALTER TABLE c MODIFY COLUMN p_id INT",
+            &mut pager,
+            &mut catalog,
+        );
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn test_change_column_rejected_when_self_fk_parent_depends_on_it() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE t (id BIGINT PRIMARY KEY, u BIGINT UNIQUE, pu BIGINT, FOREIGN KEY (pu) REFERENCES t(u))",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        let err = execute(
+            "ALTER TABLE t CHANGE COLUMN u u2 BIGINT",
+            &mut pager,
+            &mut catalog,
+        );
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn test_replace_rechecks_fk_after_conflict_deletes() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE t (id BIGINT PRIMARY KEY, code VARCHAR UNIQUE, parent_id BIGINT, FOREIGN KEY (parent_id) REFERENCES t(id) ON DELETE SET NULL)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "INSERT INTO t VALUES (1, 'p', NULL)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute("INSERT INTO t VALUES (2, 'c', 1)", &mut pager, &mut catalog).unwrap();
+
+        // Conflicts with code='p' and deletes parent row id=1 first.
+        // Without post-delete recheck this could insert an orphan parent_id=1.
+        let err = execute(
+            "REPLACE INTO t VALUES (3, 'p', 1)",
+            &mut pager,
+            &mut catalog,
+        );
+        assert!(err.is_err());
+
+        let p = execute("SELECT * FROM t WHERE id = 1", &mut pager, &mut catalog).unwrap();
+        if let ExecResult::Rows(rows) = p {
+            assert_eq!(rows.len(), 1);
+        } else {
+            panic!("expected rows");
+        }
+
+        let c = execute(
+            "SELECT parent_id FROM t WHERE id = 2",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        if let ExecResult::Rows(rows) = c {
+            assert_eq!(rows[0].get("parent_id"), Some(&Value::Integer(1)));
+        } else {
+            panic!("expected rows");
+        }
+    }
+
+    #[test]
+    fn test_modify_unrelated_child_column_allowed_even_if_name_matches_parent_ref_col() {
+        let (mut pager, mut catalog, _dir) = setup();
+        execute(
+            "CREATE TABLE p (id BIGINT PRIMARY KEY)",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+        execute(
+            "CREATE TABLE c (cid BIGINT PRIMARY KEY, id INT, parent_id BIGINT, FOREIGN KEY (parent_id) REFERENCES p(id))",
+            &mut pager,
+            &mut catalog,
+        )
+        .unwrap();
+
+        let ok = execute(
+            "ALTER TABLE c MODIFY COLUMN id BIGINT",
+            &mut pager,
+            &mut catalog,
+        );
+        assert!(ok.is_ok());
     }
 }

--- a/src/sql/executor/alter.rs
+++ b/src/sql/executor/alter.rs
@@ -28,6 +28,183 @@ pub(super) fn exec_alter_table(
             pager,
             catalog,
         ),
+        AlterTableOp::AddForeignKey(fk) => {
+            exec_alter_add_foreign_key(table_def, fk, &at.table_name, pager, catalog)
+        }
+        AlterTableOp::DropForeignKey(columns) => {
+            exec_alter_drop_foreign_key(table_def, columns, &at.table_name, pager, catalog)
+        }
+    }
+}
+
+fn exec_alter_add_foreign_key(
+    mut table_def: TableDef,
+    fk: &ForeignKeySpec,
+    table_name: &str,
+    pager: &mut impl PageStore,
+    catalog: &mut SystemCatalog,
+) -> Result<ExecResult> {
+    if fk.columns.is_empty() || fk.ref_columns.is_empty() {
+        return Err(MuroError::Schema(
+            "FOREIGN KEY columns cannot be empty".into(),
+        ));
+    }
+    if fk.columns.len() != fk.ref_columns.len() {
+        return Err(MuroError::Schema(
+            "FOREIGN KEY column count must match referenced column count".into(),
+        ));
+    }
+    if table_def.foreign_keys.iter().any(|existing| {
+        existing.columns == fk.columns
+            && existing.ref_table == fk.ref_table
+            && existing.ref_columns == fk.ref_columns
+    }) {
+        return Err(MuroError::Schema("Duplicate FOREIGN KEY constraint".into()));
+    }
+
+    let mut child_types = Vec::with_capacity(fk.columns.len());
+    for col_name in &fk.columns {
+        let Some(idx) = table_def.column_index(col_name) else {
+            return Err(MuroError::Schema(format!(
+                "Column '{}' not found in table '{}'",
+                col_name, table_name
+            )));
+        };
+        child_types.push(table_def.columns[idx].data_type);
+    }
+
+    let (parent_types, unique_sets) = if fk.ref_table == table_name {
+        let mut parent_types = Vec::with_capacity(fk.ref_columns.len());
+        for col_name in &fk.ref_columns {
+            let Some(idx) = table_def.column_index(col_name) else {
+                return Err(MuroError::Schema(format!(
+                    "Referenced column '{}.{}' not found",
+                    fk.ref_table, col_name
+                )));
+            };
+            parent_types.push(table_def.columns[idx].data_type);
+        }
+        let mut unique_sets = vec![table_def.pk_columns.clone()];
+        for idx in catalog.get_indexes_for_table(pager, table_name)? {
+            if idx.is_unique {
+                unique_sets.push(idx.column_names);
+            }
+        }
+        (parent_types, unique_sets)
+    } else {
+        let parent_def = catalog.get_table(pager, &fk.ref_table)?.ok_or_else(|| {
+            MuroError::Schema(format!(
+                "Referenced table '{}' not found for FOREIGN KEY",
+                fk.ref_table
+            ))
+        })?;
+        let mut parent_types = Vec::with_capacity(fk.ref_columns.len());
+        for col_name in &fk.ref_columns {
+            let Some(idx) = parent_def.column_index(col_name) else {
+                return Err(MuroError::Schema(format!(
+                    "Referenced column '{}.{}' not found",
+                    fk.ref_table, col_name
+                )));
+            };
+            parent_types.push(parent_def.columns[idx].data_type);
+        }
+        let mut unique_sets = vec![parent_def.pk_columns.clone()];
+        for idx in catalog.get_indexes_for_table(pager, &fk.ref_table)? {
+            if idx.is_unique {
+                unique_sets.push(idx.column_names);
+            }
+        }
+        (parent_types, unique_sets)
+    };
+
+    if !unique_sets.iter().any(|cols| cols == &fk.ref_columns) {
+        return Err(MuroError::Schema(format!(
+            "Referenced columns '{}.({})' must be PRIMARY KEY or UNIQUE",
+            fk.ref_table,
+            fk.ref_columns.join(", ")
+        )));
+    }
+    for (child_ty, parent_ty) in child_types.iter().zip(parent_types.iter()) {
+        if child_ty != parent_ty {
+            return Err(MuroError::Schema(format!(
+                "FOREIGN KEY type mismatch: child '{}' and parent '{}' must have same type",
+                child_ty, parent_ty
+            )));
+        }
+    }
+
+    let new_fk = ForeignKeyDef {
+        columns: fk.columns.clone(),
+        ref_table: fk.ref_table.clone(),
+        ref_columns: fk.ref_columns.clone(),
+        on_delete: map_fk_action(fk.on_delete),
+        on_update: map_fk_action(fk.on_update),
+    };
+
+    let mut candidate = table_def.clone();
+    candidate.foreign_keys.push(new_fk.clone());
+    let data_btree = BTree::open(table_def.data_btree_root);
+    let mut existing_rows: Vec<Vec<Value>> = Vec::new();
+    data_btree.scan(pager, |_k, row| {
+        let values =
+            deserialize_row_versioned(row, &candidate.columns, candidate.row_format_version)?;
+        existing_rows.push(values);
+        Ok(true)
+    })?;
+    for values in &existing_rows {
+        enforce_child_foreign_keys(&candidate, values, pager, catalog)?;
+    }
+
+    table_def.foreign_keys.push(new_fk);
+    catalog.update_table(pager, &table_def)?;
+    Ok(ExecResult::Ok)
+}
+
+fn exec_alter_drop_foreign_key(
+    mut table_def: TableDef,
+    columns: &[String],
+    table_name: &str,
+    pager: &mut impl PageStore,
+    catalog: &mut SystemCatalog,
+) -> Result<ExecResult> {
+    let matches: Vec<usize> = table_def
+        .foreign_keys
+        .iter()
+        .enumerate()
+        .filter_map(|(i, fk)| (fk.columns == columns).then_some(i))
+        .collect();
+    if matches.is_empty() {
+        return Err(MuroError::Schema(format!(
+            "FOREIGN KEY ({}) not found in table '{}'",
+            columns.join(", "),
+            table_name
+        )));
+    }
+    if matches.len() > 1 {
+        return Err(MuroError::Schema(format!(
+            "FOREIGN KEY ({}) is ambiguous in table '{}'",
+            columns.join(", "),
+            table_name
+        )));
+    }
+    table_def.foreign_keys.remove(matches[0]);
+    catalog.update_table(pager, &table_def)?;
+    Ok(ExecResult::Ok)
+}
+
+fn map_fk_action(
+    action: crate::sql::ast::ForeignKeyAction,
+) -> crate::schema::catalog::ForeignKeyAction {
+    match action {
+        crate::sql::ast::ForeignKeyAction::Restrict => {
+            crate::schema::catalog::ForeignKeyAction::Restrict
+        }
+        crate::sql::ast::ForeignKeyAction::Cascade => {
+            crate::schema::catalog::ForeignKeyAction::Cascade
+        }
+        crate::sql::ast::ForeignKeyAction::SetNull => {
+            crate::schema::catalog::ForeignKeyAction::SetNull
+        }
     }
 }
 
@@ -171,6 +348,29 @@ pub(super) fn exec_alter_drop_column(
             )));
         }
     }
+    for fk in &table_def.foreign_keys {
+        if fk.columns.iter().any(|c| c == col_name) {
+            return Err(MuroError::Schema(format!(
+                "Cannot drop column '{}': foreign key depends on it",
+                col_name
+            )));
+        }
+    }
+    for other in catalog.list_tables(pager)? {
+        let Some(other_def) = catalog.get_table(pager, &other)? else {
+            continue;
+        };
+        if other_def
+            .foreign_keys
+            .iter()
+            .any(|fk| fk.ref_table == table_name && fk.ref_columns.iter().any(|c| c == col_name))
+        {
+            return Err(MuroError::Schema(format!(
+                "Cannot drop column '{}': referenced by foreign key from table '{}'",
+                col_name, other
+            )));
+        }
+    }
 
     // Full table rewrite: scan all rows, remove the dropped column, re-insert
     let old_columns = table_def.columns.clone();
@@ -215,6 +415,15 @@ pub(super) fn exec_alter_modify_column(
     pager: &mut impl PageStore,
     catalog: &mut SystemCatalog,
 ) -> Result<ExecResult> {
+    ensure_column_not_fk_dependent(
+        &table_def,
+        &col_spec.name,
+        table_name,
+        pager,
+        catalog,
+        "MODIFY COLUMN",
+    )?;
+
     let col_idx = table_def.column_index(&col_spec.name).ok_or_else(|| {
         MuroError::Schema(format!(
             "Column '{}' not found in table '{}'",
@@ -284,6 +493,15 @@ pub(super) fn exec_alter_change_column(
     pager: &mut impl PageStore,
     catalog: &mut SystemCatalog,
 ) -> Result<ExecResult> {
+    ensure_column_not_fk_dependent(
+        &table_def,
+        old_name,
+        table_name,
+        pager,
+        catalog,
+        "CHANGE COLUMN",
+    )?;
+
     let col_idx = table_def.column_index(old_name).ok_or_else(|| {
         MuroError::Schema(format!(
             "Column '{}' not found in table '{}'",
@@ -462,6 +680,43 @@ pub(super) fn validate_no_nulls_in_column(
         }
         Ok(true)
     })?;
+    Ok(())
+}
+
+fn ensure_column_not_fk_dependent(
+    table_def: &TableDef,
+    col_name: &str,
+    table_name: &str,
+    pager: &mut impl PageStore,
+    catalog: &mut SystemCatalog,
+    op: &str,
+) -> Result<()> {
+    for fk in &table_def.foreign_keys {
+        let is_child_side = fk.columns.iter().any(|c| c == col_name);
+        let is_self_parent_side =
+            fk.ref_table == table_name && fk.ref_columns.iter().any(|c| c == col_name);
+        if is_child_side || is_self_parent_side {
+            return Err(MuroError::Schema(format!(
+                "Cannot {} '{}': foreign key depends on it",
+                op, col_name
+            )));
+        }
+    }
+    for other in catalog.list_tables(pager)? {
+        let Some(other_def) = catalog.get_table(pager, &other)? else {
+            continue;
+        };
+        if other_def
+            .foreign_keys
+            .iter()
+            .any(|fk| fk.ref_table == table_name && fk.ref_columns.iter().any(|c| c == col_name))
+        {
+            return Err(MuroError::Schema(format!(
+                "Cannot {} '{}': referenced by foreign key from table '{}'",
+                op, col_name, other
+            )));
+        }
+    }
     Ok(())
 }
 

--- a/src/sql/executor/ddl.rs
+++ b/src/sql/executor/ddl.rs
@@ -18,6 +18,7 @@ pub(super) fn exec_create_table(
     let has_col_pk = ct.columns.iter().any(|c| c.is_primary_key);
     let mut table_level_pk: Option<Vec<String>> = None;
     let mut table_level_uniques: Vec<(String, Vec<String>)> = Vec::new();
+    let mut table_level_fks: Vec<ForeignKeyDef> = Vec::new();
 
     for constraint in &ct.constraints {
         match constraint {
@@ -57,8 +58,50 @@ pub(super) fn exec_create_table(
                 }
                 table_level_uniques.push((idx_name, cols.clone()));
             }
+            TableConstraint::ForeignKey {
+                columns,
+                ref_table,
+                ref_columns,
+                on_delete,
+                on_update,
+            } => {
+                if columns.is_empty() || ref_columns.is_empty() {
+                    return Err(MuroError::Schema(
+                        "FOREIGN KEY columns cannot be empty".into(),
+                    ));
+                }
+                if columns.len() != ref_columns.len() {
+                    return Err(MuroError::Schema(
+                        "FOREIGN KEY column count must match referenced column count".into(),
+                    ));
+                }
+                for col_name in columns {
+                    if !col_names.contains(&col_name.as_str()) {
+                        return Err(MuroError::Schema(format!(
+                            "Column '{}' not found for FOREIGN KEY constraint",
+                            col_name
+                        )));
+                    }
+                }
+                table_level_fks.push(ForeignKeyDef {
+                    columns: columns.clone(),
+                    ref_table: ref_table.clone(),
+                    ref_columns: ref_columns.clone(),
+                    on_delete: map_fk_action(*on_delete),
+                    on_update: map_fk_action(*on_update),
+                });
+            }
         }
     }
+
+    validate_foreign_keys(
+        ct,
+        catalog,
+        pager,
+        &table_level_pk,
+        &table_level_uniques,
+        &table_level_fks,
+    )?;
 
     // Collect column-level UNIQUE index names and detect duplicates with table-level
     let mut all_index_names: Vec<String> = table_level_uniques
@@ -130,6 +173,11 @@ pub(super) fn exec_create_table(
             }
         }
         table_def.pk_columns = pk_cols;
+        table_def.foreign_keys = table_level_fks.clone();
+        catalog.update_table(pager, &table_def)?;
+    } else if !table_level_fks.is_empty() {
+        let mut table_def = catalog.get_table(pager, &ct.table_name)?.unwrap();
+        table_def.foreign_keys = table_level_fks.clone();
         catalog.update_table(pager, &table_def)?;
     }
 
@@ -178,6 +226,124 @@ pub(super) fn exec_create_table(
     }
 
     Ok(ExecResult::Ok)
+}
+
+fn map_fk_action(
+    action: crate::sql::ast::ForeignKeyAction,
+) -> crate::schema::catalog::ForeignKeyAction {
+    match action {
+        crate::sql::ast::ForeignKeyAction::Restrict => {
+            crate::schema::catalog::ForeignKeyAction::Restrict
+        }
+        crate::sql::ast::ForeignKeyAction::Cascade => {
+            crate::schema::catalog::ForeignKeyAction::Cascade
+        }
+        crate::sql::ast::ForeignKeyAction::SetNull => {
+            crate::schema::catalog::ForeignKeyAction::SetNull
+        }
+    }
+}
+
+fn validate_foreign_keys(
+    ct: &CreateTable,
+    catalog: &mut SystemCatalog,
+    pager: &mut impl PageStore,
+    table_level_pk: &Option<Vec<String>>,
+    table_level_uniques: &[(String, Vec<String>)],
+    fks: &[ForeignKeyDef],
+) -> Result<()> {
+    for fk in fks {
+        let mut child_types = Vec::with_capacity(fk.columns.len());
+        for col in &fk.columns {
+            let Some(cs) = ct.columns.iter().find(|c| c.name == *col) else {
+                return Err(MuroError::Schema(format!(
+                    "Column '{}' not found for FOREIGN KEY constraint",
+                    col
+                )));
+            };
+            child_types.push(cs.data_type);
+        }
+
+        let (parent_types, unique_sets) = if fk.ref_table == ct.table_name {
+            let mut unique_sets = Vec::new();
+            if let Some(cols) = table_level_pk {
+                unique_sets.push(cols.clone());
+            } else {
+                let pk_cols: Vec<String> = ct
+                    .columns
+                    .iter()
+                    .filter(|c| c.is_primary_key)
+                    .map(|c| c.name.clone())
+                    .collect();
+                if !pk_cols.is_empty() {
+                    unique_sets.push(pk_cols);
+                }
+            }
+            for (_name, cols) in table_level_uniques {
+                unique_sets.push(cols.clone());
+            }
+            for cs in &ct.columns {
+                if cs.is_unique {
+                    unique_sets.push(vec![cs.name.clone()]);
+                }
+            }
+
+            let mut parent_types = Vec::with_capacity(fk.ref_columns.len());
+            for col in &fk.ref_columns {
+                let Some(cs) = ct.columns.iter().find(|c| c.name == *col) else {
+                    return Err(MuroError::Schema(format!(
+                        "Referenced column '{}.{}' not found",
+                        fk.ref_table, col
+                    )));
+                };
+                parent_types.push(cs.data_type);
+            }
+            (parent_types, unique_sets)
+        } else {
+            let parent_def = catalog.get_table(pager, &fk.ref_table)?.ok_or_else(|| {
+                MuroError::Schema(format!(
+                    "Referenced table '{}' not found for FOREIGN KEY",
+                    fk.ref_table
+                ))
+            })?;
+            let mut parent_types = Vec::with_capacity(fk.ref_columns.len());
+            for col in &fk.ref_columns {
+                let Some(idx) = parent_def.column_index(col) else {
+                    return Err(MuroError::Schema(format!(
+                        "Referenced column '{}.{}' not found",
+                        fk.ref_table, col
+                    )));
+                };
+                parent_types.push(parent_def.columns[idx].data_type);
+            }
+            let mut unique_sets = Vec::new();
+            unique_sets.push(parent_def.pk_columns.clone());
+            for idx in catalog.get_indexes_for_table(pager, &fk.ref_table)? {
+                if idx.is_unique {
+                    unique_sets.push(idx.column_names.clone());
+                }
+            }
+            (parent_types, unique_sets)
+        };
+
+        if !unique_sets.iter().any(|cols| cols == &fk.ref_columns) {
+            return Err(MuroError::Schema(format!(
+                "Referenced columns '{}.({})' must be PRIMARY KEY or UNIQUE",
+                fk.ref_table,
+                fk.ref_columns.join(", ")
+            )));
+        }
+
+        for (child_ty, parent_ty) in child_types.iter().zip(parent_types.iter()) {
+            if child_ty != parent_ty {
+                return Err(MuroError::Schema(format!(
+                    "FOREIGN KEY type mismatch: child '{}' and parent '{}' must have same type",
+                    child_ty, parent_ty
+                )));
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Convert an AST expression (from DEFAULT clause) to a DefaultValue for storage.
@@ -634,6 +800,27 @@ pub(super) fn exec_drop_table(
             )));
         }
     };
+
+    for table_name in catalog.list_tables(pager)? {
+        if table_name == dt.table_name {
+            continue;
+        }
+        let Some(child) = catalog.get_table(pager, &table_name)? else {
+            continue;
+        };
+        if let Some(fk) = child
+            .foreign_keys
+            .iter()
+            .find(|fk| fk.ref_table == dt.table_name)
+        {
+            return Err(MuroError::Schema(format!(
+                "Cannot drop table '{}': referenced by '{}' FOREIGN KEY ({})",
+                dt.table_name,
+                child.name,
+                fk.columns.join(", ")
+            )));
+        }
+    }
 
     // Free the data B-tree pages
     let data_btree = BTree::open(table_def.data_btree_root);

--- a/src/sql/executor/foreign_key.rs
+++ b/src/sql/executor/foreign_key.rs
@@ -1,0 +1,630 @@
+use super::*;
+use std::collections::HashSet;
+
+#[derive(Clone)]
+struct ChildMatch {
+    pk_key: Vec<u8>,
+    row_values: Vec<Value>,
+}
+
+#[derive(Clone)]
+struct PendingDeleteAction {
+    child_table_name: String,
+    fk: ForeignKeyDef,
+    parent_key: Vec<Value>,
+}
+
+#[derive(Clone)]
+struct PendingUpdateAction {
+    child_table_name: String,
+    fk: ForeignKeyDef,
+    old_parent: Vec<Value>,
+    new_parent: Vec<Value>,
+}
+
+pub(super) fn enforce_child_foreign_keys(
+    table_def: &TableDef,
+    row_values: &[Value],
+    pager: &mut impl PageStore,
+    catalog: &mut SystemCatalog,
+) -> Result<()> {
+    for fk in &table_def.foreign_keys {
+        let child_values = fk_child_values(table_def, fk, row_values)?;
+        if child_values.iter().any(Value::is_null) {
+            continue;
+        }
+
+        let parent_def = catalog.get_table(pager, &fk.ref_table)?.ok_or_else(|| {
+            MuroError::Schema(format!("Referenced table '{}' not found", fk.ref_table))
+        })?;
+        let parent_btree = BTree::open(parent_def.data_btree_root);
+        let mut exists = false;
+        parent_btree.scan(pager, |_k, row| {
+            let parent_row =
+                deserialize_row_versioned(row, &parent_def.columns, parent_def.row_format_version)?;
+            if fk_parent_matches_row(&parent_def, fk, &parent_row, &child_values)? {
+                exists = true;
+                return Ok(false);
+            }
+            Ok(true)
+        })?;
+
+        if !exists {
+            return Err(MuroError::Execution(format!(
+                "FOREIGN KEY constraint fails: ({}) REFERENCES {}({})",
+                fk.columns.join(", "),
+                fk.ref_table,
+                fk.ref_columns.join(", "),
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn enforce_parent_restrict_on_delete(
+    parent_table: &TableDef,
+    rows_to_delete: &[Vec<Value>],
+    deleting_pk_keys: &[Vec<u8>],
+    pager: &mut impl PageStore,
+    catalog: &mut SystemCatalog,
+) -> Result<()> {
+    let mut visited = HashSet::new();
+    enforce_parent_restrict_on_delete_inner(
+        parent_table,
+        rows_to_delete,
+        deleting_pk_keys,
+        pager,
+        catalog,
+        &mut visited,
+    )
+}
+
+fn enforce_parent_restrict_on_delete_inner(
+    parent_table: &TableDef,
+    rows_to_delete: &[Vec<Value>],
+    deleting_pk_keys: &[Vec<u8>],
+    pager: &mut impl PageStore,
+    catalog: &mut SystemCatalog,
+    visited: &mut HashSet<(String, Vec<u8>)>,
+) -> Result<()> {
+    if rows_to_delete.is_empty() {
+        return Ok(());
+    }
+    if rows_to_delete.len() != deleting_pk_keys.len() {
+        return Err(MuroError::Execution(
+            "internal error: delete rows/key length mismatch".into(),
+        ));
+    }
+
+    let incoming = incoming_foreign_keys(&parent_table.name, pager, catalog)?;
+    if incoming.is_empty() {
+        return Ok(());
+    }
+
+    let deleting_pk_set: HashSet<Vec<u8>> = deleting_pk_keys.iter().cloned().collect();
+    let mut pending_all = Vec::new();
+    for (parent_row, parent_pk) in rows_to_delete.iter().zip(deleting_pk_keys.iter()) {
+        // Break cascade loops on cyclic FK graphs.
+        if !visited.insert((parent_table.name.clone(), parent_pk.clone())) {
+            continue;
+        }
+        for (child_table_name, fk) in &incoming {
+            let parent_key = fk_parent_values_from_row(parent_table, fk, parent_row)?;
+            let Some(child_table) = catalog.get_table(pager, child_table_name)? else {
+                continue;
+            };
+            let ignored_pk_set = if child_table.name == parent_table.name {
+                Some(&deleting_pk_set)
+            } else {
+                None
+            };
+            let matches =
+                find_child_references(&child_table, fk, &parent_key, None, ignored_pk_set, pager)?;
+            if matches.is_empty() {
+                continue;
+            }
+
+            if fk.on_delete == crate::schema::catalog::ForeignKeyAction::Restrict {
+                return Err(MuroError::Execution(format!(
+                    "Cannot delete parent row: referenced by {} via FOREIGN KEY ({})",
+                    child_table.name,
+                    fk.columns.join(", "),
+                )));
+            }
+            pending_all.push(PendingDeleteAction {
+                child_table_name: child_table_name.clone(),
+                fk: fk.clone(),
+                parent_key,
+            });
+        }
+    }
+
+    for action in pending_all {
+        let Some(mut child_table) = catalog.get_table(pager, &action.child_table_name)? else {
+            continue;
+        };
+        let ignored_pk_set = if child_table.name == parent_table.name {
+            Some(&deleting_pk_set)
+        } else {
+            None
+        };
+        let matches = find_child_references(
+            &child_table,
+            &action.fk,
+            &action.parent_key,
+            None,
+            ignored_pk_set,
+            pager,
+        )?;
+        if matches.is_empty() {
+            continue;
+        }
+        match action.fk.on_delete {
+            crate::schema::catalog::ForeignKeyAction::Cascade => {
+                cascade_delete_child_rows(&mut child_table, &matches, pager, catalog, visited)?;
+            }
+            crate::schema::catalog::ForeignKeyAction::SetNull => {
+                set_null_child_references(
+                    &mut child_table,
+                    &action.fk,
+                    &matches,
+                    pager,
+                    catalog,
+                    visited,
+                )?;
+            }
+            crate::schema::catalog::ForeignKeyAction::Restrict => {}
+        }
+    }
+
+    Ok(())
+}
+
+pub(super) fn enforce_parent_restrict_on_update(
+    parent_table: &TableDef,
+    current_pk_key: &[u8],
+    old_values: &[Value],
+    new_values: &[Value],
+    pager: &mut impl PageStore,
+    catalog: &mut SystemCatalog,
+) -> Result<()> {
+    let mut visited = HashSet::new();
+    enforce_parent_restrict_on_update_inner(
+        parent_table,
+        current_pk_key,
+        old_values,
+        new_values,
+        pager,
+        catalog,
+        &mut visited,
+    )
+}
+
+fn enforce_parent_restrict_on_update_inner(
+    parent_table: &TableDef,
+    current_pk_key: &[u8],
+    old_values: &[Value],
+    new_values: &[Value],
+    pager: &mut impl PageStore,
+    catalog: &mut SystemCatalog,
+    visited: &mut HashSet<(String, Vec<u8>)>,
+) -> Result<()> {
+    if !visited.insert((parent_table.name.clone(), current_pk_key.to_vec())) {
+        return Ok(());
+    }
+
+    let incoming = incoming_foreign_keys(&parent_table.name, pager, catalog)?;
+    if incoming.is_empty() {
+        return Ok(());
+    }
+
+    let mut pending = Vec::new();
+    for (child_table_name, fk) in &incoming {
+        let old_parent = fk_parent_values_from_row(parent_table, fk, old_values)?;
+        let new_parent = fk_parent_values_from_row(parent_table, fk, new_values)?;
+        if old_parent == new_parent {
+            continue;
+        }
+
+        let self_override = if child_table_name == &parent_table.name {
+            Some((current_pk_key, new_values))
+        } else {
+            None
+        };
+
+        let Some(child_table) = catalog.get_table(pager, child_table_name)? else {
+            continue;
+        };
+        let matches =
+            find_child_references(&child_table, fk, &old_parent, self_override, None, pager)?;
+        if matches.is_empty() {
+            continue;
+        }
+
+        if fk.on_update == crate::schema::catalog::ForeignKeyAction::Restrict {
+            return Err(MuroError::Execution(format!(
+                "Cannot update parent key: referenced by {} via FOREIGN KEY ({})",
+                child_table.name,
+                fk.columns.join(", "),
+            )));
+        }
+        pending.push(PendingUpdateAction {
+            child_table_name: child_table_name.clone(),
+            fk: fk.clone(),
+            old_parent,
+            new_parent,
+        });
+    }
+
+    for action in pending {
+        let self_override = if action.child_table_name == parent_table.name {
+            Some((current_pk_key, new_values))
+        } else {
+            None
+        };
+        let Some(mut child_table) = catalog.get_table(pager, &action.child_table_name)? else {
+            continue;
+        };
+        let matches = find_child_references(
+            &child_table,
+            &action.fk,
+            &action.old_parent,
+            self_override,
+            None,
+            pager,
+        )?;
+        if matches.is_empty() {
+            continue;
+        }
+        match action.fk.on_update {
+            crate::schema::catalog::ForeignKeyAction::Cascade => {
+                cascade_update_child_references(
+                    &mut child_table,
+                    &action.fk,
+                    &matches,
+                    &action.new_parent,
+                    pager,
+                    catalog,
+                    visited,
+                )?;
+            }
+            crate::schema::catalog::ForeignKeyAction::SetNull => {
+                set_null_child_references(
+                    &mut child_table,
+                    &action.fk,
+                    &matches,
+                    pager,
+                    catalog,
+                    visited,
+                )?;
+            }
+            crate::schema::catalog::ForeignKeyAction::Restrict => {}
+        }
+    }
+
+    Ok(())
+}
+
+fn incoming_foreign_keys(
+    parent_table_name: &str,
+    pager: &mut impl PageStore,
+    catalog: &mut SystemCatalog,
+) -> Result<Vec<(String, ForeignKeyDef)>> {
+    let mut incoming = Vec::new();
+    for table_name in catalog.list_tables(pager)? {
+        let Some(child_table) = catalog.get_table(pager, &table_name)? else {
+            continue;
+        };
+        for fk in &child_table.foreign_keys {
+            if fk.ref_table == parent_table_name {
+                incoming.push((child_table.name.clone(), fk.clone()));
+            }
+        }
+    }
+    Ok(incoming)
+}
+
+fn find_child_references(
+    child_table: &TableDef,
+    fk: &ForeignKeyDef,
+    parent_values: &[Value],
+    self_override: Option<(&[u8], &[Value])>,
+    ignored_pk_set: Option<&HashSet<Vec<u8>>>,
+    pager: &mut impl PageStore,
+) -> Result<Vec<ChildMatch>> {
+    let data_btree = BTree::open(child_table.data_btree_root);
+    let mut matches = Vec::new();
+    data_btree.scan(pager, |k, row| {
+        if ignored_pk_set.is_some_and(|set| set.contains(k)) {
+            return Ok(true);
+        }
+        let row_values = if let Some((override_pk, override_values)) = self_override {
+            if k == override_pk {
+                override_values.to_vec()
+            } else {
+                deserialize_row_versioned(
+                    row,
+                    &child_table.columns,
+                    child_table.row_format_version,
+                )?
+            }
+        } else {
+            deserialize_row_versioned(row, &child_table.columns, child_table.row_format_version)?
+        };
+
+        let child_values = fk_child_values(child_table, fk, &row_values)?;
+        if child_values.iter().any(Value::is_null) {
+            return Ok(true);
+        }
+        if child_values == parent_values {
+            matches.push(ChildMatch {
+                pk_key: k.to_vec(),
+                row_values,
+            });
+        }
+        Ok(true)
+    })?;
+    Ok(matches)
+}
+
+fn cascade_delete_child_rows(
+    child_table: &mut TableDef,
+    matches: &[ChildMatch],
+    pager: &mut impl PageStore,
+    catalog: &mut SystemCatalog,
+    visited: &mut HashSet<(String, Vec<u8>)>,
+) -> Result<()> {
+    let rows_to_delete: Vec<Vec<Value>> = matches.iter().map(|m| m.row_values.clone()).collect();
+    let deleting_pk_keys: Vec<Vec<u8>> = matches.iter().map(|m| m.pk_key.clone()).collect();
+    // Apply parent-side FK behavior for rows that will be deleted by CASCADE as well.
+    enforce_parent_restrict_on_delete_inner(
+        child_table,
+        &rows_to_delete,
+        &deleting_pk_keys,
+        pager,
+        catalog,
+        visited,
+    )?;
+
+    let mut indexes = catalog.get_indexes_for_table(pager, &child_table.name)?;
+    let mut data_btree = BTree::open(child_table.data_btree_root);
+
+    for m in matches {
+        delete_from_secondary_indexes(child_table, &mut indexes, &m.row_values, &m.pk_key, pager)?;
+        data_btree.delete(pager, &m.pk_key)?;
+    }
+
+    child_table.data_btree_root = data_btree.root_page_id();
+    catalog.update_table(pager, child_table)?;
+    persist_indexes(catalog, pager, &indexes)?;
+    Ok(())
+}
+
+fn set_null_child_references(
+    child_table: &mut TableDef,
+    fk: &ForeignKeyDef,
+    matches: &[ChildMatch],
+    pager: &mut impl PageStore,
+    catalog: &mut SystemCatalog,
+    visited: &mut HashSet<(String, Vec<u8>)>,
+) -> Result<()> {
+    let fk_indices = fk_child_column_indices(child_table, fk)?;
+    for idx in &fk_indices {
+        if !child_table.columns[*idx].is_nullable {
+            return Err(MuroError::Execution(format!(
+                "Cannot SET NULL on non-nullable child column '{}.{}'",
+                child_table.name, child_table.columns[*idx].name
+            )));
+        }
+    }
+
+    update_child_rows(
+        child_table,
+        matches,
+        pager,
+        catalog,
+        None,
+        visited,
+        |new_values| {
+            for idx in &fk_indices {
+                new_values[*idx] = Value::Null;
+            }
+        },
+    )
+}
+
+fn cascade_update_child_references(
+    child_table: &mut TableDef,
+    fk: &ForeignKeyDef,
+    matches: &[ChildMatch],
+    new_parent_values: &[Value],
+    pager: &mut impl PageStore,
+    catalog: &mut SystemCatalog,
+    visited: &mut HashSet<(String, Vec<u8>)>,
+) -> Result<()> {
+    let fk_indices = fk_child_column_indices(child_table, fk)?;
+    update_child_rows(
+        child_table,
+        matches,
+        pager,
+        catalog,
+        Some(fk),
+        visited,
+        |new_values| {
+            for (i, idx) in fk_indices.iter().enumerate() {
+                new_values[*idx] = new_parent_values[i].clone();
+            }
+        },
+    )
+}
+
+fn update_child_rows<F>(
+    child_table: &mut TableDef,
+    matches: &[ChildMatch],
+    pager: &mut impl PageStore,
+    catalog: &mut SystemCatalog,
+    skip_fk_validation: Option<&ForeignKeyDef>,
+    visited: &mut HashSet<(String, Vec<u8>)>,
+    mut apply_update: F,
+) -> Result<()>
+where
+    F: FnMut(&mut Vec<Value>),
+{
+    ensure_row_format_v1(child_table, pager, catalog)?;
+
+    let mut indexes = catalog.get_indexes_for_table(pager, &child_table.name)?;
+    let mut data_btree = BTree::open(child_table.data_btree_root);
+    let mut seen_new_pk_keys: HashSet<Vec<u8>> = HashSet::new();
+
+    for m in matches {
+        let mut new_values = m.row_values.clone();
+        apply_update(&mut new_values);
+        let new_pk_key = encode_pk_key(child_table, &new_values);
+        if !seen_new_pk_keys.insert(new_pk_key.clone()) {
+            return Err(MuroError::UniqueViolation(
+                "Duplicate primary key".to_string(),
+            ));
+        }
+        if new_pk_key != m.pk_key && data_btree.search(pager, &new_pk_key)?.is_some() {
+            return Err(MuroError::UniqueViolation(
+                "Duplicate primary key".to_string(),
+            ));
+        }
+
+        check_unique_index_constraints_excluding(
+            child_table,
+            &indexes,
+            &new_values,
+            &m.pk_key,
+            pager,
+        )?;
+        enforce_child_foreign_keys_with_skip(
+            child_table,
+            &new_values,
+            skip_fk_validation,
+            pager,
+            catalog,
+        )?;
+        enforce_parent_restrict_on_update_inner(
+            child_table,
+            &m.pk_key,
+            &m.row_values,
+            &new_values,
+            pager,
+            catalog,
+            visited,
+        )?;
+
+        delete_from_secondary_indexes(child_table, &mut indexes, &m.row_values, &m.pk_key, pager)?;
+        insert_into_secondary_indexes(child_table, &mut indexes, &new_values, &new_pk_key, pager)?;
+
+        let row_data = serialize_row(&new_values, &child_table.columns);
+        if new_pk_key != m.pk_key {
+            data_btree.delete(pager, &m.pk_key)?;
+        }
+        data_btree.insert(pager, &new_pk_key, &row_data)?;
+    }
+
+    child_table.data_btree_root = data_btree.root_page_id();
+    catalog.update_table(pager, child_table)?;
+    persist_indexes(catalog, pager, &indexes)?;
+    Ok(())
+}
+
+fn enforce_child_foreign_keys_with_skip(
+    table_def: &TableDef,
+    row_values: &[Value],
+    skip_fk: Option<&ForeignKeyDef>,
+    pager: &mut impl PageStore,
+    catalog: &mut SystemCatalog,
+) -> Result<()> {
+    for fk in &table_def.foreign_keys {
+        if skip_fk.is_some_and(|s| {
+            s.columns == fk.columns
+                && s.ref_table == fk.ref_table
+                && s.ref_columns == fk.ref_columns
+        }) {
+            continue;
+        }
+        let child_values = fk_child_values(table_def, fk, row_values)?;
+        if child_values.iter().any(Value::is_null) {
+            continue;
+        }
+
+        let parent_def = catalog.get_table(pager, &fk.ref_table)?.ok_or_else(|| {
+            MuroError::Schema(format!("Referenced table '{}' not found", fk.ref_table))
+        })?;
+        let parent_btree = BTree::open(parent_def.data_btree_root);
+        let mut exists = false;
+        parent_btree.scan(pager, |_k, row| {
+            let parent_row =
+                deserialize_row_versioned(row, &parent_def.columns, parent_def.row_format_version)?;
+            if fk_parent_matches_row(&parent_def, fk, &parent_row, &child_values)? {
+                exists = true;
+                return Ok(false);
+            }
+            Ok(true)
+        })?;
+
+        if !exists {
+            return Err(MuroError::Execution(format!(
+                "FOREIGN KEY constraint fails: ({}) REFERENCES {}({})",
+                fk.columns.join(", "),
+                fk.ref_table,
+                fk.ref_columns.join(", "),
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn fk_child_column_indices(table_def: &TableDef, fk: &ForeignKeyDef) -> Result<Vec<usize>> {
+    let mut indices = Vec::with_capacity(fk.columns.len());
+    for col in &fk.columns {
+        let idx = table_def.column_index(col).ok_or_else(|| {
+            MuroError::Schema(format!("Column '{}.{}' not found", table_def.name, col))
+        })?;
+        indices.push(idx);
+    }
+    Ok(indices)
+}
+
+fn fk_child_values(
+    table_def: &TableDef,
+    fk: &ForeignKeyDef,
+    row_values: &[Value],
+) -> Result<Vec<Value>> {
+    let mut values = Vec::with_capacity(fk.columns.len());
+    for col in &fk.columns {
+        let idx = table_def.column_index(col).ok_or_else(|| {
+            MuroError::Schema(format!("Column '{}.{}' not found", table_def.name, col))
+        })?;
+        values.push(row_values[idx].clone());
+    }
+    Ok(values)
+}
+
+fn fk_parent_values_from_row(
+    table_def: &TableDef,
+    fk: &ForeignKeyDef,
+    row_values: &[Value],
+) -> Result<Vec<Value>> {
+    let mut values = Vec::with_capacity(fk.ref_columns.len());
+    for col in &fk.ref_columns {
+        let idx = table_def.column_index(col).ok_or_else(|| {
+            MuroError::Schema(format!("Column '{}.{}' not found", table_def.name, col))
+        })?;
+        values.push(row_values[idx].clone());
+    }
+    Ok(values)
+}
+
+fn fk_parent_matches_row(
+    parent_table: &TableDef,
+    fk: &ForeignKeyDef,
+    parent_row: &[Value],
+    child_values: &[Value],
+) -> Result<bool> {
+    let parent_values = fk_parent_values_from_row(parent_table, fk, parent_row)?;
+    Ok(parent_values == child_values)
+}

--- a/src/sql/executor/indexing.rs
+++ b/src/sql/executor/indexing.rs
@@ -298,60 +298,6 @@ pub(super) fn check_unique_index_constraints_excluding(
     Ok(())
 }
 
-/// For REPLACE INTO: delete rows that conflict on any unique index.
-/// MySQL's REPLACE deletes ALL conflicting rows (PK + all unique indexes).
-pub(super) fn replace_delete_unique_conflicts(
-    table_def: &TableDef,
-    indexes: &mut [IndexDef],
-    new_values: &[Value],
-    pager: &mut impl PageStore,
-    data_btree: &mut BTree,
-) -> Result<()> {
-    for idx_pos in 0..indexes.len() {
-        let idx = indexes[idx_pos].clone();
-        if idx.is_unique {
-            let col_indices: Vec<usize> = idx
-                .column_names
-                .iter()
-                .filter_map(|cn| table_def.column_index(cn))
-                .collect();
-            if col_indices.len() != idx.column_names.len() {
-                continue;
-            }
-            let is_composite = idx.column_names.len() > 1;
-            let encoded = encode_index_key_from_row(
-                new_values,
-                &col_indices,
-                &table_def.columns,
-                is_composite,
-            );
-            if let Some(idx_key) = encoded {
-                let idx_btree = BTree::open(idx.btree_root);
-                if let Some(existing_pk_key) = idx_btree.search(pager, &idx_key)? {
-                    // Found a conflicting row via this unique index — delete it
-                    if let Some(existing_data) = data_btree.search(pager, &existing_pk_key)? {
-                        let existing_values = deserialize_row_versioned(
-                            &existing_data,
-                            &table_def.columns,
-                            table_def.row_format_version,
-                        )?;
-                        delete_from_secondary_indexes(
-                            table_def,
-                            indexes,
-                            &existing_values,
-                            &existing_pk_key,
-                            pager,
-                        )?;
-                        data_btree.delete(pager, &existing_pk_key)?;
-                        *data_btree = BTree::open(data_btree.root_page_id());
-                    }
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 /// Insert values into secondary indexes.
 /// For non-unique indexes, the B-tree key is `index_key + pk_key` so that
 /// duplicate indexed values each get their own B-tree entry.

--- a/src/sql/executor/insert.rs
+++ b/src/sql/executor/insert.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::collections::HashSet;
 
 pub(super) fn exec_insert(
     ins: &Insert,
@@ -97,6 +98,8 @@ pub(super) fn exec_insert(
             }
         }
 
+        enforce_child_foreign_keys(&table_def, &values, pager, catalog)?;
+
         let pk_key = encode_pk_key(&table_def, &values);
 
         // Detect conflicts: PK first, then unique indexes
@@ -119,21 +122,44 @@ pub(super) fn exec_insert(
         if has_conflict {
             let conflict_pk = conflict_pk_key.unwrap();
             if ins.is_replace {
-                // REPLACE INTO: delete the conflicting row, then insert new one
-                let existing_data = data_btree.search(pager, &conflict_pk)?.unwrap();
-                let existing_values = deserialize_row_versioned(
-                    &existing_data,
-                    &table_def.columns,
-                    table_def.row_format_version,
-                )?;
-                delete_from_secondary_indexes(
+                // REPLACE INTO: pre-collect all conflicting rows (PK + all UNIQUE conflicts),
+                // validate FK effects for all of them, then delete.
+                let conflicts = collect_replace_conflicts(
                     &table_def,
-                    &mut indexes,
-                    &existing_values,
+                    &indexes,
+                    &values,
                     &conflict_pk,
                     pager,
+                    &data_btree,
                 )?;
-                data_btree.delete(pager, &conflict_pk)?;
+                let deleting_rows: Vec<Vec<Value>> =
+                    conflicts.iter().map(|(_, row)| row.clone()).collect();
+                let deleting_keys: Vec<Vec<u8>> =
+                    conflicts.iter().map(|(pk, _)| pk.clone()).collect();
+                validate_replace_child_foreign_keys_after_conflict_deletes(
+                    &table_def,
+                    &values,
+                    &deleting_keys,
+                    pager,
+                    catalog,
+                )?;
+                enforce_parent_restrict_on_delete(
+                    &table_def,
+                    &deleting_rows,
+                    &deleting_keys,
+                    pager,
+                    catalog,
+                )?;
+                for (pk, existing_values) in conflicts {
+                    delete_from_secondary_indexes(
+                        &table_def,
+                        &mut indexes,
+                        &existing_values,
+                        &pk,
+                        pager,
+                    )?;
+                    data_btree.delete(pager, &pk)?;
+                }
                 data_btree = BTree::open(data_btree.root_page_id());
             } else if let Some(ref assignments) = ins.on_duplicate_key_update {
                 // ON DUPLICATE KEY UPDATE: read original, apply updates, write back
@@ -166,6 +192,15 @@ pub(super) fn exec_insert(
                     &updated_values,
                     &conflict_pk,
                     pager,
+                )?;
+                enforce_child_foreign_keys(&table_def, &updated_values, pager, catalog)?;
+                enforce_parent_restrict_on_update(
+                    &table_def,
+                    &conflict_pk,
+                    &original_values,
+                    &updated_values,
+                    pager,
+                    catalog,
                 )?;
 
                 // Delete old secondary index entries using original values
@@ -211,17 +246,7 @@ pub(super) fn exec_insert(
             }
         }
 
-        // For REPLACE: also delete rows conflicting on other unique indexes
-        // (handles case where PK is new but unique index conflicts with a different row)
-        if ins.is_replace {
-            replace_delete_unique_conflicts(
-                &table_def,
-                &mut indexes,
-                &values,
-                pager,
-                &mut data_btree,
-            )?;
-        } else {
+        if !ins.is_replace {
             check_unique_index_constraints(&table_def, &indexes, &values, pager)?;
         }
 
@@ -241,6 +266,114 @@ pub(super) fn exec_insert(
     }
 
     Ok(ExecResult::RowsAffected(rows_inserted))
+}
+
+fn collect_replace_conflicts(
+    table_def: &TableDef,
+    indexes: &[IndexDef],
+    new_values: &[Value],
+    conflict_pk: &[u8],
+    pager: &mut impl PageStore,
+    data_btree: &BTree,
+) -> Result<Vec<(Vec<u8>, Vec<Value>)>> {
+    let mut conflict_keys: HashSet<Vec<u8>> = HashSet::new();
+    conflict_keys.insert(conflict_pk.to_vec());
+    for idx in indexes {
+        if !idx.is_unique {
+            continue;
+        }
+        let col_indices: Vec<usize> = idx
+            .column_names
+            .iter()
+            .filter_map(|cn| table_def.column_index(cn))
+            .collect();
+        if col_indices.len() != idx.column_names.len() {
+            continue;
+        }
+        let is_composite = idx.column_names.len() > 1;
+        let encoded =
+            encode_index_key_from_row(new_values, &col_indices, &table_def.columns, is_composite);
+        if let Some(idx_key) = encoded {
+            let idx_btree = BTree::open(idx.btree_root);
+            if let Some(existing_pk_key) = idx_btree.search(pager, &idx_key)? {
+                conflict_keys.insert(existing_pk_key);
+            }
+        }
+    }
+    let mut conflicts = Vec::new();
+    for pk in conflict_keys {
+        if let Some(existing_data) = data_btree.search(pager, &pk)? {
+            let existing_values = deserialize_row_versioned(
+                &existing_data,
+                &table_def.columns,
+                table_def.row_format_version,
+            )?;
+            conflicts.push((pk, existing_values));
+        }
+    }
+    Ok(conflicts)
+}
+
+fn validate_replace_child_foreign_keys_after_conflict_deletes(
+    table_def: &TableDef,
+    row_values: &[Value],
+    deleting_pk_keys: &[Vec<u8>],
+    pager: &mut impl PageStore,
+    _catalog: &mut SystemCatalog,
+) -> Result<()> {
+    if deleting_pk_keys.is_empty() {
+        return Ok(());
+    }
+
+    let deleting_pk_set: HashSet<Vec<u8>> = deleting_pk_keys.iter().cloned().collect();
+    for fk in &table_def.foreign_keys {
+        if fk.ref_table != table_def.name {
+            continue;
+        }
+
+        let mut child_values = Vec::with_capacity(fk.columns.len());
+        for col in &fk.columns {
+            let idx = table_def.column_index(col).ok_or_else(|| {
+                MuroError::Schema(format!("Column '{}.{}' not found", table_def.name, col))
+            })?;
+            child_values.push(row_values[idx].clone());
+        }
+        if child_values.iter().any(Value::is_null) {
+            continue;
+        }
+
+        let data_btree = BTree::open(table_def.data_btree_root);
+        let mut exists = false;
+        data_btree.scan(pager, |_pk, row| {
+            let parent_row =
+                deserialize_row_versioned(row, &table_def.columns, table_def.row_format_version)?;
+            let parent_pk = encode_pk_key(table_def, &parent_row);
+            if deleting_pk_set.contains(&parent_pk) {
+                return Ok(true);
+            }
+
+            for (i, ref_col) in fk.ref_columns.iter().enumerate() {
+                let idx = table_def.column_index(ref_col).ok_or_else(|| {
+                    MuroError::Schema(format!("Column '{}.{}' not found", table_def.name, ref_col))
+                })?;
+                if parent_row[idx] != child_values[i] {
+                    return Ok(true);
+                }
+            }
+            exists = true;
+            Ok(false)
+        })?;
+
+        if !exists {
+            return Err(MuroError::Execution(format!(
+                "FOREIGN KEY constraint fails: ({}) REFERENCES {}({})",
+                fk.columns.join(", "),
+                fk.ref_table,
+                fk.ref_columns.join(", "),
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// Convert a Value to a literal Expr.

--- a/src/sql/executor/mutation.rs
+++ b/src/sql/executor/mutation.rs
@@ -186,6 +186,15 @@ pub(super) fn exec_update(
 
         // Check unique constraints on new values
         check_unique_index_constraints(&table_def, &indexes, &new_values, pager)?;
+        enforce_child_foreign_keys(&table_def, &new_values, pager, catalog)?;
+        enforce_parent_restrict_on_update(
+            &table_def,
+            &pk_key,
+            &old_values,
+            &new_values,
+            pager,
+            catalog,
+        )?;
 
         // Update secondary indexes: remove old entries, insert new entries
         delete_from_secondary_indexes(&table_def, &mut indexes, &old_values, &pk_key, pager)?;
@@ -350,6 +359,17 @@ pub(super) fn exec_delete(
 
     let mut data_btree = BTree::open(table_def.data_btree_root);
     let mut count = 0u64;
+
+    let deleting_rows: Vec<Vec<Value>> =
+        to_delete.iter().map(|(_, values)| values.clone()).collect();
+    let deleting_pk_keys: Vec<Vec<u8>> = to_delete.iter().map(|(pk, _)| pk.clone()).collect();
+    enforce_parent_restrict_on_delete(
+        &table_def,
+        &deleting_rows,
+        &deleting_pk_keys,
+        pager,
+        catalog,
+    )?;
 
     for (pk_key, values) in &to_delete {
         delete_from_secondary_indexes(&table_def, &mut indexes, values, pk_key, pager)?;

--- a/src/sql/executor/row_format.rs
+++ b/src/sql/executor/row_format.rs
@@ -6,6 +6,24 @@ pub(super) fn exec_rename_table(
     catalog: &mut SystemCatalog,
 ) -> Result<ExecResult> {
     catalog.rename_table(pager, &rt.old_name, &rt.new_name)?;
+
+    // Rewrite all FOREIGN KEY references that point to the old table name.
+    for table_name in catalog.list_tables(pager)? {
+        let Some(mut table_def) = catalog.get_table(pager, &table_name)? else {
+            continue;
+        };
+        let mut changed = false;
+        for fk in &mut table_def.foreign_keys {
+            if fk.ref_table == rt.old_name {
+                fk.ref_table = rt.new_name.clone();
+                changed = true;
+            }
+        }
+        if changed {
+            catalog.update_table(pager, &table_def)?;
+        }
+    }
+
     Ok(ExecResult::Ok)
 }
 

--- a/src/sql/executor/select_query.rs
+++ b/src/sql/executor/select_query.rs
@@ -66,6 +66,7 @@ pub(super) fn exec_select_without_table_inner(sel: &Select) -> Result<ExecResult
             next_rowid: 0,
             row_format_version: 0,
             stats_row_count: 0,
+            foreign_keys: Vec::new(),
         };
         let raw_rows = if where_passed {
             vec![vec![]]

--- a/src/sql/executor/show.rs
+++ b/src/sql/executor/show.rs
@@ -44,6 +44,16 @@ pub(super) fn exec_show_create_table(
             table_constraints.push(format!("  UNIQUE ({})", idx.column_names.join(", ")));
         }
     }
+    for fk in &table_def.foreign_keys {
+        table_constraints.push(format!(
+            "  FOREIGN KEY ({}) REFERENCES {}({}) ON DELETE {} ON UPDATE {}",
+            fk.columns.join(", "),
+            fk.ref_table,
+            fk.ref_columns.join(", "),
+            fk_action_to_sql(&fk.on_delete),
+            fk_action_to_sql(&fk.on_update),
+        ));
+    }
 
     let total_items = visible_columns.len() + table_constraints.len();
     for (i, col) in visible_columns.iter().enumerate() {
@@ -143,7 +153,47 @@ pub(super) fn exec_describe(
             ],
         });
     }
+    for fk in &table_def.foreign_keys {
+        rows.push(Row {
+            values: vec![
+                (
+                    "Field".to_string(),
+                    Value::Varchar("CONSTRAINT".to_string()),
+                ),
+                (
+                    "Type".to_string(),
+                    Value::Varchar(format!(
+                        "FOREIGN KEY ({}) REFERENCES {}({}) ON DELETE {} ON UPDATE {}",
+                        fk.columns.join(", "),
+                        fk.ref_table,
+                        fk.ref_columns.join(", "),
+                        fk_action_to_sql(&fk.on_delete),
+                        fk_action_to_sql(&fk.on_update),
+                    )),
+                ),
+                ("Null".to_string(), Value::Varchar(String::new())),
+                ("Key".to_string(), Value::Varchar("FK".to_string())),
+                ("Default".to_string(), Value::Varchar(String::new())),
+                (
+                    "Extra".to_string(),
+                    Value::Varchar(format!(
+                        "ON DELETE {} ON UPDATE {}",
+                        fk_action_to_sql(&fk.on_delete),
+                        fk_action_to_sql(&fk.on_update),
+                    )),
+                ),
+            ],
+        });
+    }
     Ok(ExecResult::Rows(rows))
+}
+
+fn fk_action_to_sql(action: &crate::schema::catalog::ForeignKeyAction) -> &'static str {
+    match action {
+        crate::schema::catalog::ForeignKeyAction::Restrict => "RESTRICT",
+        crate::schema::catalog::ForeignKeyAction::Cascade => "CASCADE",
+        crate::schema::catalog::ForeignKeyAction::SetNull => "SET NULL",
+    }
 }
 
 // --- Row serialization ---

--- a/src/sql/lexer.rs
+++ b/src/sql/lexer.rs
@@ -92,6 +92,8 @@ pub enum Token {
     All,
     Duplicate,
     Key,
+    Foreign,
+    References,
     Replace,
     Explain,
     Analyze,
@@ -101,6 +103,8 @@ pub enum Token {
     Force,
     Use,
     Ignore,
+    Cascade,
+    Restrict,
     PrimaryKey,    // "PRIMARY KEY" as a combined token
     TinyIntType,   // "TINYINT"
     SmallIntType,  // "SMALLINT"
@@ -440,6 +444,8 @@ fn lex_keyword_or_ident(input: &str) -> IResult<&str, Token> {
         "ALL" => Token::All,
         "DUPLICATE" => Token::Duplicate,
         "KEY" => Token::Key,
+        "FOREIGN" => Token::Foreign,
+        "REFERENCES" => Token::References,
         "REPLACE" => Token::Replace,
         "EXPLAIN" => Token::Explain,
         "ANALYZE" => Token::Analyze,
@@ -449,6 +455,8 @@ fn lex_keyword_or_ident(input: &str) -> IResult<&str, Token> {
         "FORCE" => Token::Force,
         "USE" => Token::Use,
         "IGNORE" => Token::Ignore,
+        "CASCADE" => Token::Cascade,
+        "RESTRICT" => Token::Restrict,
         "PRIMARY" => {
             // Check if next tokens form "PRIMARY KEY"
             let rest = remaining.trim_start();
@@ -592,5 +600,16 @@ mod tests {
     fn test_tokenize_bind_parameter() {
         let tokens = tokenize("SELECT * FROM t WHERE id = ?").unwrap();
         assert!(tokens.contains(&Token::Question));
+    }
+
+    #[test]
+    fn test_tokenize_foreign_key() {
+        let tokens = tokenize(
+            "CREATE TABLE child (parent_id BIGINT, FOREIGN KEY (parent_id) REFERENCES parent(id))",
+        )
+        .unwrap();
+        assert!(tokens.contains(&Token::Foreign));
+        assert!(tokens.contains(&Token::Key));
+        assert!(tokens.contains(&Token::References));
     }
 }

--- a/src/sql/parser/mod.rs
+++ b/src/sql/parser/mod.rs
@@ -231,18 +231,36 @@ impl Parser {
         let operation = match self.peek() {
             Some(Token::Add) => {
                 self.advance(); // ADD
-                                // Optional COLUMN keyword
-                if self.peek() == Some(&Token::Column) {
-                    self.advance();
+                if self.peek() == Some(&Token::Foreign) {
+                    let fk = self.parse_foreign_key_spec()?;
+                    AlterTableOp::AddForeignKey(fk)
+                } else {
+                    // Optional COLUMN keyword
+                    if self.peek() == Some(&Token::Column) {
+                        self.advance();
+                    }
+                    let col_spec = self.parse_column_spec()?;
+                    AlterTableOp::AddColumn(col_spec)
                 }
-                let col_spec = self.parse_column_spec()?;
-                AlterTableOp::AddColumn(col_spec)
             }
             Some(Token::Drop) => {
                 self.advance(); // DROP
-                self.expect(&Token::Column)?;
-                let col_name = self.expect_ident()?;
-                AlterTableOp::DropColumn(col_name)
+                match self.peek() {
+                    Some(Token::Column) => {
+                        self.advance();
+                        let col_name = self.expect_ident()?;
+                        AlterTableOp::DropColumn(col_name)
+                    }
+                    Some(Token::Foreign) => {
+                        self.advance(); // FOREIGN
+                        self.expect(&Token::Key)?;
+                        self.expect(&Token::LParen)?;
+                        let cols = self.parse_ident_list()?;
+                        self.expect(&Token::RParen)?;
+                        AlterTableOp::DropForeignKey(cols)
+                    }
+                    _ => return Err("Expected COLUMN or FOREIGN KEY after DROP".into()),
+                }
             }
             Some(Token::Modify) => {
                 self.advance(); // MODIFY
@@ -334,6 +352,28 @@ impl Parser {
                         continue;
                     }
                 }
+                Some(Token::Foreign) => {
+                    let fk = self.parse_foreign_key_spec()?;
+                    constraints.push(TableConstraint::ForeignKey {
+                        columns: fk.columns,
+                        ref_table: fk.ref_table,
+                        ref_columns: fk.ref_columns,
+                        on_delete: fk.on_delete,
+                        on_update: fk.on_update,
+                    });
+
+                    match self.peek() {
+                        Some(Token::Comma) => {
+                            self.advance();
+                        }
+                        Some(Token::RParen) => {
+                            self.advance();
+                            break;
+                        }
+                        _ => return Err("Expected ',' or ')' after table constraint".into()),
+                    }
+                    continue;
+                }
                 _ => {}
             }
 
@@ -368,6 +408,66 @@ impl Parser {
             names.push(self.expect_ident()?);
         }
         Ok(names)
+    }
+
+    fn parse_foreign_key_spec(&mut self) -> Result<ForeignKeySpec, String> {
+        self.expect(&Token::Foreign)?;
+        self.expect(&Token::Key)?;
+        self.expect(&Token::LParen)?;
+        let columns = self.parse_ident_list()?;
+        self.expect(&Token::RParen)?;
+        self.expect(&Token::References)?;
+        let ref_table = self.expect_ident()?;
+        self.expect(&Token::LParen)?;
+        let ref_columns = self.parse_ident_list()?;
+        self.expect(&Token::RParen)?;
+
+        let mut on_delete = ForeignKeyAction::Restrict;
+        let mut on_update = ForeignKeyAction::Restrict;
+        loop {
+            if self.peek() != Some(&Token::On) {
+                break;
+            }
+            self.advance(); // ON
+            match self.peek() {
+                Some(Token::Delete) => {
+                    self.advance();
+                    on_delete = self.parse_foreign_key_action()?;
+                }
+                Some(Token::Update) => {
+                    self.advance();
+                    on_update = self.parse_foreign_key_action()?;
+                }
+                _ => return Err("Expected DELETE or UPDATE after ON".into()),
+            }
+        }
+
+        Ok(ForeignKeySpec {
+            columns,
+            ref_table,
+            ref_columns,
+            on_delete,
+            on_update,
+        })
+    }
+
+    fn parse_foreign_key_action(&mut self) -> Result<ForeignKeyAction, String> {
+        match self.peek() {
+            Some(Token::Cascade) => {
+                self.advance();
+                Ok(ForeignKeyAction::Cascade)
+            }
+            Some(Token::Set) => {
+                self.advance();
+                self.expect(&Token::Null)?;
+                Ok(ForeignKeyAction::SetNull)
+            }
+            Some(Token::Restrict) => {
+                self.advance();
+                Ok(ForeignKeyAction::Restrict)
+            }
+            _ => Err("Expected CASCADE, SET NULL, or RESTRICT".into()),
+        }
     }
 
     fn parse_column_spec(&mut self) -> Result<ColumnSpec, String> {

--- a/src/sql/parser/tests.rs
+++ b/src/sql/parser/tests.rs
@@ -29,6 +29,58 @@ fn test_parse_create_table_if_not_exists() {
 }
 
 #[test]
+fn test_parse_create_table_with_foreign_key() {
+    let stmt = parse_sql(
+        "CREATE TABLE child (id BIGINT PRIMARY KEY, parent_id BIGINT, FOREIGN KEY (parent_id) REFERENCES parent(id))",
+    )
+    .unwrap();
+    if let Statement::CreateTable(ct) = stmt {
+        assert_eq!(ct.constraints.len(), 1);
+        match &ct.constraints[0] {
+            TableConstraint::ForeignKey {
+                columns,
+                ref_table,
+                ref_columns,
+                on_delete,
+                on_update,
+            } => {
+                assert_eq!(columns, &vec!["parent_id".to_string()]);
+                assert_eq!(ref_table, "parent");
+                assert_eq!(ref_columns, &vec!["id".to_string()]);
+                assert_eq!(*on_delete, ForeignKeyAction::Restrict);
+                assert_eq!(*on_update, ForeignKeyAction::Restrict);
+            }
+            _ => panic!("Expected ForeignKey constraint"),
+        }
+    } else {
+        panic!("Expected CreateTable");
+    }
+}
+
+#[test]
+fn test_parse_create_table_with_foreign_key_actions() {
+    let stmt = parse_sql(
+        "CREATE TABLE child (id BIGINT PRIMARY KEY, parent_id BIGINT, FOREIGN KEY (parent_id) REFERENCES parent(id) ON DELETE CASCADE ON UPDATE SET NULL)",
+    )
+    .unwrap();
+    if let Statement::CreateTable(ct) = stmt {
+        match &ct.constraints[0] {
+            TableConstraint::ForeignKey {
+                on_delete,
+                on_update,
+                ..
+            } => {
+                assert_eq!(*on_delete, ForeignKeyAction::Cascade);
+                assert_eq!(*on_update, ForeignKeyAction::SetNull);
+            }
+            _ => panic!("Expected ForeignKey constraint"),
+        }
+    } else {
+        panic!("Expected CreateTable");
+    }
+}
+
+#[test]
 fn test_parse_insert() {
     let stmt = parse_sql("INSERT INTO t (id, name) VALUES (1, 'hello')").unwrap();
     if let Statement::Insert(ins) = stmt {
@@ -254,6 +306,41 @@ fn test_parse_bind_parameter() {
         assert!(matches!(right.as_ref(), Expr::BindParam));
     } else {
         panic!("Expected Select");
+    }
+}
+
+#[test]
+fn test_parse_alter_table_add_foreign_key() {
+    let stmt = parse_sql(
+        "ALTER TABLE child ADD FOREIGN KEY (parent_id) REFERENCES parent(id) ON DELETE CASCADE ON UPDATE SET NULL",
+    )
+    .unwrap();
+    let Statement::AlterTable(at) = stmt else {
+        panic!("Expected AlterTable");
+    };
+    match at.operation {
+        AlterTableOp::AddForeignKey(fk) => {
+            assert_eq!(fk.columns, vec!["parent_id".to_string()]);
+            assert_eq!(fk.ref_table, "parent");
+            assert_eq!(fk.ref_columns, vec!["id".to_string()]);
+            assert_eq!(fk.on_delete, ForeignKeyAction::Cascade);
+            assert_eq!(fk.on_update, ForeignKeyAction::SetNull);
+        }
+        _ => panic!("Expected AddForeignKey"),
+    }
+}
+
+#[test]
+fn test_parse_alter_table_drop_foreign_key() {
+    let stmt = parse_sql("ALTER TABLE child DROP FOREIGN KEY (parent_id)").unwrap();
+    let Statement::AlterTable(at) = stmt else {
+        panic!("Expected AlterTable");
+    };
+    match at.operation {
+        AlterTableOp::DropForeignKey(cols) => {
+            assert_eq!(cols, vec!["parent_id".to_string()]);
+        }
+        _ => panic!("Expected DropForeignKey"),
     }
 }
 

--- a/src/sql/prepared.rs
+++ b/src/sql/prepared.rs
@@ -129,7 +129,9 @@ fn count_statement_bind_params(stmt: &Statement) -> usize {
                         .map(count_expr_bind_params)
                         .unwrap_or(0)
             }
-            AlterTableOp::DropColumn(_) => 0,
+            AlterTableOp::DropColumn(_)
+            | AlterTableOp::AddForeignKey(_)
+            | AlterTableOp::DropForeignKey(_) => 0,
         },
         Statement::CreateIndex(_)
         | Statement::CreateFulltextIndex(_)
@@ -302,7 +304,9 @@ fn bind_statement_in_place(stmt: &mut Statement, params: &[Value], next: &mut us
             | AlterTableOp::ChangeColumn(_, spec) => {
                 bind_column_spec_in_place(spec, params, next)?;
             }
-            AlterTableOp::DropColumn(_) => {}
+            AlterTableOp::DropColumn(_)
+            | AlterTableOp::AddForeignKey(_)
+            | AlterTableOp::DropForeignKey(_) => {}
         },
         Statement::CreateIndex(_)
         | Statement::CreateFulltextIndex(_)


### PR DESCRIPTION
## Summary
- add SQL parser/catalog support for `FOREIGN KEY` constraints (including `ON DELETE` / `ON UPDATE` actions)
- add executor-level FK enforcement for insert/update/delete with `RESTRICT`, `CASCADE`, and `SET NULL`
- add ALTER/DDL/SHOW/DESCRIBE integration and dependency checks for FK-aware schema changes
- refactor FK logic into `src/sql/executor/foreign_key.rs`
- add broad regression coverage for cascade ordering, cycle guards, REPLACE/ON DUP side effects, and ALTER edge cases

## Validation
- `cargo test -q`

Closes #189
