### PR TITLE
Add explicit query cancellation API and Ctrl-C cancellation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "borsh"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +365,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
+dependencies = [
+ "dispatch2",
+ "nix 0.30.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +384,18 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -654,6 +686,7 @@ dependencies = [
  "argon2",
  "base64",
  "clap",
+ "ctrlc",
  "fs4",
  "hmac",
  "jsonpath_lib",
@@ -696,6 +729,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,6 +758,21 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -1044,7 +1104,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix",
+ "nix 0.29.0",
  "radix_trie",
  "unicode-segmentation",
  "unicode-width",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ thiserror = "2"
 clap = { version = "4", features = ["derive"] }
 rpassword = "5"
 rustyline = "15"
+ctrlc = "3"
 
 [features]
 test-utils = []

--- a/docs-site/src/getting-started/first-session.md
+++ b/docs-site/src/getting-started/first-session.md
@@ -58,6 +58,10 @@ murodb demo.db
 
 Start without `-e` to enter REPL mode.
 
+Tip:
+- Press `Ctrl-C` while typing to clear the current buffer.
+- Press `Ctrl-C` during statement execution to cancel the running statement and keep the REPL open.
+
 ## Next
 
 - [Quick Start](quick-start.md) for concise command examples.

--- a/docs-site/src/user-guide/cli.md
+++ b/docs-site/src/user-guide/cli.md
@@ -52,6 +52,13 @@ The CLI parses each statement and routes execution automatically:
 - Write and transaction-control statements (`INSERT`, `UPDATE`, `DELETE`, DDL, `BEGIN`/`COMMIT`/`ROLLBACK`) use the write path.
 - While an explicit transaction is active (`BEGIN` ... `COMMIT`/`ROLLBACK`), all statements (including `SELECT`) run with execute semantics.
 
+## Ctrl-C behavior
+
+- In REPL input mode (while typing a statement), `Ctrl-C` clears the current input buffer.
+- While a statement is executing, `Ctrl-C` requests cancellation of the in-flight statement.
+- If cancellation succeeds, the statement returns an error and the REPL stays alive.
+- In one-shot mode (`-e`), `Ctrl-C` also requests cancellation; the command then exits after printing the statement error.
+
 ## JSON output
 
 When using `--format json`, results are emitted as a single JSON object per statement.

--- a/docs-site/src/user-guide/sql-reference.md
+++ b/docs-site/src/user-guide/sql-reference.md
@@ -1027,6 +1027,10 @@ Rust API note:
 - `Database::query()` takes `&mut self` because read execution may refresh pager/catalog state from disk before running.
 - For concurrent reads in one process, use multiple read-only handles (for example `Database::open_reader()`).
 - Inside an explicit transaction (`BEGIN` ... `COMMIT`/`ROLLBACK`), run statements through `Database::execute()`, including `SELECT`.
+- `Database::cancel_handle()` / `DatabaseReader::cancel_handle()` returns a `QueryCancelHandle`.
+- `QueryCancelHandle::cancel()` returns `true` when a statement is currently in flight, otherwise `false`.
+- Cancellation errors are reported as `MuroError::Cancelled`.
+- Cancellation safety for explicit transactions: cancellation checks in write paths are performed before row-application phases, so a cancelled statement does not commit partial row changes.
 
 ## Hidden _rowid
 

--- a/src/bin/murodb.rs
+++ b/src/bin/murodb.rs
@@ -1,10 +1,12 @@
 use std::path::PathBuf;
 use std::process;
+use std::sync::{Arc, Mutex};
 
 use base64::Engine;
 use clap::{Parser, ValueEnum};
 use murodb::{
-    Database, DatabaseEncryption, ExecResult, MuroError, RecoveryMode, SqlStatementClass, Value,
+    Database, DatabaseEncryption, ExecResult, MuroError, QueryCancelHandle, RecoveryMode,
+    SqlStatementClass, Value,
 };
 
 #[derive(Clone, Debug, ValueEnum)]
@@ -287,7 +289,47 @@ fn base64_encode(bytes: &[u8]) -> String {
     base64::engine::general_purpose::STANDARD.encode(bytes)
 }
 
-fn execute_sql(db: &mut Database, sql: &str, format: &OutputFormatArg, in_explicit_tx: &mut bool) {
+#[derive(Clone, Default)]
+struct InterruptController {
+    active_handle: Arc<Mutex<Option<QueryCancelHandle>>>,
+}
+
+impl InterruptController {
+    fn install_sigint_handler(&self) {
+        let active_handle = Arc::clone(&self.active_handle);
+        if let Err(e) = ctrlc::set_handler(move || {
+            let handle = match active_handle.lock() {
+                Ok(guard) => guard.as_ref().cloned(),
+                Err(_) => None,
+            };
+            if let Some(handle) = handle {
+                let _ = handle.cancel();
+            }
+        }) {
+            eprintln!("WARNING: failed to install Ctrl-C handler: {}", e);
+        }
+    }
+
+    fn begin_statement(&self, handle: QueryCancelHandle) {
+        if let Ok(mut slot) = self.active_handle.lock() {
+            *slot = Some(handle);
+        }
+    }
+
+    fn end_statement(&self) {
+        if let Ok(mut slot) = self.active_handle.lock() {
+            *slot = None;
+        }
+    }
+}
+
+fn execute_sql(
+    db: &mut Database,
+    sql: &str,
+    format: &OutputFormatArg,
+    in_explicit_tx: &mut bool,
+    interrupts: &InterruptController,
+) {
     let class = match Database::classify_sql(sql) {
         Ok(class) => class,
         Err(MuroError::Parse(e)) => {
@@ -308,6 +350,7 @@ fn execute_sql(db: &mut Database, sql: &str, format: &OutputFormatArg, in_explic
         }
     };
 
+    interrupts.begin_statement(db.cancel_handle());
     let result = match class {
         SqlStatementClass::ReadOnly if !*in_explicit_tx => db.query(sql).map(ExecResult::Rows),
         SqlStatementClass::Begin
@@ -316,6 +359,8 @@ fn execute_sql(db: &mut Database, sql: &str, format: &OutputFormatArg, in_explic
         | SqlStatementClass::ReadOnly
         | SqlStatementClass::Write => db.execute(sql),
     };
+    interrupts.end_statement();
+
     match result {
         Ok(result) => match format {
             OutputFormatArg::Text => {
@@ -348,7 +393,7 @@ fn execute_sql(db: &mut Database, sql: &str, format: &OutputFormatArg, in_explic
     }
 }
 
-fn run_repl(db: &mut Database, format: &OutputFormatArg) {
+fn run_repl(db: &mut Database, format: &OutputFormatArg, interrupts: &InterruptController) {
     let mut rl = rustyline::DefaultEditor::new().unwrap_or_else(|e| {
         eprintln!("ERROR: Failed to initialize REPL: {}", e);
         process::exit(1);
@@ -381,7 +426,7 @@ fn run_repl(db: &mut Database, format: &OutputFormatArg) {
                 if buffer.trim_end().ends_with(';') {
                     let sql = buffer.trim().to_string();
                     let _ = rl.add_history_entry(&sql);
-                    execute_sql(db, &sql, format, &mut in_explicit_tx);
+                    execute_sql(db, &sql, format, &mut in_explicit_tx, interrupts);
                     buffer.clear();
                 }
             }
@@ -501,15 +546,18 @@ fn main() {
         db
     };
 
+    let interrupts = InterruptController::default();
+    interrupts.install_sigint_handler();
+
     if let Some(sql) = &cli.execute {
         let mut in_explicit_tx = false;
-        execute_sql(&mut db, sql, &cli.format, &mut in_explicit_tx);
+        execute_sql(&mut db, sql, &cli.format, &mut in_explicit_tx, &interrupts);
         if let Err(e) = db.flush() {
             eprintln!("ERROR: Failed to flush database: {}", e);
             process::exit(1);
         }
     } else {
-        run_repl(&mut db, &cli.format);
+        run_repl(&mut db, &cli.format, &interrupts);
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,6 +35,9 @@ pub enum MuroError {
     #[error("SQL execution error: {0}")]
     Execution(String),
 
+    #[error("Query cancelled")]
+    Cancelled,
+
     #[error("Unique constraint violation: {0}")]
     UniqueViolation(String),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ pub use crate::error::{MuroError, Result};
 pub use crate::fts::snippet::fts_snippet;
 pub use crate::sql::executor::{ExecResult, Row};
 pub use crate::sql::prepared::PreparedStatement;
-pub use crate::sql::session::Session;
+pub use crate::sql::session::{QueryCancelHandle, Session};
 pub use crate::storage::pager::DbEncryptionInfo;
 pub use crate::types::{format_date, format_datetime, format_uuid, parse_uuid_string, Value};
 pub use crate::wal::recovery::{RecoveryMode, RecoveryResult, RecoverySkipCode, RecoverySkippedTx};
@@ -801,6 +801,11 @@ impl Database {
         self.session.execute(sql)
     }
 
+    /// Get a handle that can request cancellation of in-flight statements.
+    pub fn cancel_handle(&self) -> QueryCancelHandle {
+        self.session.cancel_handle()
+    }
+
     /// Get current session runtime configuration.
     pub fn runtime_config(&self) -> Result<RuntimeConfig> {
         let _guard = self.lock_manager.read_lock()?;
@@ -980,6 +985,11 @@ impl Database {
 }
 
 impl DatabaseReader {
+    /// Get a handle that can request cancellation of in-flight statements.
+    pub fn cancel_handle(&self) -> QueryCancelHandle {
+        self.session.cancel_handle()
+    }
+
     /// Parse SQL into a reusable prepared statement template.
     pub fn prepare(&self, sql: &str) -> Result<PreparedStatement> {
         self.session.prepare(sql)

--- a/src/sql/executor.rs
+++ b/src/sql/executor.rs
@@ -93,6 +93,11 @@ pub enum ExecResult {
     RowsAffected(u64),
     Ok,
 }
+
+pub(super) fn cancellation_point() -> Result<()> {
+    crate::sql::session::cancellation_point_current()
+}
+
 pub fn execute(
     sql: &str,
     pager: &mut impl PageStore,

--- a/src/sql/executor/aggregation.rs
+++ b/src/sql/executor/aggregation.rs
@@ -411,9 +411,11 @@ pub(super) fn execute_aggregation(
     let mut group_index: HashMap<Vec<ValueKey>, usize> = HashMap::new();
 
     for raw_row in &raw_rows {
+        cancellation_point()?;
         let group_key = if let Some(group_exprs) = &sel.group_by {
             let mut key = Vec::with_capacity(group_exprs.len());
             for gexpr in group_exprs {
+                cancellation_point()?;
                 let val = eval_expr(gexpr, &|name| {
                     table_def
                         .column_index(name)
@@ -444,6 +446,7 @@ pub(super) fn execute_aggregation(
     let mut result_rows = Vec::new();
 
     for (_group_key, group_rows) in &groups {
+        cancellation_point()?;
         // Create accumulators for each aggregate
         let mut accumulators: Vec<Accumulator> = aggs
             .iter()
@@ -452,6 +455,7 @@ pub(super) fn execute_aggregation(
 
         // Feed rows into accumulators
         for raw_row in group_rows {
+            cancellation_point()?;
             for (i, agg_info) in aggs.iter().enumerate() {
                 if let Some(arg_expr) = &agg_info.arg {
                     let val = eval_expr(arg_expr, &|name| {
@@ -494,6 +498,7 @@ pub(super) fn execute_aggregation(
         let mut row_values = Vec::new();
 
         for sel_col in &sel.columns {
+            cancellation_point()?;
             match sel_col {
                 SelectColumn::Star => {
                     if let Some(raw) = rep_row {
@@ -564,9 +569,11 @@ pub(super) fn execute_aggregation_join(
     let mut group_index: HashMap<Vec<ValueKey>, usize> = HashMap::new();
 
     for jrow in joined_rows {
+        cancellation_point()?;
         let group_key = if let Some(group_exprs) = &sel.group_by {
             let mut key = Vec::with_capacity(group_exprs.len());
             for gexpr in group_exprs {
+                cancellation_point()?;
                 let val = eval_join_expr(gexpr, jrow)?;
                 key.push(ValueKey(val));
             }
@@ -591,12 +598,14 @@ pub(super) fn execute_aggregation_join(
     let mut result_rows = Vec::new();
 
     for (_group_key, group_rows) in &groups {
+        cancellation_point()?;
         let mut accumulators: Vec<Accumulator> = aggs
             .iter()
             .map(|a| Accumulator::new(&a.name, a.distinct))
             .collect();
 
         for jrow in group_rows {
+            cancellation_point()?;
             for (i, agg_info) in aggs.iter().enumerate() {
                 if let Some(arg_expr) = &agg_info.arg {
                     let val = eval_join_expr(arg_expr, jrow)?;
@@ -622,6 +631,7 @@ pub(super) fn execute_aggregation_join(
         let mut row_values = Vec::new();
 
         for sel_col in &sel.columns {
+            cancellation_point()?;
             match sel_col {
                 SelectColumn::Star => {
                     for (qualified_name, val) in rep_row {

--- a/src/sql/executor/insert.rs
+++ b/src/sql/executor/insert.rs
@@ -19,7 +19,6 @@ pub(super) fn exec_insert(
     let mut rows_inserted = 0u64;
 
     for value_row in &ins.values {
-        cancellation_point()?;
         let mut values = resolve_insert_values(&table_def, &ins.columns, value_row)?;
 
         // Apply DEFAULT values for NULL columns that have defaults
@@ -303,7 +302,6 @@ fn collect_replace_conflicts(
     }
     let mut conflicts = Vec::new();
     for pk in conflict_keys {
-        cancellation_point()?;
         if let Some(existing_data) = data_btree.search(pager, &pk)? {
             let existing_values = deserialize_row_versioned(
                 &existing_data,

--- a/src/sql/executor/insert.rs
+++ b/src/sql/executor/insert.rs
@@ -19,6 +19,7 @@ pub(super) fn exec_insert(
     let mut rows_inserted = 0u64;
 
     for value_row in &ins.values {
+        cancellation_point()?;
         let mut values = resolve_insert_values(&table_def, &ins.columns, value_row)?;
 
         // Apply DEFAULT values for NULL columns that have defaults
@@ -302,6 +303,7 @@ fn collect_replace_conflicts(
     }
     let mut conflicts = Vec::new();
     for pk in conflict_keys {
+        cancellation_point()?;
         if let Some(existing_data) = data_btree.search(pager, &pk)? {
             let existing_values = deserialize_row_versioned(
                 &existing_data,

--- a/src/sql/executor/mutation.rs
+++ b/src/sql/executor/mutation.rs
@@ -70,6 +70,7 @@ pub(super) fn exec_update(
                 .ok_or_else(|| MuroError::Execution(format!("Index '{}' not found", index_name)))?;
             let pk_keys = index_seek_pk_keys(idx, &idx_key, pager)?;
             for pk_key in pk_keys {
+                cancellation_point()?;
                 if let Some(data) = data_btree.search(pager, &pk_key)? {
                     let values = deserialize_row_versioned(
                         &data,
@@ -123,6 +124,7 @@ pub(super) fn exec_update(
                 .ok_or_else(|| MuroError::Execution(format!("Index '{}' not found", index_name)))?;
             let pk_keys = index_seek_pk_keys_range(idx, lower_key, upper_key, pager)?;
             for pk_key in pk_keys {
+                cancellation_point()?;
                 if let Some(data) = data_btree.search(pager, &pk_key)? {
                     let values = deserialize_row_versioned(
                         &data,
@@ -141,6 +143,7 @@ pub(super) fn exec_update(
         | Plan::FullScan { .. }
         | Plan::FtsScan { .. } => {
             data_btree.scan(pager, |k, v| {
+                cancellation_point()?;
                 let values =
                     deserialize_row_versioned(v, &table_def.columns, table_def.row_format_version)?;
                 if matches_where(&upd.where_clause, &table_def, &values)? {
@@ -276,6 +279,7 @@ pub(super) fn exec_delete(
                 .ok_or_else(|| MuroError::Execution(format!("Index '{}' not found", index_name)))?;
             let pk_keys = index_seek_pk_keys(idx, &idx_key, pager)?;
             for pk_key in pk_keys {
+                cancellation_point()?;
                 if let Some(data) = data_btree.search(pager, &pk_key)? {
                     let values = deserialize_row_versioned(
                         &data,
@@ -329,6 +333,7 @@ pub(super) fn exec_delete(
                 .ok_or_else(|| MuroError::Execution(format!("Index '{}' not found", index_name)))?;
             let pk_keys = index_seek_pk_keys_range(idx, lower_key, upper_key, pager)?;
             for pk_key in pk_keys {
+                cancellation_point()?;
                 if let Some(data) = data_btree.search(pager, &pk_key)? {
                     let values = deserialize_row_versioned(
                         &data,
@@ -347,6 +352,7 @@ pub(super) fn exec_delete(
         | Plan::FullScan { .. }
         | Plan::FtsScan { .. } => {
             data_btree.scan(pager, |k, v| {
+                cancellation_point()?;
                 let values =
                     deserialize_row_versioned(v, &table_def.columns, table_def.row_format_version)?;
                 if matches_where(&del.where_clause, &table_def, &values)? {

--- a/src/sql/executor/select_join.rs
+++ b/src/sql/executor/select_join.rs
@@ -10,6 +10,7 @@ pub(super) fn scan_table_qualified(
     let data_btree = BTree::open(table_def.data_btree_root);
     let mut result = Vec::new();
     data_btree.scan(pager, |_k, v| {
+        cancellation_point()?;
         let values =
             deserialize_row_versioned(v, &table_def.columns, table_def.row_format_version)?;
         let mut row: Vec<(String, Value)> = Vec::with_capacity(table_def.columns.len());
@@ -106,6 +107,7 @@ pub(super) fn exec_select_join(
 
     // 2. For each JOIN, perform nested loop join
     for join in &sel.joins {
+        cancellation_point()?;
         let right_table_def = catalog
             .get_table(pager, &join.table_name)?
             .ok_or_else(|| MuroError::Schema(format!("Table '{}' not found", join.table_name)))?;
@@ -138,7 +140,9 @@ pub(super) fn exec_select_join(
                     == JoinLoopOrder::RightOuter
                 {
                     for right in &right_rows {
+                        cancellation_point()?;
                         for left in &joined_rows {
+                            cancellation_point()?;
                             let mut combined: Vec<(String, Value)> =
                                 Vec::with_capacity(left.len() + right.len());
                             // Keep logical row shape stable: left columns first, then right.
@@ -157,7 +161,9 @@ pub(super) fn exec_select_join(
                     }
                 } else {
                     for left in &joined_rows {
+                        cancellation_point()?;
                         for right in &right_rows {
+                            cancellation_point()?;
                             let mut combined: Vec<(String, Value)> =
                                 Vec::with_capacity(left.len() + right.len());
                             combined.extend(left.iter().cloned());
@@ -177,8 +183,10 @@ pub(super) fn exec_select_join(
             }
             JoinType::Left => {
                 for left in &joined_rows {
+                    cancellation_point()?;
                     let mut matched = false;
                     for right in &right_rows {
+                        cancellation_point()?;
                         let mut combined: Vec<(String, Value)> =
                             Vec::with_capacity(left.len() + right.len());
                         combined.extend(left.iter().cloned());
@@ -210,8 +218,10 @@ pub(super) fn exec_select_join(
                     .collect();
 
                 for right in &right_rows {
+                    cancellation_point()?;
                     let mut matched = false;
                     for left in &joined_rows {
+                        cancellation_point()?;
                         let mut combined: Vec<(String, Value)> =
                             Vec::with_capacity(left.len() + right.len());
                         combined.extend(left.iter().cloned());
@@ -240,7 +250,9 @@ pub(super) fn exec_select_join(
                     == JoinLoopOrder::RightOuter
                 {
                     for right in &right_rows {
+                        cancellation_point()?;
                         for left in &joined_rows {
+                            cancellation_point()?;
                             let mut combined: Vec<(String, Value)> =
                                 Vec::with_capacity(left.len() + right.len());
                             combined.extend(left.iter().cloned());
@@ -250,7 +262,9 @@ pub(super) fn exec_select_join(
                     }
                 } else {
                     for left in &joined_rows {
+                        cancellation_point()?;
                         for right in &right_rows {
+                            cancellation_point()?;
                             let mut combined: Vec<(String, Value)> =
                                 Vec::with_capacity(left.len() + right.len());
                             combined.extend(left.iter().cloned());
@@ -350,6 +364,7 @@ pub(super) fn exec_select_join(
         // 7. Project SELECT columns
         let mut rows: Vec<Row> = Vec::new();
         for jrow in &joined_rows {
+            cancellation_point()?;
             let row = build_join_row(jrow, &sel.columns, &hidden_columns)?;
             rows.push(row);
         }

--- a/src/sql/executor/select_query.rs
+++ b/src/sql/executor/select_query.rs
@@ -254,6 +254,7 @@ pub(super) fn exec_select(
                 let pk_keys = index_seek_pk_keys(idx, &idx_key, pager)?;
                 let data_btree = BTree::open(table_def.data_btree_root);
                 for pk_key in &pk_keys {
+                    cancellation_point()?;
                     if let Some(data) = data_btree.search(pager, pk_key)? {
                         let values = deserialize_row_versioned(
                             &data,
@@ -317,6 +318,7 @@ pub(super) fn exec_select(
                 let pk_keys = index_seek_pk_keys_range(idx, lower_key, upper_key, pager)?;
                 let data_btree = BTree::open(table_def.data_btree_root);
                 for pk_key in &pk_keys {
+                    cancellation_point()?;
                     if let Some(data) = data_btree.search(pager, pk_key)? {
                         let values = deserialize_row_versioned(
                             &data,
@@ -348,6 +350,7 @@ pub(super) fn exec_select(
                 if needs_fts_doc_ids {
                     let mut entries: Vec<(Vec<u8>, Vec<Value>)> = Vec::new();
                     data_btree.scan(pager, |pk_key, v| {
+                        cancellation_point()?;
                         let values = deserialize_row_versioned(
                             v,
                             &table_def.columns,
@@ -357,6 +360,7 @@ pub(super) fn exec_select(
                         Ok(true)
                     })?;
                     for (pk_key, values) in entries {
+                        cancellation_point()?;
                         populate_fts_row_doc_ids(
                             &mut fts_ctx,
                             &pk_key,
@@ -375,6 +379,7 @@ pub(super) fn exec_select(
                     }
                 } else {
                     data_btree.scan(pager, |_, v| {
+                        cancellation_point()?;
                         let values = deserialize_row_versioned(
                             v,
                             &table_def.columns,
@@ -401,6 +406,7 @@ pub(super) fn exec_select(
                 let fts_rows =
                     execute_fts_scan_rows(&table_def, &indexes, &column, &query, mode, pager)?;
                 for (_doc_id, values) in fts_rows {
+                    cancellation_point()?;
                     if needs_fts_doc_ids {
                         let pk_key = encode_pk_key(&table_def, &values);
                         populate_fts_row_doc_ids(
@@ -506,6 +512,7 @@ pub(super) fn exec_select(
                 let pk_keys = index_seek_pk_keys(idx, &idx_key, pager)?;
                 let data_btree = BTree::open(table_def.data_btree_root);
                 for pk_key in &pk_keys {
+                    cancellation_point()?;
                     if let Some(data) = data_btree.search(pager, pk_key)? {
                         let values = deserialize_row_versioned(
                             &data,
@@ -576,6 +583,7 @@ pub(super) fn exec_select(
                 let pk_keys = index_seek_pk_keys_range(idx, lower_key, upper_key, pager)?;
                 let data_btree = BTree::open(table_def.data_btree_root);
                 for pk_key in &pk_keys {
+                    cancellation_point()?;
                     if let Some(data) = data_btree.search(pager, pk_key)? {
                         let values = deserialize_row_versioned(
                             &data,
@@ -614,6 +622,7 @@ pub(super) fn exec_select(
                 if needs_fts_doc_ids {
                     let mut entries: Vec<(Vec<u8>, Vec<Value>)> = Vec::new();
                     data_btree.scan(pager, |pk_key, v| {
+                        cancellation_point()?;
                         let values = deserialize_row_versioned(
                             v,
                             &table_def.columns,
@@ -623,6 +632,7 @@ pub(super) fn exec_select(
                         Ok(true)
                     })?;
                     for (pk_key, values) in entries {
+                        cancellation_point()?;
                         populate_fts_row_doc_ids(
                             &mut fts_ctx,
                             &pk_key,
@@ -648,6 +658,7 @@ pub(super) fn exec_select(
                     }
                 } else {
                     data_btree.scan(pager, |_, v| {
+                        cancellation_point()?;
                         let values = deserialize_row_versioned(
                             v,
                             &table_def.columns,
@@ -681,6 +692,7 @@ pub(super) fn exec_select(
                 let fts_rows =
                     execute_fts_scan_rows(&table_def, &indexes, &column, &query, mode, pager)?;
                 for (_doc_id, values) in fts_rows {
+                    cancellation_point()?;
                     if needs_fts_doc_ids {
                         let pk_key = encode_pk_key(&table_def, &values);
                         populate_fts_row_doc_ids(
@@ -731,6 +743,7 @@ pub(super) fn exec_select(
         // Strip extra ORDER BY columns that were injected for sorting
         if !extra_order_cols.is_empty() {
             for row in &mut rows {
+                cancellation_point()?;
                 row.values
                     .retain(|(name, _)| !extra_order_cols.contains(name));
             }

--- a/src/sql/session/mod.rs
+++ b/src/sql/session/mod.rs
@@ -14,6 +14,9 @@ use crate::types::Value;
 use crate::wal::record::TxId;
 use crate::wal::writer::WalWriter;
 use checkpoint::CheckpointPolicy;
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 const CHECKPOINT_MAX_ATTEMPTS: usize = 2;
 const DEFAULT_CHECKPOINT_TX_THRESHOLD: u64 = 1;
@@ -50,6 +53,51 @@ pub struct RuntimeConfig {
     pub checkpoint_interval_ms: u64,
 }
 
+#[derive(Debug, Default)]
+struct QueryCancelState {
+    in_flight: AtomicBool,
+    cancelled: AtomicBool,
+}
+
+/// Handle for requesting cancellation of the currently running statement.
+#[derive(Debug, Clone)]
+pub struct QueryCancelHandle {
+    state: Arc<QueryCancelState>,
+}
+
+impl QueryCancelHandle {
+    /// Request cancellation of the in-flight statement.
+    ///
+    /// Returns `true` if a statement was running when the request was issued.
+    /// Returns `false` when no statement is currently executing.
+    pub fn cancel(&self) -> bool {
+        if self.state.in_flight.load(Ordering::SeqCst) {
+            self.state.cancelled.store(true, Ordering::SeqCst);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+struct StatementExecutionGuard {
+    state: Arc<QueryCancelState>,
+}
+
+thread_local! {
+    static ACTIVE_CANCEL_STATE: RefCell<Option<Arc<QueryCancelState>>> = const { RefCell::new(None) };
+}
+
+impl Drop for StatementExecutionGuard {
+    fn drop(&mut self) {
+        ACTIVE_CANCEL_STATE.with(|slot| {
+            *slot.borrow_mut() = None;
+        });
+        self.state.cancelled.store(false, Ordering::SeqCst);
+        self.state.in_flight.store(false, Ordering::SeqCst);
+    }
+}
+
 /// A session that manages explicit transaction state.
 ///
 /// - `BEGIN` starts a transaction (dirty-page buffering).
@@ -71,6 +119,7 @@ pub struct Session {
     checkpoint_policy: CheckpointPolicy,
     pending_checkpoint_ops: u64,
     last_checkpoint_at: std::time::Instant,
+    cancel_state: Arc<QueryCancelState>,
     #[cfg(test)]
     inject_checkpoint_failures_remaining: usize,
     #[cfg(test)]
@@ -117,10 +166,18 @@ impl Session {
             checkpoint_policy: CheckpointPolicy::from_env(),
             pending_checkpoint_ops: 0,
             last_checkpoint_at: std::time::Instant::now(),
+            cancel_state: Arc::new(QueryCancelState::default()),
             #[cfg(test)]
             inject_checkpoint_failures_remaining: 0,
             #[cfg(test)]
             inject_wal_recreate_fail_once: false,
+        }
+    }
+
+    /// Get a handle that can request cancellation of in-flight statements.
+    pub fn cancel_handle(&self) -> QueryCancelHandle {
+        QueryCancelHandle {
+            state: Arc::clone(&self.cancel_state),
         }
     }
 
@@ -158,6 +215,9 @@ impl Session {
     }
 
     fn execute_statement_with_session(&mut self, stmt: &Statement) -> Result<ExecResult> {
+        let _statement_guard = self.enter_statement();
+        self.cancellation_point()?;
+
         // Stats queries are always allowed, even on poisoned sessions,
         // so operators can inspect counters after CommitInDoubt.
         match stmt {
@@ -212,6 +272,9 @@ impl Session {
     }
 
     fn execute_read_only_query_statement(&mut self, stmt: &Statement) -> Result<Vec<Row>> {
+        let _statement_guard = self.enter_statement();
+        self.cancellation_point()?;
+
         // Stats queries are always allowed, even on poisoned sessions.
         match stmt {
             Statement::ShowCheckpointStats => {
@@ -238,6 +301,24 @@ impl Session {
             // Read directly from pager/catalog without opening an implicit WAL transaction.
             Self::rows_from_exec_result(execute_statement(stmt, &mut self.pager, &mut self.catalog))
         }
+    }
+
+    fn enter_statement(&self) -> StatementExecutionGuard {
+        self.cancel_state.cancelled.store(false, Ordering::SeqCst);
+        self.cancel_state.in_flight.store(true, Ordering::SeqCst);
+        ACTIVE_CANCEL_STATE.with(|slot| {
+            *slot.borrow_mut() = Some(Arc::clone(&self.cancel_state));
+        });
+        StatementExecutionGuard {
+            state: Arc::clone(&self.cancel_state),
+        }
+    }
+
+    pub(crate) fn cancellation_point(&self) -> Result<()> {
+        if self.cancel_state.cancelled.load(Ordering::SeqCst) {
+            return Err(MuroError::Cancelled);
+        }
+        Ok(())
     }
 
     fn rows_from_exec_result(result: Result<ExecResult>) -> Result<Vec<Row>> {
@@ -544,6 +625,19 @@ impl Session {
     pub fn catalog(&self) -> &SystemCatalog {
         &self.catalog
     }
+}
+
+pub(crate) fn cancellation_point_current() -> Result<()> {
+    ACTIVE_CANCEL_STATE.with(|slot| {
+        if slot
+            .borrow()
+            .as_ref()
+            .is_some_and(|state| state.cancelled.load(Ordering::SeqCst))
+        {
+            return Err(MuroError::Cancelled);
+        }
+        Ok(())
+    })
 }
 
 #[cfg(test)]

--- a/src/sql/session/mod.rs
+++ b/src/sql/session/mod.rs
@@ -15,7 +15,7 @@ use crate::wal::record::TxId;
 use crate::wal::writer::WalWriter;
 use checkpoint::CheckpointPolicy;
 use std::cell::RefCell;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 const CHECKPOINT_MAX_ATTEMPTS: usize = 2;
@@ -55,8 +55,9 @@ pub struct RuntimeConfig {
 
 #[derive(Debug, Default)]
 struct QueryCancelState {
-    in_flight: AtomicBool,
-    cancelled: AtomicBool,
+    active_statement_id: AtomicU64,
+    cancel_requested_for_statement_id: AtomicU64,
+    next_statement_id: AtomicU64,
 }
 
 /// Handle for requesting cancellation of the currently running statement.
@@ -71,17 +72,20 @@ impl QueryCancelHandle {
     /// Returns `true` if a statement was running when the request was issued.
     /// Returns `false` when no statement is currently executing.
     pub fn cancel(&self) -> bool {
-        if self.state.in_flight.load(Ordering::SeqCst) {
-            self.state.cancelled.store(true, Ordering::SeqCst);
-            true
-        } else {
-            false
+        let active_id = self.state.active_statement_id.load(Ordering::SeqCst);
+        if active_id == 0 {
+            return false;
         }
+        self.state
+            .cancel_requested_for_statement_id
+            .store(active_id, Ordering::SeqCst);
+        true
     }
 }
 
 struct StatementExecutionGuard {
     state: Arc<QueryCancelState>,
+    statement_id: u64,
 }
 
 thread_local! {
@@ -93,8 +97,12 @@ impl Drop for StatementExecutionGuard {
         ACTIVE_CANCEL_STATE.with(|slot| {
             *slot.borrow_mut() = None;
         });
-        self.state.cancelled.store(false, Ordering::SeqCst);
-        self.state.in_flight.store(false, Ordering::SeqCst);
+        let _ = self.state.active_statement_id.compare_exchange(
+            self.statement_id,
+            0,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        );
     }
 }
 
@@ -304,18 +312,32 @@ impl Session {
     }
 
     fn enter_statement(&self) -> StatementExecutionGuard {
-        self.cancel_state.cancelled.store(false, Ordering::SeqCst);
-        self.cancel_state.in_flight.store(true, Ordering::SeqCst);
+        let statement_id = self
+            .cancel_state
+            .next_statement_id
+            .fetch_add(1, Ordering::SeqCst)
+            .saturating_add(1);
+        self.cancel_state
+            .active_statement_id
+            .store(statement_id, Ordering::SeqCst);
         ACTIVE_CANCEL_STATE.with(|slot| {
             *slot.borrow_mut() = Some(Arc::clone(&self.cancel_state));
         });
         StatementExecutionGuard {
             state: Arc::clone(&self.cancel_state),
+            statement_id,
         }
     }
 
     pub(crate) fn cancellation_point(&self) -> Result<()> {
-        if self.cancel_state.cancelled.load(Ordering::SeqCst) {
+        let active_id = self.cancel_state.active_statement_id.load(Ordering::SeqCst);
+        if active_id != 0
+            && self
+                .cancel_state
+                .cancel_requested_for_statement_id
+                .load(Ordering::SeqCst)
+                == active_id
+        {
             return Err(MuroError::Cancelled);
         }
         Ok(())
@@ -629,11 +651,18 @@ impl Session {
 
 pub(crate) fn cancellation_point_current() -> Result<()> {
     ACTIVE_CANCEL_STATE.with(|slot| {
-        if slot
-            .borrow()
-            .as_ref()
-            .is_some_and(|state| state.cancelled.load(Ordering::SeqCst))
-        {
+        let borrowed = slot.borrow();
+        let Some(state) = borrowed.as_ref() else {
+            return Ok(());
+        };
+        let active_id = state.active_statement_id.load(Ordering::SeqCst);
+        if active_id == 0 {
+            return Ok(());
+        }
+        let cancel_target = state
+            .cancel_requested_for_statement_id
+            .load(Ordering::SeqCst);
+        if cancel_target == active_id {
             return Err(MuroError::Cancelled);
         }
         Ok(())

--- a/src/sql/session/tests/tail.rs
+++ b/src/sql/session/tests/tail.rs
@@ -183,6 +183,90 @@ fn test_rekey_wal_recreate_failure_poison_session() {
 }
 
 #[test]
+fn test_cancel_handle_returns_false_when_no_statement_is_running() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let wal_path = dir.path().join("test.wal");
+
+    let mut pager = Pager::create(&db_path, &test_key()).unwrap();
+    let catalog = SystemCatalog::create(&mut pager).unwrap();
+    pager.set_catalog_root(catalog.root_page_id());
+    pager.flush_meta().unwrap();
+    let wal = WalWriter::create(&wal_path, &test_key()).unwrap();
+    let session = Session::new(pager, catalog, wal);
+
+    let handle = session.cancel_handle();
+    assert!(!handle.cancel());
+}
+
+#[test]
+fn test_cancel_handle_marks_in_flight_statement() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let wal_path = dir.path().join("test.wal");
+
+    let mut pager = Pager::create(&db_path, &test_key()).unwrap();
+    let catalog = SystemCatalog::create(&mut pager).unwrap();
+    pager.set_catalog_root(catalog.root_page_id());
+    pager.flush_meta().unwrap();
+    let wal = WalWriter::create(&wal_path, &test_key()).unwrap();
+    let session = Session::new(pager, catalog, wal);
+
+    let handle = session.cancel_handle();
+    let statement_guard = session.enter_statement();
+    assert!(handle.cancel());
+    assert!(matches!(
+        session.cancellation_point(),
+        Err(MuroError::Cancelled)
+    ));
+    drop(statement_guard);
+    assert!(session.cancellation_point().is_ok());
+}
+
+#[test]
+fn test_inflight_cancel_interrupts_long_running_query() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let wal_path = dir.path().join("test.wal");
+
+    let mut pager = Pager::create(&db_path, &test_key()).unwrap();
+    let catalog = SystemCatalog::create(&mut pager).unwrap();
+    pager.set_catalog_root(catalog.root_page_id());
+    pager.flush_meta().unwrap();
+    let wal = WalWriter::create(&wal_path, &test_key()).unwrap();
+    let mut session = Session::new(pager, catalog, wal);
+
+    session
+        .execute("CREATE TABLE t (id BIGINT PRIMARY KEY)")
+        .unwrap();
+    for i in 0..1000 {
+        session
+            .execute(&format!("INSERT INTO t VALUES ({})", i))
+            .unwrap();
+    }
+
+    let handle = session.cancel_handle();
+    let canceller = std::thread::spawn(move || {
+        for _ in 0..200_000 {
+            if handle.cancel() {
+                return true;
+            }
+            std::thread::yield_now();
+        }
+        false
+    });
+
+    let result = session.execute_read_only_query("SELECT a.id FROM t a CROSS JOIN t b");
+    let cancel_observed = canceller.join().unwrap();
+
+    assert!(
+        cancel_observed,
+        "canceller did not observe in-flight statement"
+    );
+    assert!(matches!(result, Err(MuroError::Cancelled)));
+}
+
+#[test]
 fn test_read_only_query_select_does_not_create_wal_records() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
@@ -398,4 +482,53 @@ fn test_rollback_to_savepoint_restores_pager_allocation_state() {
         _ => panic!("Expected rows"),
     };
     assert!(rows.is_empty());
+}
+
+#[test]
+fn test_cancelled_update_in_explicit_tx_does_not_apply_partial_changes() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let wal_path = dir.path().join("test.wal");
+
+    let mut pager = Pager::create(&db_path, &test_key()).unwrap();
+    let catalog = SystemCatalog::create(&mut pager).unwrap();
+    pager.set_catalog_root(catalog.root_page_id());
+    pager.flush_meta().unwrap();
+    let wal = WalWriter::create(&wal_path, &test_key()).unwrap();
+    let mut session = Session::new(pager, catalog, wal);
+
+    session
+        .execute("CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR)")
+        .unwrap();
+    session
+        .execute("CREATE UNIQUE INDEX idx_name ON t(name)")
+        .unwrap();
+    session.execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+    session.execute("INSERT INTO t VALUES (2, 'b')").unwrap();
+
+    session.execute("BEGIN").unwrap();
+    let handle = session.cancel_handle();
+    let statement_guard = session.enter_statement();
+    assert!(handle.cancel());
+    let stmt = parse_sql("UPDATE t SET name = 'x'").unwrap();
+    let err = session
+        .execute_in_tx(&stmt)
+        .expect_err("update should be cancelled");
+    drop(statement_guard);
+    assert!(matches!(err, MuroError::Cancelled));
+
+    let rows = match session
+        .execute("SELECT id, name FROM t WHERE name = 'x'")
+        .unwrap()
+    {
+        ExecResult::Rows(rows) => rows,
+        _ => panic!("Expected rows"),
+    };
+    assert_eq!(
+        rows.len(),
+        0,
+        "cancelled statement must not leave partial updates"
+    );
+
+    session.execute("ROLLBACK").unwrap();
 }


### PR DESCRIPTION
## Summary
- add explicit query cancellation API via `QueryCancelHandle`
- add `MuroError::Cancelled` and wire cancellation checkpoints through long-running executor loops
- keep explicit transaction behavior safe on cancellation by checking write-path cancellation before row-application phases
- add CLI `Ctrl-C` integration to cancel in-flight statements while keeping REPL usable
- document cancellation API and CLI Ctrl-C behavior in docs

## API
- new: `Database::cancel_handle()`
- new: `DatabaseReader::cancel_handle()`
- new: `QueryCancelHandle::cancel() -> bool`
- new error variant: `MuroError::Cancelled`

## Tests
- `cargo test --lib test_cancel_handle -- --nocapture`
- `cargo test --lib test_inflight_cancel_interrupts_long_running_query -- --nocapture`
- `cargo test --lib test_cancelled_update_in_explicit_tx_does_not_apply_partial_changes -- --nocapture`
- `cargo test --bin murodb -- --nocapture`

Closes #191
