### PR TITLE
ci: add cargo-audit vulnerability scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,5 @@ jobs:
       - run: cargo test --features test-utils
       - run: cargo clippy -- -D warnings
       - run: cargo fmt -- --check
+      - run: cargo install cargo-audit --locked
+      - run: cargo audit


### PR DESCRIPTION
## Summary
- add `cargo-audit` installation step to CI
- run `cargo audit` in the main CI check job
- close #217

## Verification
- cargo audit
