### PR TITLE
Add busy_timeout_ms guardrail for lock acquisition

### DIFF
--- a/docs-site/src/user-guide/cli.md
+++ b/docs-site/src/user-guide/cli.md
@@ -16,6 +16,7 @@ murodb <database-file> [options]
 | `--password <PW>` | Password for `aes256-gcm-siv` mode (prompts if omitted) |
 | `--recovery-mode <strict\|permissive>` | WAL recovery policy for open |
 | `--format <text\|json>` | Output format for query results |
+| `--busy-timeout-ms <N>` | Lock wait timeout in milliseconds (`0` = wait indefinitely) |
 
 ## Examples
 

--- a/docs-site/src/user-guide/sql-reference.md
+++ b/docs-site/src/user-guide/sql-reference.md
@@ -1027,6 +1027,8 @@ Rust API note:
 - `Database::query()` takes `&mut self` because read execution may refresh pager/catalog state from disk before running.
 - For concurrent reads in one process, use multiple read-only handles (for example `Database::open_reader()`).
 - Inside an explicit transaction (`BEGIN` ... `COMMIT`/`ROLLBACK`), run statements through `Database::execute()`, including `SELECT`.
+- `Database::set_busy_timeout_ms(ms)` sets lock wait timeout (`0` = wait indefinitely).
+- `DatabaseReader::set_busy_timeout_ms(ms)` does the same for read-only handles.
 - `Database::cancel_handle()` / `DatabaseReader::cancel_handle()` returns a `QueryCancelHandle`.
 - `QueryCancelHandle::cancel()` returns `true` when a statement is currently in flight, otherwise `false`.
 - Cancellation errors are reported as `MuroError::Cancelled`.

--- a/src/bin/murodb.rs
+++ b/src/bin/murodb.rs
@@ -85,6 +85,12 @@ struct Cli {
     /// `text` is human-readable; `json` is intended for tool integration.
     #[arg(long, value_enum, default_value = "text")]
     format: OutputFormatArg,
+
+    /// Lock wait timeout in milliseconds.
+    ///
+    /// `0` means wait indefinitely.
+    #[arg(long, default_value_t = 0)]
+    busy_timeout_ms: u64,
 }
 
 fn get_password(cli_password: &Option<String>) -> String {
@@ -545,6 +551,8 @@ fn main() {
         }
         db
     };
+
+    db.set_busy_timeout_ms(cli.busy_timeout_ms);
 
     let interrupts = InterruptController::default();
     interrupts.install_sigint_handler();

--- a/src/concurrency/mod.rs
+++ b/src/concurrency/mod.rs
@@ -5,6 +5,7 @@
 /// Process-level: fs4 file lock
 use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use fs4::fs_std::FileExt;
 use parking_lot::RwLock;
@@ -39,11 +40,54 @@ impl LockManager {
 
     /// Acquire a shared (read) lock.
     pub fn read_lock(&self) -> Result<ReadGuard<'_>> {
-        let thread_guard = self.rw_lock.read();
+        self.read_lock_with_timeout(None)
+    }
 
