### PR TITLE
Add statement_timeout_ms guardrail

### DIFF
--- a/docs-site/src/user-guide/cli.md
+++ b/docs-site/src/user-guide/cli.md
@@ -17,6 +17,7 @@ murodb <database-file> [options]
 | `--recovery-mode <strict\|permissive>` | WAL recovery policy for open |
 | `--format <text\|json>` | Output format for query results |
 | `--busy-timeout-ms <N>` | Lock wait timeout in milliseconds (`0` = wait indefinitely) |
+| `--statement-timeout-ms <N>` | Per-statement execution timeout in milliseconds (`0` = no timeout) |
 
 ## Examples
 

--- a/docs-site/src/user-guide/sql-reference.md
+++ b/docs-site/src/user-guide/sql-reference.md
@@ -1032,6 +1032,8 @@ Rust API note:
 - `Database::cancel_handle()` / `DatabaseReader::cancel_handle()` returns a `QueryCancelHandle`.
 - `QueryCancelHandle::cancel()` returns `true` when a statement is currently in flight, otherwise `false`.
 - Cancellation errors are reported as `MuroError::Cancelled`.
+- `Database::set_statement_timeout_ms(ms)` and `DatabaseReader::set_statement_timeout_ms(ms)` set per-statement execution timeout (`0` = no timeout).
+- Timeout errors are reported as `MuroError::StatementTimeout { timeout_ms }`.
 - Cancellation safety for explicit transactions: cancellation checks in write paths are performed before row-application phases, so a cancelled statement does not commit partial row changes.
 
 ## Hidden _rowid