-        self.lock_file
-            .lock_shared()
-            .map_err(|e| MuroError::Lock(format!("Failed to acquire shared file lock: {}", e)))?;
+    /// Acquire a shared (read) lock with timeout.
+    ///
+    /// If `timeout` is `None`, this blocks until acquired.
+    pub fn read_lock_with_timeout(&self, timeout: Option<Duration>) -> Result<ReadGuard<'_>> {
+        let timeout_ms = timeout.map(|d| d.as_millis() as u64).unwrap_or(0);
+        let thread_guard = if let Some(timeout) = timeout {
+            self.rw_lock
+                .try_read_for(timeout)
+                .ok_or(MuroError::LockTimeout {
+                    mode: "shared",
+                    timeout_ms,
+                })?
+        } else {
+            self.rw_lock.read()
+        };
+
+        if let Some(timeout) = timeout {
+            let deadline = Instant::now() + timeout;
+            loop {
+                match self.lock_file.try_lock_shared() {
+                    Ok(()) => break,
+                    Err(std::fs::TryLockError::WouldBlock) => {
+                        let now = Instant::now();
+                        if now >= deadline {
+                            return Err(MuroError::LockTimeout {
+                                mode: "shared",
+                                timeout_ms,
+                            });
+                        }
+                        let remaining = deadline.saturating_duration_since(now);
+                        std::thread::sleep(std::cmp::min(Duration::from_millis(1), remaining));
+                    }
+                    Err(std::fs::TryLockError::Error(e)) => {
+                        return Err(MuroError::Lock(format!(
+                            "Failed to acquire shared file lock: {}",
+                            e
+                        )))
+                    }
+                }
+            }
+        } else {
+            self.lock_file.lock_shared().map_err(|e| {
+                MuroError::Lock(format!("Failed to acquire shared file lock: {}", e))
+            })?;
+        }
 
         Ok(ReadGuard {
             _thread_guard: thread_guard,
@@ -53,11 +97,54 @@ impl LockManager {
 
     /// Acquire an exclusive (write) lock.
     pub fn write_lock(&self) -> Result<WriteGuard<'_>> {
-        let thread_guard = self.rw_lock.write();
+        self.write_lock_with_timeout(None)
+    }
 
-        self.lock_file.lock_exclusive().map_err(|e| {
-            MuroError::Lock(format!("Failed to acquire exclusive file lock: {}", e))
-        })?;
+    /// Acquire an exclusive (write) lock with timeout.
+    ///
+    /// If `timeout` is `None`, this blocks until acquired.
+    pub fn write_lock_with_timeout(&self, timeout: Option<Duration>) -> Result<WriteGuard<'_>> {
+        let timeout_ms = timeout.map(|d| d.as_millis() as u64).unwrap_or(0);
+        let thread_guard = if let Some(timeout) = timeout {
+            self.rw_lock
+                .try_write_for(timeout)
+                .ok_or(MuroError::LockTimeout {
+                    mode: "exclusive",
+                    timeout_ms,
+                })?
+        } else {
+            self.rw_lock.write()
+        };
+
+        if let Some(timeout) = timeout {
+            let deadline = Instant::now() + timeout;
+            loop {
+                match self.lock_file.try_lock_exclusive() {
+                    Ok(()) => break,
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        let now = Instant::now();
+                        if now >= deadline {
+                            return Err(MuroError::LockTimeout {
+                                mode: "exclusive",
+                                timeout_ms,
+                            });
+                        }
+                        let remaining = deadline.saturating_duration_since(now);
+                        std::thread::sleep(std::cmp::min(Duration::from_millis(1), remaining));
+                    }
+                    Err(e) => {
+                        return Err(MuroError::Lock(format!(
+                            "Failed to acquire exclusive file lock: {}",
+                            e
+                        )))
+                    }
+                }
+            }
+        } else {
+            self.lock_file.lock_exclusive().map_err(|e| {
+                MuroError::Lock(format!("Failed to acquire exclusive file lock: {}", e))
+            })?;
+        }
 
         Ok(WriteGuard {
             _thread_guard: thread_guard,
@@ -153,5 +240,22 @@ mod tests {
 
         writer.join().unwrap();
         reader.join().unwrap();
+    }
+
+    #[test]
+    fn test_read_lock_timeout_when_writer_is_held() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+        File::create(&db_path).unwrap();
+
+        let lock_mgr = LockManager::new(&db_path).unwrap();
+        let _writer_guard = lock_mgr.write_lock().unwrap();
+
+        let err = match lock_mgr.read_lock_with_timeout(Some(std::time::Duration::from_millis(20)))
+        {
+            Err(err) => err,
+            Ok(_) => panic!("read lock should time out while writer lock is held"),
+        };
+        assert!(matches!(err, MuroError::LockTimeout { mode: "shared", .. }));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,6 +47,9 @@ pub enum MuroError {
     #[error("Lock error: {0}")]
     Lock(String),
 
+    #[error("Lock timeout after {timeout_ms}ms while acquiring {mode} lock")]
+    LockTimeout { mode: &'static str, timeout_ms: u64 },
+
     #[error("FTS error: {0}")]
     Fts(String),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ pub use crate::wal::recovery::{RecoveryMode, RecoveryResult, RecoverySkipCode, R
 pub type QueryResult = Vec<Row>;
 
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::btree::ops::BTree;
 use crate::concurrency::LockManager;
@@ -99,6 +99,7 @@ const LEGACY_SQL_FTS_TERM_KEY: [u8; 32] = [0x55u8; 32];
 pub struct Database {
     session: Session,
     lock_manager: LockManager,
+    busy_timeout_ms: u64,
     master_key: Option<MasterKey>,
     db_path: PathBuf,
     encryption_suite: EncryptionSuite,
@@ -108,6 +109,7 @@ pub struct Database {
 pub struct DatabaseReader {
     session: Session,
     lock_manager: LockManager,
+    busy_timeout_ms: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -454,6 +456,7 @@ impl Database {
         Ok(Database {
             session,
             lock_manager,
+            busy_timeout_ms: 0,
             master_key: Some(master_key.clone()),
             db_path: path.to_path_buf(),
             encryption_suite: EncryptionSuite::Aes256GcmSiv,
@@ -477,6 +480,7 @@ impl Database {
         Ok(Database {
             session,
             lock_manager,
+            busy_timeout_ms: 0,
             master_key: None,
             db_path: path.to_path_buf(),
             encryption_suite: EncryptionSuite::Plaintext,
@@ -559,6 +563,7 @@ impl Database {
             Database {
                 session,
                 lock_manager,
+                busy_timeout_ms: 0,
                 master_key: Some(master_key.clone()),
                 db_path: path.to_path_buf(),
                 encryption_suite: EncryptionSuite::Aes256GcmSiv,
@@ -614,6 +619,7 @@ impl Database {
             Database {
                 session,
                 lock_manager,
+                busy_timeout_ms: 0,
                 master_key: None,
                 db_path: path.to_path_buf(),
                 encryption_suite: EncryptionSuite::Plaintext,
@@ -643,6 +649,7 @@ impl Database {
         Ok(Database {
             session,
             lock_manager,
+            busy_timeout_ms: 0,
             master_key: Some(master_key),
             db_path: path.to_path_buf(),
             encryption_suite: EncryptionSuite::Aes256GcmSiv,
@@ -797,7 +804,13 @@ impl Database {
 
     /// Execute a SQL statement. Returns the result.
     pub fn execute(&mut self, sql: &str) -> Result<ExecResult> {
-        let _guard = self.lock_manager.write_lock()?;
+        let timeout_ms = self.busy_timeout_ms;
+        let _guard = if timeout_ms == 0 {
+            self.lock_manager.write_lock()?
+        } else {
+            self.lock_manager
+                .write_lock_with_timeout(Some(Duration::from_millis(timeout_ms)))?
+        };
         self.session.execute(sql)
     }
 
@@ -808,14 +821,40 @@ impl Database {
 
     /// Get current session runtime configuration.
     pub fn runtime_config(&self) -> Result<RuntimeConfig> {
-        let _guard = self.lock_manager.read_lock()?;
+        let timeout_ms = self.busy_timeout_ms;
+        let _guard = if timeout_ms == 0 {
+            self.lock_manager.read_lock()?
+        } else {
+            self.lock_manager
+                .read_lock_with_timeout(Some(Duration::from_millis(timeout_ms)))?
+        };
         Ok(self.session.runtime_config())
     }
 
     /// Update session runtime configuration.
     pub fn set_runtime_config(&mut self, config: RuntimeConfig) -> Result<()> {
-        let _guard = self.lock_manager.write_lock()?;
+        let timeout_ms = self.busy_timeout_ms;
+        let _guard = if timeout_ms == 0 {
+            self.lock_manager.write_lock()?
+        } else {
+            self.lock_manager
+                .write_lock_with_timeout(Some(Duration::from_millis(timeout_ms)))?
+        };
         self.session.set_runtime_config(config)
+    }
+
+    /// Configure lock wait timeout in milliseconds.
+    ///
+    /// `0` means wait indefinitely (default).
+    pub fn set_busy_timeout_ms(&mut self, timeout_ms: u64) {
+        self.busy_timeout_ms = timeout_ms;
+    }
+
+    /// Current lock wait timeout in milliseconds.
+    ///
+    /// `0` means wait indefinitely.
+    pub fn busy_timeout_ms(&self) -> u64 {
+        self.busy_timeout_ms
     }
 
     /// Parse SQL into a reusable prepared statement template.
@@ -829,7 +868,13 @@ impl Database {
         prepared: &PreparedStatement,
         params: &[Value],
     ) -> Result<ExecResult> {
-        let _guard = self.lock_manager.write_lock()?;
+        let timeout_ms = self.busy_timeout_ms;
+        let _guard = if timeout_ms == 0 {
+            self.lock_manager.write_lock()?
+        } else {
+            self.lock_manager
+                .write_lock_with_timeout(Some(Duration::from_millis(timeout_ms)))?
+        };
         self.session.execute_prepared(prepared, params)
     }
 
@@ -847,7 +892,13 @@ impl Database {
     /// pager/catalog state from disk before executing the read.
     /// Non-read-only SQL returns an execution error.
     pub fn query(&mut self, sql: &str) -> Result<Vec<Row>> {
-        let _guard = self.lock_manager.read_lock()?;
+        let timeout_ms = self.busy_timeout_ms;
+        let _guard = if timeout_ms == 0 {
+            self.lock_manager.read_lock()?
+        } else {
+            self.lock_manager
+                .read_lock_with_timeout(Some(Duration::from_millis(timeout_ms)))?
+        };
         self.session.execute_read_only_query(sql)
     }
 
@@ -857,7 +908,13 @@ impl Database {
         prepared: &PreparedStatement,
         params: &[Value],
     ) -> Result<Vec<Row>> {
-        let _guard = self.lock_manager.read_lock()?;
+        let timeout_ms = self.busy_timeout_ms;
+        let _guard = if timeout_ms == 0 {
+            self.lock_manager.read_lock()?
+        } else {
+            self.lock_manager
+                .read_lock_with_timeout(Some(Duration::from_millis(timeout_ms)))?
+        };
         self.session
             .execute_read_only_prepared_query(prepared, params)
     }
@@ -900,6 +957,7 @@ impl Database {
                 Ok(DatabaseReader {
                     session,
                     lock_manager,
+                    busy_timeout_ms: self.busy_timeout_ms,
                 })
             }
             EncryptionSuite::Aes256GcmSiv => {
@@ -927,6 +985,7 @@ impl Database {
                 Ok(DatabaseReader {
                     session,
                     lock_manager,
+                    busy_timeout_ms: self.busy_timeout_ms,
                 })
             }
         }
@@ -934,7 +993,13 @@ impl Database {
 
     /// Re-encrypt the database with a new password-derived key.
     pub fn rekey_with_password(&mut self, new_password: &str) -> Result<()> {
-        let _guard = self.lock_manager.write_lock()?;
+        let timeout_ms = self.busy_timeout_ms;
+        let _guard = if timeout_ms == 0 {
+            self.lock_manager.write_lock()?
+        } else {
+            self.lock_manager
+                .write_lock_with_timeout(Some(Duration::from_millis(timeout_ms)))?
+        };
         self.session.rekey_with_password(new_password)?;
         let info = Pager::read_encryption_info_from_file(&self.db_path)?;
         if info.suite == EncryptionSuite::Aes256GcmSiv {
@@ -954,7 +1019,13 @@ impl Database {
 
     /// Flush all data to disk.
     pub fn flush(&mut self) -> Result<()> {
-        let _guard = self.lock_manager.write_lock()?;
+        let timeout_ms = self.busy_timeout_ms;
+        let _guard = if timeout_ms == 0 {
+            self.lock_manager.write_lock()?
+        } else {
+            self.lock_manager
+                .write_lock_with_timeout(Some(Duration::from_millis(timeout_ms)))?
+        };
         let catalog_root = self.session.catalog().root_page_id();
         let pager = self.session.pager_mut();
         pager.set_catalog_root(catalog_root);
@@ -968,7 +1039,13 @@ impl Database {
     /// database file. The backup file is a valid MuroDB database that can
     /// be opened directly with the same key/password.
     pub fn backup<P: AsRef<Path>>(&mut self, dest: P) -> Result<()> {
-        let _guard = self.lock_manager.write_lock()?;
+        let timeout_ms = self.busy_timeout_ms;
+        let _guard = if timeout_ms == 0 {
+            self.lock_manager.write_lock()?
+        } else {
+            self.lock_manager
+                .write_lock_with_timeout(Some(Duration::from_millis(timeout_ms)))?
+        };
         // Checkpoint WAL so all committed data is in the data file.
         self.session.try_checkpoint_truncate_once()?;
         // Copy the data file bytes.
@@ -990,6 +1067,20 @@ impl DatabaseReader {
         self.session.cancel_handle()
     }
 
+    /// Configure lock wait timeout in milliseconds.
+    ///
+    /// `0` means wait indefinitely (default).
+    pub fn set_busy_timeout_ms(&mut self, timeout_ms: u64) {
+        self.busy_timeout_ms = timeout_ms;
+    }
+
+    /// Current lock wait timeout in milliseconds.
+    ///
+    /// `0` means wait indefinitely.
+    pub fn busy_timeout_ms(&self) -> u64 {
+        self.busy_timeout_ms
+    }
+
     /// Parse SQL into a reusable prepared statement template.
     pub fn prepare(&self, sql: &str) -> Result<PreparedStatement> {
         self.session.prepare(sql)
@@ -997,7 +1088,13 @@ impl DatabaseReader {
 
     /// Execute a read-only SQL query and return rows.
     pub fn query(&mut self, sql: &str) -> Result<Vec<Row>> {
-        let _guard = self.lock_manager.read_lock()?;
+        let timeout_ms = self.busy_timeout_ms;
+        let _guard = if timeout_ms == 0 {
+            self.lock_manager.read_lock()?
+        } else {
+            self.lock_manager
+                .read_lock_with_timeout(Some(Duration::from_millis(timeout_ms)))?
+        };
         self.session.execute_read_only_query(sql)
     }
 
@@ -1007,7 +1104,13 @@ impl DatabaseReader {
         prepared: &PreparedStatement,
         params: &[Value],
     ) -> Result<Vec<Row>> {
-        let _guard = self.lock_manager.read_lock()?;
+        let timeout_ms = self.busy_timeout_ms;
+        let _guard = if timeout_ms == 0 {
+            self.lock_manager.read_lock()?
+        } else {
+            self.lock_manager
+                .read_lock_with_timeout(Some(Duration::from_millis(timeout_ms)))?
+        };
         self.session
             .execute_read_only_prepared_query(prepared, params)
     }
@@ -1061,6 +1164,34 @@ mod tests {
         rx.recv_timeout(Duration::from_secs(2))
             .expect("flush should complete after read lock is released");
         handle.join().unwrap();
+    }
+
+    #[test]
+    fn flush_respects_busy_timeout() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("flush_timeout.db");
+
+        let mut db1 = Database::create_plaintext(&db_path).unwrap();
+        db1.execute("CREATE TABLE t (id BIGINT PRIMARY KEY)")
+            .unwrap();
+        db1.execute("INSERT INTO t VALUES (1)").unwrap();
+        db1.set_busy_timeout_ms(20);
+
+        let db2 = Database::open_plaintext(&db_path).unwrap();
+        let read_guard = db2.lock_manager.read_lock().unwrap();
+
+        let err = db1
+            .flush()
+            .expect_err("flush should time out while read lock is held");
+        assert!(matches!(
+            err,
+            crate::MuroError::LockTimeout {
+                mode: "exclusive",
+                ..
+            }
+        ));
+
+        drop(read_guard);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Implement step 1 of #187: lock wait timeout guardrail (`busy_timeout_ms`).

### What was added
- Lock timeout support in lock manager:
  - `read_lock_with_timeout(timeout: Option<Duration>)`
  - `write_lock_with_timeout(timeout: Option<Duration>)`
- Deterministic timeout error variant:
  - `MuroError::LockTimeout { mode, timeout_ms }`
- Host API on handles:
  - `Database::set_busy_timeout_ms` / `busy_timeout_ms`
  - `DatabaseReader::set_busy_timeout_ms` / `busy_timeout_ms`
- CLI option:
  - `--busy-timeout-ms` (`0` means wait indefinitely)
- Docs updates:
  - CLI options table
  - SQL reference Rust API notes

### Tests
- `cargo test --lib flush_respects_busy_timeout -- --nocapture`
- `cargo test --lib test_read_lock_timeout_when_writer_is_held -- --nocapture`
- `cargo test --lib test_inflight_cancel_interrupts_long_running_query -- --nocapture`
- `cargo test --bin murodb -- --nocapture`

Part of #187.