--- a/src/bin/murodb.rs
+++ b/src/bin/murodb.rs
@@ -91,6 +91,12 @@ struct Cli {
     /// `0` means wait indefinitely.
     #[arg(long, default_value_t = 0)]
     busy_timeout_ms: u64,
+
+    /// Per-statement execution timeout in milliseconds.
+    ///
+    /// `0` means no timeout.
+    #[arg(long, default_value_t = 0)]
+    statement_timeout_ms: u64,
 }
 
 fn get_password(cli_password: &Option<String>) -> String {
@@ -553,6 +559,7 @@ fn main() {
     };
 
     db.set_busy_timeout_ms(cli.busy_timeout_ms);
+    db.set_statement_timeout_ms(cli.statement_timeout_ms);
 
     let interrupts = InterruptController::default();
     interrupts.install_sigint_handler();

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,6 +38,9 @@ pub enum MuroError {
     #[error("Query cancelled")]
     Cancelled,
 
+    #[error("Statement timeout after {timeout_ms}ms")]
+    StatementTimeout { timeout_ms: u64 },
+
     #[error("Unique constraint violation: {0}")]
     UniqueViolation(String),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -819,6 +819,20 @@ impl Database {
         self.session.cancel_handle()
     }
 
+    /// Configure per-statement execution timeout in milliseconds.
+    ///
+    /// `0` means no timeout.
+    pub fn set_statement_timeout_ms(&mut self, timeout_ms: u64) {
+        self.session.set_statement_timeout_ms(timeout_ms);
+    }
+
+    /// Current per-statement execution timeout in milliseconds.
+    ///
+    /// `0` means no timeout.
+    pub fn statement_timeout_ms(&self) -> u64 {
+        self.session.statement_timeout_ms()
+    }
+
     /// Get current session runtime configuration.
     pub fn runtime_config(&self) -> Result<RuntimeConfig> {
         let timeout_ms = self.busy_timeout_ms;
@@ -953,7 +967,8 @@ impl Database {
                 // Reader handles never write WAL; fixed LSN is acceptable.
                 let wal = WalWriter::open_plaintext(&wp, 0)?;
                 let lock_manager = LockManager::new(path)?;
-                let session = Session::new(pager, catalog, wal);
+                let mut session = Session::new(pager, catalog, wal);
+                session.set_statement_timeout_ms(self.session.statement_timeout_ms());
                 Ok(DatabaseReader {
                     session,
                     lock_manager,
@@ -981,7 +996,8 @@ impl Database {
                 // Reader handles never write WAL; fixed LSN is acceptable.
                 let wal = WalWriter::open(&wp, master_key, 0)?;
                 let lock_manager = LockManager::new(path)?;
-                let session = Session::new(pager, catalog, wal);
+                let mut session = Session::new(pager, catalog, wal);
+                session.set_statement_timeout_ms(self.session.statement_timeout_ms());
                 Ok(DatabaseReader {
                     session,
                     lock_manager,
@@ -1079,6 +1095,20 @@ impl DatabaseReader {
     /// `0` means wait indefinitely.
     pub fn busy_timeout_ms(&self) -> u64 {
         self.busy_timeout_ms
+    }
+
+    /// Configure per-statement execution timeout in milliseconds.
+    ///
+    /// `0` means no timeout.
+    pub fn set_statement_timeout_ms(&mut self, timeout_ms: u64) {
+        self.session.set_statement_timeout_ms(timeout_ms);
+    }
+
+    /// Current per-statement execution timeout in milliseconds.
+    ///
+    /// `0` means no timeout.
+    pub fn statement_timeout_ms(&self) -> u64 {
+        self.session.statement_timeout_ms()
     }
 
     /// Parse SQL into a reusable prepared statement template.
@@ -1276,5 +1306,28 @@ mod tests {
         assert_eq!(cfg.checkpoint_tx_threshold, 7);
         assert_eq!(cfg.checkpoint_wal_bytes_threshold, 4096);
         assert_eq!(cfg.checkpoint_interval_ms, 500);
+    }
+
+    #[test]
+    fn statement_timeout_api_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("statement_timeout_api.db");
+
+        let mut db = Database::create_plaintext(&db_path).unwrap();
+        assert_eq!(db.statement_timeout_ms(), 0);
+        db.set_statement_timeout_ms(123);
+        assert_eq!(db.statement_timeout_ms(), 123);
+    }
+
+    #[test]
+    fn open_reader_inherits_statement_timeout() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("reader_statement_timeout.db");
+
+        let mut db = Database::create_plaintext(&db_path).unwrap();
+        db.set_statement_timeout_ms(77);
+
+        let reader = db.open_reader().unwrap();
+        assert_eq!(reader.statement_timeout_ms(), 77);
     }
 }

--- a/src/sql/session/mod.rs
+++ b/src/sql/session/mod.rs
@@ -17,6 +17,7 @@ use checkpoint::CheckpointPolicy;
 use std::cell::RefCell;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::Instant;
 
 const CHECKPOINT_MAX_ATTEMPTS: usize = 2;
 const DEFAULT_CHECKPOINT_TX_THRESHOLD: u64 = 1;
@@ -88,13 +89,23 @@ struct StatementExecutionGuard {
     statement_id: u64,
 }
 
+#[derive(Clone, Copy)]
+struct StatementTimeoutContext {
+    deadline: Instant,
+    timeout_ms: u64,
+}
+
 thread_local! {
     static ACTIVE_CANCEL_STATE: RefCell<Option<Arc<QueryCancelState>>> = const { RefCell::new(None) };
+    static ACTIVE_STATEMENT_TIMEOUT: RefCell<Option<StatementTimeoutContext>> = const { RefCell::new(None) };
 }
 
 impl Drop for StatementExecutionGuard {
     fn drop(&mut self) {
         ACTIVE_CANCEL_STATE.with(|slot| {
+            *slot.borrow_mut() = None;
+        });
+        ACTIVE_STATEMENT_TIMEOUT.with(|slot| {
             *slot.borrow_mut() = None;
         });
         let _ = self.state.active_statement_id.compare_exchange(
@@ -127,6 +138,7 @@ pub struct Session {
     checkpoint_policy: CheckpointPolicy,
     pending_checkpoint_ops: u64,
     last_checkpoint_at: std::time::Instant,
+    statement_timeout_ms: u64,
     cancel_state: Arc<QueryCancelState>,
     #[cfg(test)]
     inject_checkpoint_failures_remaining: usize,
@@ -174,6 +186,7 @@ impl Session {
             checkpoint_policy: CheckpointPolicy::from_env(),
             pending_checkpoint_ops: 0,
             last_checkpoint_at: std::time::Instant::now(),
+            statement_timeout_ms: 0,
             cancel_state: Arc::new(QueryCancelState::default()),
             #[cfg(test)]
             inject_checkpoint_failures_remaining: 0,
@@ -187,6 +200,20 @@ impl Session {
         QueryCancelHandle {
             state: Arc::clone(&self.cancel_state),
         }
+    }
+
+    /// Configure per-statement execution timeout in milliseconds.
+    ///
+    /// `0` means no timeout.
+    pub fn set_statement_timeout_ms(&mut self, timeout_ms: u64) {
+        self.statement_timeout_ms = timeout_ms;
+    }
+
+    /// Current per-statement execution timeout in milliseconds.
+    ///
+    /// `0` means no timeout.
+    pub fn statement_timeout_ms(&self) -> u64 {
+        self.statement_timeout_ms
     }
 
     fn check_poisoned(&self) -> Result<()> {
@@ -323,6 +350,17 @@ impl Session {
         ACTIVE_CANCEL_STATE.with(|slot| {
             *slot.borrow_mut() = Some(Arc::clone(&self.cancel_state));
         });
+        ACTIVE_STATEMENT_TIMEOUT.with(|slot| {
+            *slot.borrow_mut() = if self.statement_timeout_ms == 0 {
+                None
+            } else {
+                Some(StatementTimeoutContext {
+                    deadline: Instant::now()
+                        + std::time::Duration::from_millis(self.statement_timeout_ms),
+                    timeout_ms: self.statement_timeout_ms,
+                })
+            };
+        });
         StatementExecutionGuard {
             state: Arc::clone(&self.cancel_state),
             statement_id,
@@ -330,6 +368,9 @@ impl Session {
     }
 
     pub(crate) fn cancellation_point(&self) -> Result<()> {
+        if let Some(err) = statement_timeout_error_current() {
+            return Err(err);
+        }
         let active_id = self.cancel_state.active_statement_id.load(Ordering::SeqCst);
         if active_id != 0
             && self
@@ -650,6 +691,9 @@ impl Session {
 }
 
 pub(crate) fn cancellation_point_current() -> Result<()> {
+    if let Some(err) = statement_timeout_error_current() {
+        return Err(err);
+    }
     ACTIVE_CANCEL_STATE.with(|slot| {
         let borrowed = slot.borrow();
         let Some(state) = borrowed.as_ref() else {
@@ -666,6 +710,21 @@ pub(crate) fn cancellation_point_current() -> Result<()> {
             return Err(MuroError::Cancelled);
         }
         Ok(())
+    })
+}
+
+fn statement_timeout_error_current() -> Option<MuroError> {
+    ACTIVE_STATEMENT_TIMEOUT.with(|slot| {
+        let timeout = *slot.borrow();
+        timeout.and_then(|ctx| {
+            if Instant::now() >= ctx.deadline {
+                Some(MuroError::StatementTimeout {
+                    timeout_ms: ctx.timeout_ms,
+                })
+            } else {
+                None
+            }
+        })
     })
 }
 

--- a/src/sql/session/mod.rs
+++ b/src/sql/session/mod.rs
@@ -354,11 +354,12 @@ impl Session {
             *slot.borrow_mut() = if self.statement_timeout_ms == 0 {
                 None
             } else {
-                Some(StatementTimeoutContext {
-                    deadline: Instant::now()
-                        + std::time::Duration::from_millis(self.statement_timeout_ms),
-                    timeout_ms: self.statement_timeout_ms,
-                })
+                Instant::now()
+                    .checked_add(std::time::Duration::from_millis(self.statement_timeout_ms))
+                    .map(|deadline| StatementTimeoutContext {
+                        deadline,
+                        timeout_ms: self.statement_timeout_ms,
+                    })
             };
         });
         StatementExecutionGuard {

--- a/src/sql/session/tests/tail.rs
+++ b/src/sql/session/tests/tail.rs
@@ -297,6 +297,24 @@ fn test_statement_timeout_interrupts_long_running_query() {
 }
 
 #[test]
+fn test_statement_timeout_max_value_does_not_panic() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let wal_path = dir.path().join("test.wal");
+
+    let mut pager = Pager::create(&db_path, &test_key()).unwrap();
+    let catalog = SystemCatalog::create(&mut pager).unwrap();
+    pager.set_catalog_root(catalog.root_page_id());
+    pager.flush_meta().unwrap();
+    let wal = WalWriter::create(&wal_path, &test_key()).unwrap();
+    let mut session = Session::new(pager, catalog, wal);
+    session.set_statement_timeout_ms(u64::MAX);
+
+    let result = session.execute("SELECT 1");
+    assert!(result.is_ok());
+}
+
+#[test]
 fn test_read_only_query_select_does_not_create_wal_records() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");

--- a/src/sql/session/tests/tail.rs
+++ b/src/sql/session/tests/tail.rs
@@ -267,6 +267,36 @@ fn test_inflight_cancel_interrupts_long_running_query() {
 }
 
 #[test]
+fn test_statement_timeout_interrupts_long_running_query() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let wal_path = dir.path().join("test.wal");
+
+    let mut pager = Pager::create(&db_path, &test_key()).unwrap();
+    let catalog = SystemCatalog::create(&mut pager).unwrap();
+    pager.set_catalog_root(catalog.root_page_id());
+    pager.flush_meta().unwrap();
+    let wal = WalWriter::create(&wal_path, &test_key()).unwrap();
+    let mut session = Session::new(pager, catalog, wal);
+    session.set_statement_timeout_ms(1);
+
+    session
+        .execute("CREATE TABLE t (id BIGINT PRIMARY KEY)")
+        .unwrap();
+    for i in 0..1000 {
+        session
+            .execute(&format!("INSERT INTO t VALUES ({})", i))
+            .unwrap();
+    }
+
+    let result = session.execute_read_only_query("SELECT a.id FROM t a CROSS JOIN t b");
+    assert!(matches!(
+        result,
+        Err(MuroError::StatementTimeout { timeout_ms: 1 })
+    ));
+}
+
+#[test]
 fn test_read_only_query_select_does_not_create_wal_records() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");


### PR DESCRIPTION
## Summary
Implement step 2 of #187: statement execution timeout guardrail (`statement_timeout_ms`).

### What was added
- New timeout error variant:
  - `MuroError::StatementTimeout { timeout_ms }`
- Session timeout support:
  - statement deadline context is set per statement execution and checked via existing cancellation checkpoints
- Host API on handles:
  - `Database::set_statement_timeout_ms` / `statement_timeout_ms`
  - `DatabaseReader::set_statement_timeout_ms` / `statement_timeout_ms`
- Reader inheritance:
  - `Database::open_reader()` now copies statement-timeout config to the reader session
- CLI option:
  - `--statement-timeout-ms` (`0` = no timeout)
- Docs updates:
  - CLI options table
  - SQL reference Rust API notes

### Tests
- `cargo test --lib test_statement_timeout_interrupts_long_running_query -- --nocapture`
- `cargo test --lib statement_timeout_api_roundtrip -- --nocapture`
- `cargo test --lib open_reader_inherits_statement_timeout -- --nocapture`
- `cargo test --lib test_inflight_cancel_interrupts_long_running_query -- --nocapture`
- `cargo test --lib test_cancel_handle -- --nocapture`
- `cargo test --bin murodb -- --nocapture`

Part of #187.
